### PR TITLE
Allow for variation on RTI licence in default filtered_prefixes

### DIFF
--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -30,7 +30,7 @@ class InMemoryHandler(LineOutput):
         if filtered_prefixes is None:
             self.filtered_prefixes = [
                 b'pid', b'rc',
-                b'RTI Data Distribution Service Evaluation License issued to',
+                b'RTI Data Distribution Service',
                 b'Expires on']
         else:
             self.filtered_prefixes = filtered_prefixes


### PR DESCRIPTION
The console output of my RTI free-trial licence is a bit different to what's being filtered in the default filtered_prefixes. Mine says "RTI Data Distribution Service EVAL License issued to ..."

I understand from this [TODO](https://github.com/ros2/launch/blob/master/launch_testing/launch_testing/__init__.py#L24) that this part of the code might be removed one day, but in the meantime this allows my tests on nodes using connext to pass and might help someone else.