### PR TITLE
Add python3 buildtool and exec depends.

### DIFF
--- a/launch/package.xml
+++ b/launch/package.xml
@@ -7,6 +7,10 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <exec_depend>python3</exec_depend>
+
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
 

--- a/launch_testing/package.xml
+++ b/launch_testing/package.xml
@@ -7,8 +7,11 @@
   <maintainer email="esteve@osrfoundation.org">Esteve Fernandez</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>python3</buildtool_depend>
+
   <exec_depend>launch</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python3</exec_depend>
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
In order to be packaged these python3 dependencies are needed.