### PR TITLE
Use Python 3.5 async

### DIFF
--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -27,12 +27,14 @@ from launch.task import TaskState
 
 
 class _TaskException(Exception):
+
     def __init__(self, task_descriptor_index, exception):
         self.task_descriptor_index = task_descriptor_index
         self.exception = exception
 
 
 class DefaultLauncher(object):
+
     def __init__(self, name_prefix='', sigint_timeout=10):
         self.name_prefix = name_prefix
         self.sigint_timeout = sigint_timeout
@@ -387,6 +389,7 @@ class DefaultLauncher(object):
 
 
 class AsynchronousLauncher(threading.Thread):
+
     def __init__(self, launcher):
         super(AsynchronousLauncher, self).__init__()
         self.launcher = launcher

--- a/launch/test/test_launch_with_coroutine.py
+++ b/launch/test/test_launch_with_coroutine.py
@@ -29,22 +29,20 @@ def test_launch_with_coroutine():
     launch_descriptor = LaunchDescriptor()
     load_launch_file(launch_file, launch_descriptor, {})
 
-    @asyncio.coroutine
-    def coroutine():
-        yield from asyncio.sleep(1)
+    async def coroutine():
+        await asyncio.sleep(1)
         print('one', file=sys.stderr)
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
         print('two', file=sys.stderr)
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
         print('three', file=sys.stderr)
 
-    @asyncio.coroutine
-    def coroutine2():
-        yield from asyncio.sleep(1)
+    async def coroutine2():
+        await asyncio.sleep(1)
         print('one mississippi', file=sys.stderr)
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
         print('two mississippi', file=sys.stderr)
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
         print('three mississippi', file=sys.stderr)
 
     launch_descriptor.add_coroutine(

--- a/launch/test/test_multiple_launch.py
+++ b/launch/test/test_multiple_launch.py
@@ -27,9 +27,8 @@ def test_multiple_launch():
 def launch(index):
     default_launcher = DefaultLauncher()
 
-    @asyncio.coroutine
-    def coroutine():
-        yield from asyncio.sleep(1)
+    async def coroutine():
+        await asyncio.sleep(1)
         print('message %d' % index, file=sys.stderr)
 
     launch_descriptor = LaunchDescriptor()

--- a/launch/test/test_non_primary_return_code.py
+++ b/launch/test/test_non_primary_return_code.py
@@ -29,17 +29,15 @@ def test_non_primary_return_code():
 
     default_launcher = DefaultLauncher()
 
-    @asyncio.coroutine
-    def coroutine1():
-        yield from asyncio.sleep(1)
+    async def coroutine1():
+        await asyncio.sleep(1)
         print('one', file=sys.stderr)
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
         print('two', file=sys.stderr)
         return 3
 
-    @asyncio.coroutine
-    def coroutine2():
-        yield from asyncio.sleep(1)
+    async def coroutine2():
+        await asyncio.sleep(1)
         print('one mississippi', file=sys.stderr)
         return 0
 


### PR DESCRIPTION
Python 3.5 adds a lot of new asyncio functionality, and launch was still using the 3.4 asyncio stuff.
As python 3.5 is our minimum version as of alpha7, this PR pulls forward to the 3.5 asyncio.