### PR TITLE
catch problems when spawning of processes fails

### DIFF
--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -254,6 +254,7 @@ class DefaultLauncher(object):
 
             # cancel coroutines
             for future, index in all_futures.items():
+                p = self.task_descriptors[index]
                 if 'coroutine' in dir(p):
                     if not future.done():
                         self._process_message(p, 'cancel coroutine')

--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -125,8 +125,11 @@ class DefaultLauncher(object):
             if 'protocol' in dir(p):
                 try:
                     await self._spawn_process(index)
-                except Exception as e:
-                    raise _TaskException(index, e)
+                except Exception:
+                    # clean up already spawned processes
+                    await self._terminate_processes(launch_state, all_futures)
+                    self.launch_complete.set()
+                    return 1
                 all_futures[p.protocol.exit_future] = index
             else:
                 future = asyncio.ensure_future(p.coroutine)
@@ -209,6 +212,14 @@ class DefaultLauncher(object):
                     all_futures[p.protocol.exit_future] = index
         # end while True
 
+        await self._terminate_processes(launch_state, all_futures)
+
+        if launch_state.returncode is None:
+            launch_state.returncode = 0
+        self.launch_complete.set()
+        return launch_state.returncode
+
+    async def _terminate_processes(self, launch_state, all_futures):
         # terminate all remaining processes
         if all_futures:
 
@@ -301,11 +312,6 @@ class DefaultLauncher(object):
                 context = ExitHandlerContext(launch_state, p.task_state)
                 p.exit_handler(context)
 
-        if launch_state.returncode is None:
-            launch_state.returncode = 0
-        self.launch_complete.set()
-        return launch_state.returncode
-
     def check_for_exited_subprocesses(self, all_futures):
         for index, p in enumerate(self.task_descriptors):
             # only consider not yet done tasks
@@ -345,10 +351,15 @@ class DefaultLauncher(object):
         if p.env is not None:
             kwargs['env'] = p.env
         loop = asyncio.get_event_loop()
-        transport, protocol = await loop.subprocess_exec(
-            lambda: SubprocessProtocol(p.output_handler),
-            *p.cmd,
-            **kwargs)
+        try:
+            transport, protocol = await loop.subprocess_exec(
+                lambda: SubprocessProtocol(p.output_handler),
+                *p.cmd,
+                **kwargs)
+        except Exception as e:
+            self._process_message(
+                p, 'Failed to spawn command %s: %s' % (p.cmd, e))
+            raise
         p.transport = transport
         p.protocol = protocol
 


### PR DESCRIPTION
Fixes #54.

@dhood Can you please verify that it fixes the problem for you too.

The CI builds will only indicate no regressions and I only tested up to `launch_testing`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2758)](http://ci.ros2.org/job/ci_linux/2758/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=291)](http://ci.ros2.org/job/ci_linux-aarch64/291/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2231)](http://ci.ros2.org/job/ci_osx/2231/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2887)](http://ci.ros2.org/job/ci_windows/2887/)