### PR TITLE
fix PEP257 warning D211

### DIFF
--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -16,7 +16,6 @@ import os
 
 
 class ExitHandlerContext(object):
-
     """The context which is passed to an exit handler function."""
 
     def __init__(self, launch_state, task_state):

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -6,7 +6,6 @@ from launch.output_handler import LineOutput
 
 
 class InMemoryHandler(LineOutput):
-
     """Aggregate data from standard output.
 
     @param name: Name of the process being tested.


### PR DESCRIPTION
Since we don't want to follow D203 (ament/ament_lint#47) I assume we will follow D211 (which is checked by newer versions of `pydocstyle`).