### PR TITLE
send SIGINT instead of terminate() if possible

### DIFF
--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -2,6 +2,7 @@ from importlib.machinery import SourceFileLoader
 import io
 import os
 import re
+import signal
 
 import ament_index_python
 from launch.output_handler import LineOutput
@@ -84,7 +85,11 @@ class InMemoryHandler(LineOutput):
             # We matched and we're in charge; shut myself down
             for td in self.launch_descriptor.task_descriptors:
                 if td.name == self.name:
-                    td.terminate()
+                    if os.name != 'nt':
+                        td.task_state.signals_received.append(signal.SIGINT)
+                        td.transport.send_signal(signal.SIGINT)
+                    else:
+                        td.terminate()
                     return
 
     def on_stderr_lines(self, lines):


### PR DESCRIPTION
Currently calling `terminate()` will make the process fail with a potentially non-zero return code. If a `SIGINT` is sent instead the process might not respond to it. Imo that is an error case (the process not honoring the `SIGINT` signal) so if the process keeps running it will be catched by the timeout which will then fail the test.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1863)](http://ci.ros2.org/job/ci_linux/1863/)
* OS X [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1398)](http://ci.ros2.org/job/ci_osx/1398/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1781)](http://ci.ros2.org/job/ci_windows/1781/)