### PR TITLE
multiple improvements

### DIFF
--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class ExitHandlerContext(object):
 
     """The context which is passed to an exit handler function."""

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -30,7 +30,9 @@ def default_exit_handler(context):
     # trigger tear down if not already tearing down
     if not context.launch_state.teardown:
         context.launch_state.teardown = True
-        # set launch return code
+
+    # set launch return code if not already set
+    if not context.launch_state.returncode:
         try:
             rc = int(context.task_state.returncode)
         except (TypeError, ValueError):

--- a/launch/launch/launch.py
+++ b/launch/launch/launch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class LaunchState(object):
 
     def __init__(self):

--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -27,7 +27,7 @@ from launch.task import TaskState
 
 class DefaultLauncher(object):
 
-    def __init__(self, name_prefix='', sigint_timeout=3):
+    def __init__(self, name_prefix='', sigint_timeout=10):
         self.name_prefix = name_prefix
         self.sigint_timeout = sigint_timeout
         self.task_descriptors = []

--- a/launch/launch/task.py
+++ b/launch/launch/task.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class TaskState(object):
 
     def __init__(self):

--- a/launch/test/test_launch_with_coroutine.py
+++ b/launch/test/test_launch_with_coroutine.py
@@ -47,8 +47,9 @@ def test_launch_with_coroutine():
         yield from asyncio.sleep(1)
         print('three mississippi', file=sys.stderr)
 
-    launch_descriptor.add_coroutine(coroutine(), name='coroutine', exit_handler=primary_exit_handler)
-    #launch_descriptor.add_coroutine(coroutine2())
+    launch_descriptor.add_coroutine(
+        coroutine(), name='coroutine', exit_handler=primary_exit_handler)
+    # launch_descriptor.add_coroutine(coroutine2())
 
     print('launch', file=sys.stderr)
     default_launcher.add_launch_descriptor(launch_descriptor)

--- a/launch/test/test_multiple_launch.py
+++ b/launch/test/test_multiple_launch.py
@@ -1,0 +1,45 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import sys
+
+from launch import LaunchDescriptor
+from launch.launcher import DefaultLauncher
+
+
+def test_multiple_launch():
+    launch(1)
+    launch(2)
+
+
+def launch(index):
+    default_launcher = DefaultLauncher()
+
+    @asyncio.coroutine
+    def coroutine():
+        yield from asyncio.sleep(1)
+        print('message %d' % index, file=sys.stderr)
+
+    launch_descriptor = LaunchDescriptor()
+    launch_descriptor.add_coroutine(coroutine(), name='coroutine%d' % index)
+
+    print('launch %d' % index, file=sys.stderr)
+    default_launcher.add_launch_descriptor(launch_descriptor)
+    rc = default_launcher.launch()
+    print('done %d' % index, rc, file=sys.stderr)
+
+
+if __name__ == '__main__':
+    test_multiple_launch()

--- a/launch/test/test_non_primary_return_code.py
+++ b/launch/test/test_non_primary_return_code.py
@@ -1,0 +1,53 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import sys
+
+from launch import LaunchDescriptor
+from launch.exit_handler import primary_exit_handler
+from launch.launcher import DefaultLauncher
+
+
+def test_non_primary_return_code():
+    default_launcher = DefaultLauncher()
+
+    @asyncio.coroutine
+    def coroutine1():
+        yield from asyncio.sleep(1)
+        print('one', file=sys.stderr)
+        yield from asyncio.sleep(1)
+        print('two', file=sys.stderr)
+        return 3
+
+    @asyncio.coroutine
+    def coroutine2():
+        yield from asyncio.sleep(1)
+        print('one mississippi', file=sys.stderr)
+        return 0
+
+    launch_descriptor = LaunchDescriptor()
+    launch_descriptor.add_coroutine(coroutine1(), name='coroutine1')
+    launch_descriptor.add_coroutine(
+        coroutine2(), name='coroutine2', exit_handler=primary_exit_handler)
+
+    print('launch', file=sys.stderr)
+    default_launcher.add_launch_descriptor(launch_descriptor)
+    rc = default_launcher.launch()
+    print('done', rc, file=sys.stderr)
+    assert rc == 3, 'Expected return code is 3'
+
+
+if __name__ == '__main__':
+    test_non_primary_return_code()


### PR DESCRIPTION
* allow running multiple asyncio / launch tests in a single nosetests invocation
* allow non-primary processes to set the launch return code

http://ci.ros2.org/job/ros2_batch_ci_linux/281/

* increase default timeout to react on SIGINT giving the test processes enough time to exit

http://ci.ros2.org/job/ros2_batch_ci_osx/211/