### PR TITLE
Send sigint when regex gets matched

### DIFF
--- a/launch/launch/__init__.py
+++ b/launch/launch/__init__.py
@@ -16,6 +16,9 @@ from launch.output_handler import CompositeOutputHandler
 from launch.output_handler import ConsoleOutput
 from launch.exit_handler import default_exit_handler
 
+import os
+import signal
+
 
 class LaunchDescriptor(object):
 
@@ -76,7 +79,10 @@ class ProcessDescriptor(TaskDescriptor):
     def send_signal(self, signal):
         if self.transport:
             self.transport.send_signal(signal)
+            self.task_state.signals_received.append(signal)
 
     def terminate(self):
-        if self.transport:
+        if os.name != 'nt':
+            self.send_signal(signal.SIGINT)
+        elif self.transport:
             self.transport.terminate()

--- a/launch/launch/__init__.py
+++ b/launch/launch/__init__.py
@@ -78,8 +78,8 @@ class ProcessDescriptor(TaskDescriptor):
 
     def send_signal(self, signal):
         if self.transport:
-            self.transport.send_signal(signal)
             self.task_state.signals_received.append(signal)
+            self.transport.send_signal(signal)
 
     def terminate(self):
         if os.name != 'nt':

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -2,6 +2,7 @@ from importlib.machinery import SourceFileLoader
 import io
 import os
 import re
+import signal
 
 import ament_index_python
 from launch.output_handler import LineOutput
@@ -83,7 +84,10 @@ class InMemoryHandler(LineOutput):
             # We matched and we're in charge; shut myself down
             for td in self.launch_descriptor.task_descriptors:
                 if td.name == self.name:
-                    td.terminate()
+                    if os.name != 'nt':
+                        td.send_signal(signal.SIGINT)
+                    else:
+                        td.terminate()
                     return
 
     def on_stderr_lines(self, lines):

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -2,7 +2,6 @@ from importlib.machinery import SourceFileLoader
 import io
 import os
 import re
-import signal
 
 import ament_index_python
 from launch.output_handler import LineOutput

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -84,10 +84,8 @@ class InMemoryHandler(LineOutput):
             # We matched and we're in charge; shut myself down
             for td in self.launch_descriptor.task_descriptors:
                 if td.name == self.name:
-                    if os.name != 'nt':
-                        td.send_signal(signal.SIGINT)
-                    else:
-                        td.terminate()
+                    td.terminate()
+                    td.protocol.exit_future.set_result(True)
                     return
 
     def on_stderr_lines(self, lines):

--- a/launch_testing/test/hang_after_match.py
+++ b/launch_testing/test/hang_after_match.py
@@ -19,30 +19,15 @@ import sys
 import time
 
 
-# from http://stackoverflow.com/questions/842557
-class IgnoreKeyboardInterrupt(object):
-    def __enter__(self):
-        self.signal_received = False
-        self.old_handler = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGINT, self.handler)
-
-    def handler(self, sig, frame):
-        self.signal_received = (sig, frame)
-
-    def __exit__(self, type, value, traceback):
-        signal.signal(signal.SIGINT, self.old_handler)
-        if self.signal_received:
-            self.old_handler(*self.signal_received)
-
-
 def main():
     print("this is line 1", file=sys.stdout)
     print("this is line b", file=sys.stdout)
     sys.stdout.flush()
 
-    with IgnoreKeyboardInterrupt():
-        while True:
-            pass
+    signal.signal(signal.SIGINT, lambda signum, frame: print('ignoring SIGINT'))
+
+    while True:
+        pass
 
     return 0
 

--- a/launch_testing/test/hang_after_match.py
+++ b/launch_testing/test/hang_after_match.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import signal
+import sys
+import time
+
+
+# from http://stackoverflow.com/questions/842557
+class IgnoreKeyboardInterrupt(object):
+    def __enter__(self):
+        self.signal_received = False
+        self.old_handler = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, self.handler)
+
+    def handler(self, sig, frame):
+        self.signal_received = (sig, frame)
+
+    def __exit__(self, type, value, traceback):
+        signal.signal(signal.SIGINT, self.old_handler)
+        if self.signal_received:
+            self.old_handler(*self.signal_received)
+
+
+def main():
+    print("this is line 1", file=sys.stdout)
+    print("this is line b", file=sys.stdout)
+    sys.stdout.flush()
+
+    with IgnoreKeyboardInterrupt():
+        while True:
+            pass
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/launch_testing/test/test_hang_after_match.py
+++ b/launch_testing/test/test_hang_after_match.py
@@ -16,13 +16,13 @@ import os
 import sys
 import tempfile
 from launch import LaunchDescriptor
-from launch.exit_handler import ignore_exit_handler
+from launch.exit_handler import ignore_signal_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
 
 
-def test_matching():
+def test_hang_after_match():
     output_handlers = []
 
     launch_descriptor = LaunchDescriptor()
@@ -36,7 +36,7 @@ def test_matching():
 
     name = "test_executable_0"
 
-    handler = create_handler(name, launch_descriptor, output_file)
+    handler = create_handler(name, launch_descriptor, output_file, exit_on_match=True)
 
     assert handler, 'Cannot find appropriate handler for %s' % output_file
 
@@ -44,12 +44,12 @@ def test_matching():
 
     executable_command = [
         sys.executable,
-        os.path.join(os.path.abspath(os.path.dirname(__file__)), 'matching.py')]
+        os.path.join(os.path.abspath(os.path.dirname(__file__)), 'hang_after_match.py')]
 
     launch_descriptor.add_process(
         cmd=executable_command,
         name=name,
-        exit_handler=ignore_exit_handler,
+        exit_handler=ignore_signal_exit_handler,
         output_handlers=[ConsoleOutput(), handler])
 
     launcher = DefaultLauncher()
@@ -64,4 +64,4 @@ def test_matching():
 
 
 if __name__ == '__main__':
-    test_matching()
+    test_hang_after_match()


### PR DESCRIPTION
Fixes ros2/ros2#239

When a process that was instrumented by gcov is interrupted by SIGKILL, SIGHUP or SIGTERM, it does not write a gcda file. The reason no gcda files were written for intra_process_demo is that all of the nosetests for the demos use regex matching, which through the codepath of `TaskDescriptor.terminate` sends SIGHUP to the child processes.

This affected files in other packages as well, for example the `talker/listener` in rclcpp_examples only has coverage information for the talker, because the listener uses regex matching and "exit_on_match":

http://ci.ros2.org/view/nightly/job/nightly_linux_coverage/5/cobertura/_home_rosbuild_ci_scripts_ws_src_ros2_examples_rclcpp_examples_src_topics/

We should expect this job to have results for the intra_process_demo package:
http://ci.ros2.org/job/ci_linux/1539/
