### PR TITLE
Add ignore signal exit handler

### DIFF
--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -91,7 +91,10 @@ def primary_ignore_returncode_exit_handler(context):
 
 def ignore_signal_exit_handler(context):
     """
-    Trigger teardown of launch and ignore return code if SIGINT (Unix) or SIGTERM (Windows) was triggered.
+    Trigger teardown of launch and ignore nonzero return codes if the process
+    received a shutdown signal.
+
+    Ignores return code if SIGINT (Unix) or SIGTERM (Windows) was triggered.
     """
     if context.launch_state.teardown:
         # Check the return code

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -91,14 +91,15 @@ def primary_ignore_returncode_exit_handler(context):
 
 def ignore_signal_exit_handler(context):
     """
-    Trigger teardown of launch and ignore nonzero return codes if the process
-    received a shutdown signal.
+    Succeed if the process received a shutdown signal on teardown.
 
-    Ignores return code if SIGINT (Unix) or SIGTERM (Windows) was triggered.
+    Ignores return code if launch sent a SIGINT or SIGKILL to the task.
     """
     if context.launch_state.teardown:
         # Check the return code
-        if task_state.terminated_from_launch:
+        sigint_received = signal.SIGINT in context.task_state.signals_received
+        sigterm_received = signal.SIGTERM in context.task_state.signals_received
+        if sigint_received or sigterm_received:
             context.task_state.returncode = 0
 
     default_exit_handler(context)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -99,13 +99,9 @@ def ignore_signal_exit_handler(context):
     if context.launch_state.teardown:
         # Check the return code
         ret = context.task_state.returncode
-        if os.name == 'nt':
-            if ret == -signal.SIGTERM:
-                context.task_state.returncode = 0
-        else:
-            # On Unix, return codes are negated for subprocesses
-            # Launched processes are always subprocesses
-            if ret == -signal.SIGINT:
-                context.task_state.returncode = 0
+        # Return codes are negated for subprocesses
+        # Launched processes are always subprocesses
+        if ret == -signal.SIGINT or ret == -signal.SIGTERM:
+            context.task_state.returncode = 0
 
     default_exit_handler(context)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import signal
 
 
 class ExitHandlerContext(object):
@@ -87,7 +86,6 @@ def primary_ignore_returncode_exit_handler(context):
             context.launch_state.returncode = 1
 
     default_exit_handler(context, ignore_returncode=True)
-
 
 def ignore_signal_exit_handler(context):
     """

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -91,13 +91,13 @@ def primary_ignore_returncode_exit_handler(context):
 
 def ignore_signal_exit_handler(context):
     """
-    Trigger teardown of launch and ignore return code if SIGINT or SIGTERM was triggered.
+    Trigger teardown of launch and ignore return code if SIGINT (Unix) or SIGTERM (Windows) was triggered.
     """
     if context.launch_state.teardown:
         # Check the return code
         ret = context.task_state.returncode
         if os.name == 'nt':
-            if ret == signal.SIGINT or ret == signal.SIGTERM:
+            if ret == -signal.SIGTERM:
                 context.task_state.returncode = 0
         else:
             # On Unix, return codes are negated for subprocesses

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import signal
 
 
 class ExitHandlerContext(object):
@@ -84,5 +85,20 @@ def primary_ignore_returncode_exit_handler(context):
     if context.launch_state.teardown:
         if not context.launch_state.returncode:
             context.launch_state.returncode = 1
+
+    default_exit_handler(context, ignore_returncode=True)
+
+
+def ignore_signal_exit_handler(context):
+    """
+    Trigger teardown of launch and ignore return code if SIGINT or SIGTERM was triggered.
+
+    Same as primary exit handler but ignore return codes set by SIGINT or SIGTERM.
+    """
+    if context.launch_state.teardown:
+        # Check the return code
+        ret = context.launch_state.returncode
+        if ret == signal.SIGINT or ret == signal.SIGTERM:
+            context.launch_state.returncode = 0
 
     default_exit_handler(context, ignore_returncode=True)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -97,9 +97,7 @@ def ignore_signal_exit_handler(context):
     """
     if context.launch_state.teardown:
         # Check the return code
-        sigint_received = signal.SIGINT in context.task_state.signals_received
-        sigterm_received = signal.SIGTERM in context.task_state.signals_received
-        if sigint_received or sigterm_received:
+        if context.task_state.signals_received:
             context.task_state.returncode = 0
 
     default_exit_handler(context)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -92,13 +92,11 @@ def primary_ignore_returncode_exit_handler(context):
 def ignore_signal_exit_handler(context):
     """
     Trigger teardown of launch and ignore return code if SIGINT or SIGTERM was triggered.
-
-    Same as primary exit handler but ignore return codes set by SIGINT or SIGTERM.
     """
     if context.launch_state.teardown:
         # Check the return code
-        ret = context.launch_state.returncode
+        ret = context.task_state.returncode
         if ret == signal.SIGINT or ret == signal.SIGTERM:
-            context.launch_state.returncode = 0
+            context.task_state.returncode = 0
 
-    default_exit_handler(context, ignore_returncode=True)
+    default_exit_handler(context)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -96,7 +96,7 @@ def ignore_signal_exit_handler(context):
     if context.launch_state.teardown:
         # Check the return code
         ret = context.task_state.returncode
-        if abs(ret) == signal.SIGINT or ret == signal.SIGTERM:
+        if abs(ret) == signal.SIGINT or abs(ret) == signal.SIGTERM:
             context.task_state.returncode = 0
 
     default_exit_handler(context)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -96,7 +96,13 @@ def ignore_signal_exit_handler(context):
     if context.launch_state.teardown:
         # Check the return code
         ret = context.task_state.returncode
-        if abs(ret) == signal.SIGINT or abs(ret) == signal.SIGTERM:
-            context.task_state.returncode = 0
+        if os.name == 'nt':
+            if ret == signal.SIGINT or ret == signal.SIGTERM:
+                context.task_state.returncode = 0
+        else:
+            # On Unix, return codes are negated for subprocesses
+            # Launched processes are always subprocesses
+            if ret == -signal.SIGINT:
+                context.task_state.returncode = 0
 
     default_exit_handler(context)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -98,10 +98,7 @@ def ignore_signal_exit_handler(context):
     """
     if context.launch_state.teardown:
         # Check the return code
-        ret = context.task_state.returncode
-        # Return codes are negated for subprocesses
-        # Launched processes are always subprocesses
-        if ret == -signal.SIGINT or ret == -signal.SIGTERM:
+        if task_state.terminated_from_launch:
             context.task_state.returncode = 0
 
     default_exit_handler(context)

--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -96,7 +96,7 @@ def ignore_signal_exit_handler(context):
     if context.launch_state.teardown:
         # Check the return code
         ret = context.task_state.returncode
-        if ret == signal.SIGINT or ret == signal.SIGTERM:
+        if abs(ret) == signal.SIGINT or ret == signal.SIGTERM:
             context.task_state.returncode = 0
 
     default_exit_handler(context)

--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -218,7 +218,7 @@ class DefaultLauncher(object):
                         self._process_message(p, 'signal SIGINT')
                         try:
                             p.transport.send_signal(signal.SIGINT)
-                            p.task_state.terminated_from_launch = True
+                            p.task_state.signals_received.append(signal.SIGINT)
                         except ProcessLookupError:
                             pass
 
@@ -252,7 +252,7 @@ class DefaultLauncher(object):
                         self._process_message(p, 'signal SIGTERM')
                         try:
                             p.transport.send_signal(signal.SIGTERM)
-                            p.task_state.terminated_from_launch = True
+                            p.task_state.signals_received.append(signal.SIGTERM)
                         except ProcessLookupError:
                             pass
 

--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -218,6 +218,7 @@ class DefaultLauncher(object):
                         self._process_message(p, 'signal SIGINT')
                         try:
                             p.transport.send_signal(signal.SIGINT)
+                            p.task_state.terminated_from_launch = True
                         except ProcessLookupError:
                             pass
 
@@ -251,6 +252,7 @@ class DefaultLauncher(object):
                         self._process_message(p, 'signal SIGTERM')
                         try:
                             p.transport.send_signal(signal.SIGTERM)
+                            p.task_state.terminated_from_launch = True
                         except ProcessLookupError:
                             pass
 

--- a/launch/launch/task.py
+++ b/launch/launch/task.py
@@ -21,4 +21,4 @@ class TaskState(object):
         self.restart = False
         self.restart_count = 0
         self.returncode = None
-        self.terminated_from_launch = False
+        self.signals_received = []

--- a/launch/launch/task.py
+++ b/launch/launch/task.py
@@ -21,3 +21,4 @@ class TaskState(object):
         self.restart = False
         self.restart_count = 0
         self.returncode = None
+        self.terminated_from_launch = False


### PR DESCRIPTION
This is needed for the C services tests. To test remote services, the service process must stick around until the client receives a response from the service. Rather than introducing signal handling in the rcl tests, we will instead make the service process block forever and use the exit handler introduced by this PR to ignore only SIGINT or SIGTERM in the service process when it is interrupted. I opted not to use the ignore all return codes exit handler in case there are other errors in the service handler.