### PR TITLE
handle Windows case

### DIFF
--- a/launch/launch/exit_handler.py
+++ b/launch/launch/exit_handler.py
@@ -107,7 +107,14 @@ def exit_on_error_exit_handler(context):
     If the return code indicates an error trigger a tear down.
 
     If the return code is zero continue the other tasks.
+    On Windows the task return code is ignored if launch sent a SIGINT or
+    SIGKILL to the task.
     """
+    if context.launch_state.teardown and context.task_state.signals_received \
+            and os.name == 'nt':
+        context.task_state.returncode = 0
+        return
+
     try:
         rc = int(context.task_state.returncode)
     except (TypeError, ValueError):


### PR DESCRIPTION
This is a follow up of #46. I certainly don't think these exit handlers should stay that way. But this will get composition and Windows to be happy together... [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1855)](http://ci.ros2.org/job/ci_windows/1855/)

E.g. this special case should be addressed within launch itself since it is a platform flaw which the exit handlers shouldn't need to work around. 