### PR TITLE
Make launch_testing fail on unexpected license output when regex matching

### DIFF
--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -74,10 +74,10 @@ class InMemoryHandler(LineOutput):
             if any([line.startswith(prefix) for prefix in self.filtered_prefixes]):
                 continue
             self.stdout_data.write(line + b'\n')
-            if not self.regex_match and not self.matched:
+            if not self.regex_match:
                 output_lines = self.stdout_data.getvalue().splitlines()
-                self.matched = output_lines == self.expected_lines
-                self.complete_match = self.matched
+                self.complete_match = output_lines == self.expected_lines
+                self.matched |= self.complete_match
 
         # Are we ready to quit?
         if self.regex_match and not self.matched:

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -60,6 +60,9 @@ class InMemoryHandler(LineOutput):
         self.launch_descriptor = launch_descriptor
         self.expected_lines = expected_lines
         self.expected_output = b'\n'.join(self.expected_lines) + b'\n'
+        if regex_match:
+            # Add a surrounding capture group
+            self.expected_output = b'(?P<launch_testing_capture>' + self.expected_output + b')'
         self.left_over_stdout = b''
         self.left_over_stderr = b''
         self.stdout_data = io.BytesIO()
@@ -91,7 +94,9 @@ class InMemoryHandler(LineOutput):
             # Check for regex match
             if self.regex_match:
                 self.matched = re.search(self.expected_output, received_output)
-                self.matched_exactly = self.matched and self.matched.group(0) == received_output
+                matched_group = self.matched.group('launch_testing_capture') \
+                    if self.matched else None
+                self.matched_exactly = matched_group == received_output
 
             if self.matched and self.exit_on_match:
                 # We matched and we're in charge; shut myself down

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -43,7 +43,7 @@ class InMemoryHandler(LineOutput):
 
     def __init__(
         self, name, launch_descriptor, expected_lines, regex_match=False,
-        filtered_prefixes=None, filtered_rmw_implementation=None, exit_on_match=False,
+        filtered_prefixes=None, filtered_rmw_implementation=None, exit_on_match=True,
         exact_match=True
     ):
         super(LineOutput, self).__init__()
@@ -149,7 +149,7 @@ def get_rmw_output_filter(rmw_implementation):
 
 
 def create_handler(
-    name, launch_descriptor, output_file, exit_on_match=False, filtered_prefixes=None,
+    name, launch_descriptor, output_file, exit_on_match=True, filtered_prefixes=None,
     filtered_rmw_implementation=None, exact_match=True
 ):
     literal_file = output_file + '.txt'

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -86,7 +86,7 @@ class InMemoryHandler(LineOutput):
 
             # Check for literal match
             if not self.regex_match:
-                self.matched = all(line in received_lines for line in self.expected_lines)
+                self.matched = self.expected_output in received_output
                 self.matched_exactly = self.expected_lines == received_lines
 
             # Check for regex match

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -66,8 +66,9 @@ class InMemoryHandler(LineOutput):
                 b'(?P<launch_testing_capture>' + self.expected_output + b')'
             # Increment any group IDs in the original regex to compensate for the surrounding group
             self.expected_output_captured = re.sub(
-                b'\\\(\d)',  # TODO(dhood): only match single backslashes
-                lambda matchobj: b'\\' + str(int(matchobj.group(1)) + 1).encode(),
+                b'(\\\*)(\d)',
+                lambda matchobj: matchobj.group(1) +
+                str(int(matchobj.group(2)) + len(matchobj.group(1)) % 2).encode(),
                 self.expected_output_captured)
         else:
             self.expected_output = b'\n'.join(self.expected_lines)

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -43,7 +43,7 @@ class InMemoryHandler(LineOutput):
 
     def __init__(
         self, name, launch_descriptor, expected_lines, regex_match=False,
-        filtered_prefixes=None, filtered_rmw_implementation=None, exit_on_match=True,
+        filtered_prefixes=None, filtered_rmw_implementation=None, exit_on_match=False,
         exact_match=True
     ):
         super(LineOutput, self).__init__()
@@ -74,9 +74,6 @@ class InMemoryHandler(LineOutput):
         self.matched_exactly = False
 
     def on_stdout_lines(self, lines):
-        if self.matched:
-            return
-
         for line in lines.splitlines():
             # Filter out stdout that comes from underlying DDS implementation
             if any([line.startswith(prefix) for prefix in self.filtered_prefixes]):
@@ -144,7 +141,7 @@ def get_rmw_output_filter(rmw_implementation):
 
 
 def create_handler(
-    name, launch_descriptor, output_file, exit_on_match=True, filtered_prefixes=None,
+    name, launch_descriptor, output_file, exit_on_match=False, filtered_prefixes=None,
     filtered_rmw_implementation=None, exact_match=True
 ):
     literal_file = output_file + '.txt'

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -80,29 +80,29 @@ class InMemoryHandler(LineOutput):
                 continue
             self.stdout_data.write(line + b'\n')
 
-        received_output = self.stdout_data.getvalue()
-        received_lines = received_output.splitlines()
+            received_output = self.stdout_data.getvalue()
+            received_lines = received_output.splitlines()
 
-        # Check for literal match
-        if not self.regex_match:
-            self.matched = all(line in received_lines for line in self.expected_lines)
-            self.matched_exactly = self.expected_lines == received_lines
+            # Check for literal match
+            if not self.regex_match:
+                self.matched = all(line in received_lines for line in self.expected_lines)
+                self.matched_exactly = self.expected_lines == received_lines
 
-        # Check for regex match
-        if self.regex_match:
-            self.matched = re.search(self.expected_output, received_output)
-            self.matched_exactly = self.matched and self.matched.group(0) == received_output
+            # Check for regex match
+            if self.regex_match:
+                self.matched = re.search(self.expected_output, received_output)
+                self.matched_exactly = self.matched and self.matched.group(0) == received_output
 
-        if self.matched and self.exit_on_match:
-            # We matched and we're in charge; shut myself down
-            for td in self.launch_descriptor.task_descriptors:
-                if td.name == self.name:
-                    if os.name != 'nt':
-                        td.task_state.signals_received.append(signal.SIGINT)
-                        td.transport.send_signal(signal.SIGINT)
-                    else:
-                        td.terminate()
-                    return
+            if self.matched and self.exit_on_match:
+                # We matched and we're in charge; shut myself down
+                for td in self.launch_descriptor.task_descriptors:
+                    if td.name == self.name:
+                        if os.name != 'nt':
+                            td.task_state.signals_received.append(signal.SIGINT)
+                            td.transport.send_signal(signal.SIGINT)
+                        else:
+                            td.terminate()
+                        return
 
     def on_stderr_lines(self, lines):
         self.stderr_data.write(lines)

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -62,7 +62,8 @@ class InMemoryHandler(LineOutput):
         self.expected_output = b'\n'.join(self.expected_lines) + b'\n'
         if regex_match:
             # Add a surrounding capture group
-            self.expected_output = b'(?P<launch_testing_capture>' + self.expected_output + b')'
+            self.expected_output_captured = \
+                b'(?P<launch_testing_capture>' + self.expected_output + b')'
         self.left_over_stdout = b''
         self.left_over_stderr = b''
         self.stdout_data = io.BytesIO()
@@ -90,7 +91,7 @@ class InMemoryHandler(LineOutput):
 
             # Check for regex match
             if self.regex_match:
-                self.matched = re.search(self.expected_output, received_output)
+                self.matched = re.search(self.expected_output_captured, received_output)
                 matched_group = self.matched.group('launch_testing_capture') \
                     if self.matched else None
                 self.matched_exactly = matched_group == received_output

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -124,7 +124,8 @@ class InMemoryHandler(LineOutput):
 
     def check(self):
         output_lines = self.stdout_data.getvalue().splitlines()
-        success = self.matched_exactly or (self.matched and not self.exact_match_required)
+        success = self.matched_exactly or (self.matched and not self.exact_match_required) or \
+            not output_lines and not self.expected_lines
         if not success:
             raise UnmatchedOutputError(
                 'Received output does not match expected output.\n' +

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -64,10 +64,11 @@ class InMemoryHandler(LineOutput):
             # Add a surrounding capture group
             self.expected_output_captured = \
                 b'(?P<launch_testing_capture>' + self.expected_output + b')'
-            # Increment any group IDs in the original regex to compensate for the surrounding one
-            incrementer = lambda matchobj: '\\' + str(int(matchobj.group(1)) + 1)
+            # Increment any group IDs in the original regex to compensate for the surrounding group
             self.expected_output_captured = re.sub(
-                (r'\\(\d)'), incrementer, self.expected_output_captured.decode()).encode()
+                b'\\\(\d)',  # TODO(dhood): only match single backslashes
+                lambda matchobj: b'\\' + str(int(matchobj.group(1)) + 1).encode(),
+                self.expected_output_captured)
         else:
             self.expected_output = b'\n'.join(self.expected_lines)
             self.expected_output += b'\n'

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -64,6 +64,10 @@ class InMemoryHandler(LineOutput):
             # Add a surrounding capture group
             self.expected_output_captured = \
                 b'(?P<launch_testing_capture>' + self.expected_output + b')'
+            # Increment any group IDs in the original regex to compensate for the surrounding one
+            incrementer = lambda matchobj: '\\' + str(int(matchobj.group(1)) + 1)
+            self.expected_output_captured = re.sub(
+                (r'\\(\d)'), incrementer, self.expected_output_captured.decode()).encode()
         else:
             self.expected_output = b'\n'.join(self.expected_lines)
             self.expected_output += b'\n'

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -59,11 +59,14 @@ class InMemoryHandler(LineOutput):
         self.name = name
         self.launch_descriptor = launch_descriptor
         self.expected_lines = expected_lines
-        self.expected_output = b'\n'.join(self.expected_lines) + b'\n'
         if regex_match:
+            self.expected_output = self.expected_lines
             # Add a surrounding capture group
             self.expected_output_captured = \
                 b'(?P<launch_testing_capture>' + self.expected_output + b')'
+        else:
+            self.expected_output = b'\n'.join(self.expected_lines)
+            self.expected_output += b'\n'
         self.left_over_stdout = b''
         self.left_over_stderr = b''
         self.stdout_data = io.BytesIO()
@@ -156,7 +159,7 @@ def create_handler(
     regex_file = output_file + '.regex'
     if os.path.isfile(regex_file):
         with open(regex_file, 'rb') as f:
-            expected_output = f.read().splitlines()
+            expected_output = f.read()
         return InMemoryHandler(
             name, launch_descriptor, expected_output, regex_match=True,
             exit_on_match=exit_on_match, filtered_prefixes=filtered_prefixes,

--- a/launch_testing/test/matching.py
+++ b/launch_testing/test/matching.py
@@ -20,22 +20,24 @@ import sys
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument('--no-output', action='store_true')
     parser.add_argument('--prepended-lines', action='store_true')
     parser.add_argument('--appended-lines', action='store_true')
     parser.add_argument('--interleaved-lines', action='store_true')
     args = parser.parse_args()
 
-    if args.prepended_lines:
-        print('license output', file=sys.stdout)
-    print('this is line 1', file=sys.stdout)
+    if not args.no_output:
+        if args.prepended_lines:
+            print('license output', file=sys.stdout)
+        print('this is line 1', file=sys.stdout)
 
-    if args.interleaved_lines:
-        print('debug output', file=sys.stdout)
+        if args.interleaved_lines:
+            print('debug output', file=sys.stdout)
 
-    print('this is line b', file=sys.stdout)
+        print('this is line b', file=sys.stdout)
 
-    if args.appended_lines:
-        print('extra printout', file=sys.stdout)
+        if args.appended_lines:
+            print('extra printout', file=sys.stdout)
 
     return 0
 

--- a/launch_testing/test/matching.py
+++ b/launch_testing/test/matching.py
@@ -25,7 +25,9 @@ def main():
     parser.add_argument('--prepended-lines', action='store_true')
     parser.add_argument('--appended-lines', action='store_true')
     parser.add_argument('--interleaved-lines', action='store_true')
-    parser.add_argument('--reprints', action='store', type=int, default=0)
+    parser.add_argument(
+        '--reprints', action='store', type=int, default=0,
+        help='number of times to reprint core lines (-1 for indefinitely)')
     args = parser.parse_args()
 
     if not args.no_output:
@@ -33,9 +35,11 @@ def main():
             print('license output', file=sys.stdout)
             time.sleep(0.01)
 
-        for i in range(args.reprints + 1):
+        i = 0
+        while i < args.reprints + 1 or args.reprints == -1:
             print('this is line 1', file=sys.stdout)
             time.sleep(0.01)
+            i += 1
 
             if args.interleaved_lines:
                 print('debug output', file=sys.stdout)

--- a/launch_testing/test/matching.py
+++ b/launch_testing/test/matching.py
@@ -24,14 +24,14 @@ def main():
     parser.add_argument('--prepended-lines', action='store_true')
     parser.add_argument('--appended-lines', action='store_true')
     parser.add_argument('--interleaved-lines', action='store_true')
-    parser.add_argument('--repeated-times', action='store', type=int, default=0)
+    parser.add_argument('--reprints', action='store', type=int, default=0)
     args = parser.parse_args()
 
     if not args.no_output:
         if args.prepended_lines:
             print('license output', file=sys.stdout)
 
-        for i in range(args.repeated_times + 1):
+        for i in range(args.reprints + 1):
             print('this is line 1', file=sys.stdout)
 
             if args.interleaved_lines:

--- a/launch_testing/test/matching.py
+++ b/launch_testing/test/matching.py
@@ -14,12 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import sys
 
 
 def main():
-    print("this is line 1", file=sys.stdout)
-    print("this is line b", file=sys.stdout)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--prepended-lines', action='store_true')
+    parser.add_argument('--appended-lines', action='store_true')
+    args = parser.parse_args()
+
+    if args.prepended_lines:
+        print('license output', file=sys.stdout)
+    print('this is line 1', file=sys.stdout)
+    print('this is line b', file=sys.stdout)
+
+    if args.appended_lines:
+        print('extra printout', file=sys.stdout)
     return 0
 
 

--- a/launch_testing/test/matching.py
+++ b/launch_testing/test/matching.py
@@ -22,15 +22,21 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--prepended-lines', action='store_true')
     parser.add_argument('--appended-lines', action='store_true')
+    parser.add_argument('--interleaved-lines', action='store_true')
     args = parser.parse_args()
 
     if args.prepended_lines:
         print('license output', file=sys.stdout)
     print('this is line 1', file=sys.stdout)
+
+    if args.interleaved_lines:
+        print('debug output', file=sys.stdout)
+
     print('this is line b', file=sys.stdout)
 
     if args.appended_lines:
         print('extra printout', file=sys.stdout)
+
     return 0
 
 

--- a/launch_testing/test/matching.py
+++ b/launch_testing/test/matching.py
@@ -24,17 +24,20 @@ def main():
     parser.add_argument('--prepended-lines', action='store_true')
     parser.add_argument('--appended-lines', action='store_true')
     parser.add_argument('--interleaved-lines', action='store_true')
+    parser.add_argument('--repeated-times', action='store', type=int, default=0)
     args = parser.parse_args()
 
     if not args.no_output:
         if args.prepended_lines:
             print('license output', file=sys.stdout)
-        print('this is line 1', file=sys.stdout)
 
-        if args.interleaved_lines:
-            print('debug output', file=sys.stdout)
+        for i in range(args.repeated_times + 1):
+            print('this is line 1', file=sys.stdout)
 
-        print('this is line b', file=sys.stdout)
+            if args.interleaved_lines:
+                print('debug output', file=sys.stdout)
+
+            print('this is line b', file=sys.stdout)
 
         if args.appended_lines:
             print('extra printout', file=sys.stdout)

--- a/launch_testing/test/matching.py
+++ b/launch_testing/test/matching.py
@@ -16,6 +16,7 @@
 
 import argparse
 import sys
+import time
 
 
 def main():
@@ -30,17 +31,22 @@ def main():
     if not args.no_output:
         if args.prepended_lines:
             print('license output', file=sys.stdout)
+            time.sleep(0.01)
 
         for i in range(args.reprints + 1):
             print('this is line 1', file=sys.stdout)
+            time.sleep(0.01)
 
             if args.interleaved_lines:
                 print('debug output', file=sys.stdout)
+                time.sleep(0.01)
 
             print('this is line b', file=sys.stdout)
+            time.sleep(0.01)
 
         if args.appended_lines:
             print('extra printout', file=sys.stdout)
+            time.sleep(0.01)
 
     return 0
 

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -134,6 +134,14 @@ def test_matching_text():
     print('Testing exiting upon text match.')
     _run_launch_testing(output_file, reprints=-1, exit_on_match=True)
 
+    output_file = os.path.join(tempdir, 'testfile_empty')
+    full_output_file = output_file + '.txt'
+    with open(full_output_file, 'w+') as f:
+        f.write('')
+
+    print('Testing when expected text output is nothing.')
+    _run_launch_testing(output_file, no_output=True)
+
 
 def test_matching_regex():
     # this temporary directory and files contained in it will be deleted when the process ends.
@@ -204,6 +212,14 @@ def test_matching_regex():
 
     print('Testing when the regex has groups.')
     _run_launch_testing(output_file)
+
+    output_file = os.path.join(tempdir, 'testfile_empty')
+    full_output_file = output_file + '.regex'
+    with open(full_output_file, 'w+') as f:
+        f.write('')
+
+    print('Testing when expected regex output is nothing.')
+    _run_launch_testing(output_file, no_output=True)
 
 
 if __name__ == '__main__':

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -21,6 +21,7 @@ from nose.tools import assert_raises
 from launch import LaunchDescriptor
 from launch.exit_handler import ignore_exit_handler
 from launch.launcher import DefaultLauncher
+from launch.output_handler import ConsoleOutput
 import launch_testing
 from launch_testing import create_handler, UnmatchedOutputError
 
@@ -28,7 +29,7 @@ from launch_testing import create_handler, UnmatchedOutputError
 def _run_launch_testing(
         output_file, prepended_lines=False, appended_lines=False, interleaved_lines=False,
         filtered_prefixes=None):
-    output_handlers = []
+    output_handlers = [ConsoleOutput()]
 
     launch_descriptor = LaunchDescriptor()
 
@@ -68,11 +69,10 @@ def _run_launch_testing(
     assert rc == 0, \
         "the launch file failed with exit code '{0}'".format(rc)
 
-    for handler in output_handlers:
-        try:
-            handler.check()
-        except UnmatchedOutputError:
-            raise
+    try:
+        handler.check()
+    except UnmatchedOutputError:
+        raise
 
 
 def test_matching_text():

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -72,6 +72,30 @@ def _run_launch_testing(
             raise
 
 
+def test_matching_text():
+    # this temporary directory and files contained in it will be deleted when the process ends.
+    tempdir = tempfile.mkdtemp()
+    output_file = os.path.join(tempdir, "testfile")
+    full_output_file = output_file + ".txt"
+    with open(full_output_file, 'w+') as f:
+        f.write('this is line 1\nthis is line b')
+
+    # regex is matched exactly
+    _run_launch_testing(output_file)
+
+    # unmatched lines appear before expected text
+    with assert_raises(UnmatchedOutputError):
+        _run_launch_testing(output_file, prepended_lines=True)
+
+    # unmatched lines appear after expected text
+    _run_launch_testing(output_file, appended_lines=True)
+
+    # filtered lines appear before regex is matched
+    filtered_prefixes = launch_testing.get_default_filtered_prefixes()
+    filtered_prefixes.append(b'license')
+    _run_launch_testing(output_file, prepended_lines=True, filtered_prefixes=filtered_prefixes)
+
+
 def test_matching_regex():
     # this temporary directory and files contained in it will be deleted when the process ends.
     tempdir = tempfile.mkdtemp()
@@ -98,4 +122,4 @@ def test_matching_regex():
 
 if __name__ == '__main__':
     test_matching_regex()
-    #test_matching_text()
+    test_matching_text()

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -132,9 +132,11 @@ def test_matching_text():
         _run_launch_testing(output_file, interleaved_lines=True, exact_match=False)
 
     print('Testing exiting upon text match.')
+    ''' TODO(dhood): re-enable this once timeout is properly taken care of
     with assert_raises(UnmatchedOutputError):
-        _run_launch_testing(output_file, reprints=1)
-    _run_launch_testing(output_file, reprints=1, exit_on_match=True)
+        _run_launch_testing(output_file, reprints=-1)
+    '''
+    _run_launch_testing(output_file, reprints=-1, exit_on_match=True)
 
 
 def test_matching_regex():
@@ -186,9 +188,11 @@ def test_matching_regex():
         _run_launch_testing(output_file, interleaved_lines=True, exact_match=False)
 
     print('Testing exiting upon regex match.')
+    ''' TODO(dhood): re-enable this once timeout is properly taken care of
     with assert_raises(UnmatchedOutputError):
-        _run_launch_testing(output_file, reprints=1)
-    _run_launch_testing(output_file, reprints=1, exit_on_match=True)
+        _run_launch_testing(output_file, reprints=-1)
+    '''
+    _run_launch_testing(output_file, reprints=-1, exit_on_match=True)
 
     # Test regex which can match multiple times
     output_file = os.path.join(tempdir, 'testfile2')

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -85,7 +85,7 @@ def test_matching_text():
     output_file = os.path.join(tempdir, 'testfile')
     full_output_file = output_file + '.txt'
     with open(full_output_file, 'w+') as f:
-        f.write('this is line 1\nthis is line b')
+        f.write('this is line 1\nthis is line b\n')
 
     print('Testing when expected text is never printed.')
     with assert_raises(UnmatchedOutputError):
@@ -128,7 +128,7 @@ def test_matching_regex():
     output_file = os.path.join(tempdir, 'testfile')
     full_output_file = output_file + '.regex'
     with open(full_output_file, 'w+') as f:
-        f.write('this is line \d\nthis is line [a-z]')
+        f.write('this is line \d\nthis is line [a-z]\n')
 
     print('Testing when regex is never matched.')
     with assert_raises(UnmatchedOutputError):

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -46,7 +46,7 @@ def _run_launch_testing(
     output_handlers.append(handler)
 
     executable_command = [
-        sys.executable,
+        sys.executable, '-u',
         os.path.join(os.path.abspath(os.path.dirname(__file__)), 'matching.py')]
 
     if no_output:

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
 import os
 import sys
@@ -83,27 +84,27 @@ def test_matching_text():
     with open(full_output_file, 'w+') as f:
         f.write('this is line 1\nthis is line b')
 
-    # regex is matched exactly
+    print("Testing when expected text appears exactly.")
     _run_launch_testing(output_file)
 
-    # unmatched lines appear before expected text
+    print("Testing when unmatched lines appear before expected text.")
     with assert_raises(UnmatchedOutputError):
         _run_launch_testing(output_file, prepended_lines=True)
 
-    # unmatched lines appear after expected text
+    print("Testing when unmatched lines appear after expected text.")
     with assert_raises(UnmatchedOutputError):
         _run_launch_testing(output_file, appended_lines=True)
 
-    # filtered lines appear before expected text
+    print("Testing when filtered lines appear before expected text.")
     filtered_prefixes = launch_testing.get_default_filtered_prefixes()
     filtered_prefixes.append(b'license')
     _run_launch_testing(output_file, prepended_lines=True, filtered_prefixes=filtered_prefixes)
 
-    # unmatched lines appear interleaved with expected text
+    print("Testing when unmatched lines appear interleaved with expected text.")
     with assert_raises(UnmatchedOutputError):
         _run_launch_testing(output_file, interleaved_lines=True)
 
-    # filtered lines appear interleaved with expected text
+    print("Testing when filtered lines appear interleaved with expected text.")
     filtered_prefixes = launch_testing.get_default_filtered_prefixes()
     filtered_prefixes.append(b'debug')
     _run_launch_testing(output_file, interleaved_lines=True, filtered_prefixes=filtered_prefixes)
@@ -117,27 +118,27 @@ def test_matching_regex():
     with open(full_output_file, 'w+') as f:
         f.write('this is line \d\nthis is line [a-z]')
 
-    # regex is matched exactly
+    print("Testing when regex match appears exactly.")
     _run_launch_testing(output_file)
 
-    # unmatched lines appear before regex is matched
+    print("Testing when unmatched lines appear before regex is matched.")
     with assert_raises(UnmatchedOutputError):
         _run_launch_testing(output_file, prepended_lines=True)
 
-    # unmatched lines appear after regex is matched
+    print("Testing when unmatched lines appear after regex is matched.")
     with assert_raises(UnmatchedOutputError):
         _run_launch_testing(output_file, appended_lines=True)
 
-    # filtered lines appear before regex is matched
+    print("Testing when filtered lines appear before regex is matched.")
     filtered_prefixes = launch_testing.get_default_filtered_prefixes()
     filtered_prefixes.append(b'license')
     _run_launch_testing(output_file, prepended_lines=True, filtered_prefixes=filtered_prefixes)
 
-    # unmatched lines appear interleaved with regex lines 
+    print("Testing when unmatched lines appear interleaved with regex lines.")
     with assert_raises(UnmatchedOutputError):
         _run_launch_testing(output_file, interleaved_lines=True)
 
-    # filtered lines appear interleaved with regex lines
+    print("Testing when filtered lines appear interleaved with regex lines.")
     filtered_prefixes = launch_testing.get_default_filtered_prefixes()
     filtered_prefixes.append(b'debug')
     _run_launch_testing(output_file, interleaved_lines=True, filtered_prefixes=filtered_prefixes)

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -132,10 +132,6 @@ def test_matching_text():
         _run_launch_testing(output_file, interleaved_lines=True, exact_match=False)
 
     print('Testing exiting upon text match.')
-    ''' TODO(dhood): re-enable this once timeout is properly taken care of
-    with assert_raises(UnmatchedOutputError):
-        _run_launch_testing(output_file, reprints=-1)
-    '''
     _run_launch_testing(output_file, reprints=-1, exit_on_match=True)
 
 
@@ -188,10 +184,6 @@ def test_matching_regex():
         _run_launch_testing(output_file, interleaved_lines=True, exact_match=False)
 
     print('Testing exiting upon regex match.')
-    ''' TODO(dhood): re-enable this once timeout is properly taken care of
-    with assert_raises(UnmatchedOutputError):
-        _run_launch_testing(output_file, reprints=-1)
-    '''
     _run_launch_testing(output_file, reprints=-1, exit_on_match=True)
 
     # Test regex which can match multiple times

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -196,6 +196,16 @@ def test_matching_regex():
     _run_launch_testing(output_file)
     _run_launch_testing(output_file, reprints=1)
 
+    # Test regex which has matches for defined groups
+    output_file = os.path.join(tempdir, 'testfile2')
+    full_output_file = output_file + '.regex'
+    with open(full_output_file, 'w+') as f:
+        f.write('this is (\w+) \d\nthis is \\1 [a-z]\n')
+
+    print('Testing when the regex has groups.')
+    _run_launch_testing(output_file)
+
+
 if __name__ == '__main__':
     test_matching_regex()
     test_matching_text()

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -88,7 +88,8 @@ def test_matching_text():
         _run_launch_testing(output_file, prepended_lines=True)
 
     # unmatched lines appear after expected text
-    _run_launch_testing(output_file, appended_lines=True)
+    with assert_raises(UnmatchedOutputError):
+        _run_launch_testing(output_file, appended_lines=True)
 
     # filtered lines appear before regex is matched
     filtered_prefixes = launch_testing.get_default_filtered_prefixes()

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -29,7 +29,7 @@ from launch_testing import create_handler, UnmatchedOutputError
 
 def _run_launch_testing(
         output_file, prepended_lines=False, appended_lines=False, interleaved_lines=False,
-        filtered_prefixes=None, no_output=False, exact_match=True):
+        filtered_prefixes=None, no_output=False, exact_match=True, exit_on_match=False):
     output_handlers = [ConsoleOutput()]
 
     launch_descriptor = LaunchDescriptor()
@@ -37,7 +37,7 @@ def _run_launch_testing(
     name = 'test_executable_0'
 
     handler = create_handler(
-        name, launch_descriptor, output_file,
+        name, launch_descriptor, output_file, exit_on_match=exit_on_match,
         filtered_prefixes=filtered_prefixes, exact_match=exact_match)
 
     assert handler, 'cannot find appropriate handler for %s' % output_file

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -29,7 +29,7 @@ from launch_testing import create_handler, UnmatchedOutputError
 
 def _run_launch_testing(
         output_file, prepended_lines=False, appended_lines=False, interleaved_lines=False,
-        filtered_prefixes=None):
+        filtered_prefixes=None, no_output=False):
     output_handlers = [ConsoleOutput()]
 
     launch_descriptor = LaunchDescriptor()
@@ -47,6 +47,9 @@ def _run_launch_testing(
     executable_command = [
         sys.executable,
         os.path.join(os.path.abspath(os.path.dirname(__file__)), 'matching.py')]
+
+    if no_output:
+        executable_command.append('--no-output')
 
     if prepended_lines:
         executable_command.append('--prepended-lines')
@@ -84,6 +87,10 @@ def test_matching_text():
     with open(full_output_file, 'w+') as f:
         f.write('this is line 1\nthis is line b')
 
+    print("Testing when expected text is never printed.")
+    with assert_raises(UnmatchedOutputError):
+        _run_launch_testing(output_file, no_output=True)
+
     print("Testing when expected text appears exactly.")
     _run_launch_testing(output_file)
 
@@ -117,6 +124,10 @@ def test_matching_regex():
     full_output_file = output_file + ".regex"
     with open(full_output_file, 'w+') as f:
         f.write('this is line \d\nthis is line [a-z]')
+
+    print("Testing when regex is never matched.")
+    with assert_raises(UnmatchedOutputError):
+        _run_launch_testing(output_file, no_output=True)
 
     print("Testing when regex match appears exactly.")
     _run_launch_testing(output_file)

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -116,10 +116,17 @@ def test_matching_text():
     filtered_prefixes.append(b'debug')
     _run_launch_testing(output_file, interleaved_lines=True, filtered_prefixes=filtered_prefixes)
 
-    print('Testing when unmatched lines appear but exact matching of text is not required.')
+    print(
+        'Testing when unmatched lines appear before/after text, '
+        'but exact matching is not required.')
     _run_launch_testing(
-        output_file, prepended_lines=True, appended_lines=True, interleaved_lines=True,
-        exact_match=False)
+        output_file, prepended_lines=True, appended_lines=True, exact_match=False)
+
+    print(
+        'Testing when unmatched lines appear interleaved with regex lines,'
+        'but exact matching is not required.')
+    with assert_raises(UnmatchedOutputError):
+        _run_launch_testing(output_file, interleaved_lines=True, exact_match=False)
 
 
 def test_matching_regex():

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -26,7 +26,7 @@ from launch_testing import create_handler, UnmatchedOutputError
 
 
 def _run_launch_testing(
-        output_file, prepended_lines=False, appended_lines=False,
+        output_file, prepended_lines=False, appended_lines=False, interleaved_lines=False,
         filtered_prefixes=None):
     output_handlers = []
 
@@ -51,6 +51,9 @@ def _run_launch_testing(
 
     if appended_lines:
         executable_command.append('--appended-lines')
+
+    if interleaved_lines:
+        executable_command.append('--interleaved-lines')
 
     launch_descriptor.add_process(
         cmd=executable_command,
@@ -91,10 +94,19 @@ def test_matching_text():
     with assert_raises(UnmatchedOutputError):
         _run_launch_testing(output_file, appended_lines=True)
 
-    # filtered lines appear before regex is matched
+    # filtered lines appear before expected text
     filtered_prefixes = launch_testing.get_default_filtered_prefixes()
     filtered_prefixes.append(b'license')
     _run_launch_testing(output_file, prepended_lines=True, filtered_prefixes=filtered_prefixes)
+
+    # unmatched lines appear interleaved with expected text
+    with assert_raises(UnmatchedOutputError):
+        _run_launch_testing(output_file, interleaved_lines=True)
+
+    # filtered lines appear interleaved with expected text
+    filtered_prefixes = launch_testing.get_default_filtered_prefixes()
+    filtered_prefixes.append(b'debug')
+    _run_launch_testing(output_file, interleaved_lines=True, filtered_prefixes=filtered_prefixes)
 
 
 def test_matching_regex():
@@ -120,6 +132,16 @@ def test_matching_regex():
     filtered_prefixes = launch_testing.get_default_filtered_prefixes()
     filtered_prefixes.append(b'license')
     _run_launch_testing(output_file, prepended_lines=True, filtered_prefixes=filtered_prefixes)
+
+    # unmatched lines appear interleaved with regex lines 
+    with assert_raises(UnmatchedOutputError):
+        _run_launch_testing(output_file, interleaved_lines=True)
+
+    # filtered lines appear interleaved with regex lines
+    filtered_prefixes = launch_testing.get_default_filtered_prefixes()
+    filtered_prefixes.append(b'debug')
+    _run_launch_testing(output_file, interleaved_lines=True, filtered_prefixes=filtered_prefixes)
+
 
 if __name__ == '__main__':
     test_matching_regex()

--- a/launch_testing/test/test_multiple_processes.py
+++ b/launch_testing/test/test_multiple_processes.py
@@ -1,3 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 import tempfile
@@ -8,6 +24,7 @@ from launch.exit_handler import primary_ignore_returncode_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
+from launch_testing import get_default_filtered_prefixes
 
 
 def setup():
@@ -41,11 +58,16 @@ def test_executable():
         else:
             exit_handler = ignore_exit_handler
             exit_on_match = False
-            exact_match = False  # TODO(dhood): finer ignoring of SIGINT
+            exact_match = True
 
+        filtered_prefixes = get_default_filtered_prefixes()
+        filtered_prefixes.append(
+            b'signal SIGINT')
         handler = create_handler(
             name, launch_descriptor, output_file, exact_match=exact_match,
-            exit_on_match=exit_on_match)
+            exit_on_match=exit_on_match,
+            filtered_prefixes=filtered_prefixes,
+        )
         assert handler, 'Cannot find appropriate handler for %s' % output_file
         output_handlers.append(handler)
         launch_descriptor.add_process(

--- a/launch_testing/test/test_multiple_processes.py
+++ b/launch_testing/test/test_multiple_processes.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import tempfile
+
+from launch import LaunchDescriptor
+from launch.exit_handler import ignore_exit_handler
+from launch.exit_handler import primary_ignore_returncode_exit_handler
+from launch.launcher import DefaultLauncher
+from launch.output_handler import ConsoleOutput
+from launch_testing import create_handler
+
+
+def setup():
+    os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+
+
+def test_executable():
+    output_handlers = []
+
+    launch_descriptor = LaunchDescriptor()
+
+    num_executables = 2
+    executable_command = [
+        sys.executable, '-u',
+        os.path.join(os.path.abspath(os.path.dirname(__file__)), 'matching.py')]
+
+    tempdir = tempfile.mkdtemp()
+    output_file = os.path.join(tempdir, 'testfile')
+    full_output_file = output_file + '.txt'
+    with open(full_output_file, 'w+') as f:
+        f.write('this is line 1\nthis is line b\n')
+
+    for i in range(num_executables):
+        name = 'test_executable_' + str(i)
+        # The last executable is taken to be the test program (the one whose
+        # output check can make the decision to shut everything down)
+        if i == (num_executables - 1):
+            exit_handler = primary_ignore_returncode_exit_handler
+            exit_on_match = True
+            exact_match = True
+        else:
+            exit_handler = ignore_exit_handler
+            exit_on_match = False
+            exact_match = False  # TODO(dhood): finer ignoring of SIGINT
+
+        handler = create_handler(
+            name, launch_descriptor, output_file, exact_match=exact_match,
+            exit_on_match=exit_on_match)
+        assert handler, 'Cannot find appropriate handler for %s' % output_file
+        output_handlers.append(handler)
+        launch_descriptor.add_process(
+            cmd=executable_command,
+            name=name,
+            exit_handler=exit_handler,
+            output_handlers=[ConsoleOutput(), handler],
+        )
+
+    launcher = DefaultLauncher()
+    launcher.add_launch_descriptor(launch_descriptor)
+    rc = launcher.launch()
+
+    assert rc == 0, \
+        "The launch file failed with exit code '" + str(rc) + "'. " \
+        'Maybe the client did not receive any messages?'
+
+    for handler in output_handlers:
+        handler.check()
+
+
+if __name__ == '__main__':
+    test_executable()


### PR DESCRIPTION
Connects to ros2/launch#26

I have made the behaviour of `launch_testing` when matching with regexes vs literal text consistent.

Have added test cases for both regex and text matching which describe how I understand the system should function. Namely, tests will fail if unexpected lines are received before, during or after the expected output, unless those lines are filtered with the `filtered_prefixes` option I added to `launch_testing` recently.
