### PR TITLE
Added support for command line launch arguments

### DIFF
--- a/launch/launch/arguments.py
+++ b/launch/launch/arguments.py
@@ -1,0 +1,55 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def get_launch_args(argv, separator=":="):
+    """Return a dictionay of key value pairs for launch arguments passed
+    on the command line using the format "key:=value". This will process
+    every string in the argv list.
+
+    NOTE: all key value pairs will be returned as strings and no type
+    checking is applied to the values.
+
+    For example:
+
+        argv = ["arg1:=123", "hello", "arg2:=true", "arg3:=true", "/path/to/file"]
+        args = get_launch_args(argv)
+        # Results in args = {'arg1': '123', 'arg2': 'true', 'arg3': 'true'}
+
+    :param argv: is the list of string command line arguments
+    :param separator: is the string separator for each key:=value pair (e.g., ':=')
+    :returns: a dictionary of string key value pairs
+    :rtype: dictionary
+
+    """
+    launch_args = {}
+
+    # Separate the command line arguments into a dictionary of
+    # launch key value pairs of the format key:=value. Process the
+    # first element even though it will likely be the executable name
+    # to support other lists.
+    for arg in argv:
+        # Split the arg into a key value pair
+        arg_pair = arg.split(separator)
+        if len(arg_pair) != 2:
+            continue  # Skip non launch args
+
+        key, value = arg_pair
+
+        # Ignore pairs with an empty key, which isn't a useful argument pair
+        if len(key) == 0:
+            continue
+
+        launch_args[key] = value
+
+    return launch_args

--- a/launch/launch/arguments.py
+++ b/launch/launch/arguments.py
@@ -18,7 +18,7 @@ def get_launch_args(argv, separator=':='):
     Get the list of launch arguments passed on the command line.
 
     Return a dictionary of key value pairs for launch arguments passed
-    on the command line using the format "key{separator}value". This will
+    on the command line using the format 'key{separator}value'. This will
     process every string in the argv list.
 
     NOTE: all key value pairs will be returned as strings and no type
@@ -26,7 +26,7 @@ def get_launch_args(argv, separator=':='):
 
     For example:
 
-        argv = ["arg1:=123", "hello", "arg2:=true", "arg3:=true", "/path/to/file"]
+        argv = ['arg1:=123', 'hello', 'arg2:=true', 'arg3:=true', '/path/to/file']
         args = get_launch_args(argv)
         # Results in args = {'arg1': '123', 'arg2': 'true', 'arg3': 'true'}
 
@@ -44,8 +44,9 @@ def get_launch_args(argv, separator=':='):
     # first element even though it will likely be the executable name
     # to support other lists.
     for arg in argv:
-        # Split the arg into a key value pair
-        arg_pair = arg.split(separator)
+        # Split the arg into a key value pair (allow values to contain
+        # the separator)
+        arg_pair = arg.split(separator, 1)
         if len(arg_pair) != 2:
             continue  # Skip non launch args
 

--- a/launch/launch/arguments.py
+++ b/launch/launch/arguments.py
@@ -14,7 +14,8 @@
 
 
 def get_launch_args(argv, separator=":="):
-    """Get the list of launch arguments passed on the command line.
+    """
+    Get the list of launch arguments passed on the command line.
 
     Return a dictionary of key value pairs for launch arguments passed
     on the command line using the format "key{separator}value". This will

--- a/launch/launch/arguments.py
+++ b/launch/launch/arguments.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Open Source Robotics Foundation, Inc.
+# Copyright 2017 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 def get_launch_args(argv, separator=":="):
-    """Return a dictionay of key value pairs for launch arguments passed
-    on the command line using the format "key:=value". This will process
-    every string in the argv list.
+    """Get the list of launch arguments passed on the command line.
+
+    Return a dictionary of key value pairs for launch arguments passed
+    on the command line using the format "key{separator}value". This will
+    process every string in the argv list.
 
     NOTE: all key value pairs will be returned as strings and no type
     checking is applied to the values.
@@ -27,15 +30,16 @@ def get_launch_args(argv, separator=":="):
         # Results in args = {'arg1': '123', 'arg2': 'true', 'arg3': 'true'}
 
     :param argv: is the list of string command line arguments
-    :param separator: is the string separator for each key:=value pair (e.g., ':=')
+    :type argv: list(str)
+    :param str separator: is the string separator for each key value pair (e.g., ':=')
     :returns: a dictionary of string key value pairs
-    :rtype: dictionary
+    :rtype: dict(str, str)
 
     """
     launch_args = {}
 
     # Separate the command line arguments into a dictionary of
-    # launch key value pairs of the format key:=value. Process the
+    # launch key value pairs of the format key${separator}value. Process the
     # first element even though it will likely be the executable name
     # to support other lists.
     for arg in argv:

--- a/launch/launch/arguments.py
+++ b/launch/launch/arguments.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-def get_launch_args(argv, separator=":="):
+def get_launch_args(argv, separator=':='):
     """
     Get the list of launch arguments passed on the command line.
 

--- a/launch/launch/loader.py
+++ b/launch/launch/loader.py
@@ -15,7 +15,7 @@
 from importlib.machinery import SourceFileLoader
 
 
-def load_launch_file(launch_file, launch_descriptor, argv):
+def load_launch_file(launch_file, launch_descriptor, args):
     loader = SourceFileLoader('launch_file', launch_file)
     launch_module = loader.load_module()
-    launch_module.launch(launch_descriptor, argv)
+    launch_module.launch(launch_descriptor, args)

--- a/launch/launch/main.py
+++ b/launch/launch/main.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Open Source Robotics Foundation, Inc.
+# Copyright 2017 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ def main(argv=sys.argv[1:]):
 
     # Ensure that at least one existing launch file was given
     if len(launch_files) == 0:
-        sys.stderr.write('error: you must pass at least one valid launch file\n')
+        print('error: you must pass at least one valid launch file', file=sys.stderr)
         parser.print_help()
         sys.exit(2)
 

--- a/launch/launch/main.py
+++ b/launch/launch/main.py
@@ -21,19 +21,27 @@ from launch.launcher import DefaultLauncher
 from launch.loader import load_launch_file
 
 
+def file_exists(filename):
+    if not os.path.isfile(filename):
+        raise argparse.ArgumentError("'%s' does not exist" % filename)
+    return filename
+
+
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Launch the processes specified in a launch file.')
     parser.add_argument(
         'launch_file',
-        type=str,
+        type=file_exists,
         nargs='+',
         help='The launch file.')
     parser.add_argument(
-        'arg',
+        '--args',
+        metavar="arg",
         type=str,
-        nargs='*',
-        help='An argument to the launch file (e.g., arg_name:=value).')
+        nargs='+',
+        help='An argument to the launch file (e.g., arg_name:=value). All ' +
+        'arguments will be passed to each launch file.')
     args = parser.parse_args(argv)
 
     # Get the list of launch files passed on the command line
@@ -54,12 +62,11 @@ def main(argv=sys.argv[1:]):
     # Ensure that at least one existing launch file was given
     if len(launch_files) == 0:
         parser.error('you must pass at least one valid launch file')
-        sys.exit(2)
 
     launcher = DefaultLauncher()
     for launch_file in launch_files:
         launch_descriptor = LaunchDescriptor()
-        load_launch_file(launch_file, launch_descriptor, argv)
+        load_launch_file(launch_file, launch_descriptor, args.args)
         launcher.add_launch_descriptor(launch_descriptor)
     rc = launcher.launch()
     return rc

--- a/launch/launch/main.py
+++ b/launch/launch/main.py
@@ -40,33 +40,14 @@ def main(argv=sys.argv[1:]):
         metavar="arg",
         type=str,
         nargs='+',
-        help='An argument to the launch file (e.g., arg_name:=value). All ' +
+        help='An argument to the launch file (e.g., arg_name:=value). All '
         'arguments will be passed to each launch file.')
     args = parser.parse_args(argv)
 
-    # Get the list of launch files passed on the command line
-    # NOTE: since both the launch files and launch arguments are consecutive
-    # lists of arguments, argparse will put all arguments into the launch_file
-    # list, and the arg list will be empty. This is because the '+' list is
-    # greedy and consumes the remaining arguments. Therefore the arguments
-    # need to be validated afterward
-    launch_files = []
-    for arg in args.launch_file:
-        # Store consecutive existing files and stop once a
-        # non-existing file is found
-        if os.path.isfile(arg):
-            launch_files.append(arg)
-        else:
-            break
-
-    # Ensure that at least one existing launch file was given
-    if len(launch_files) == 0:
-        parser.error('you must pass at least one valid launch file')
-
     launcher = DefaultLauncher()
-    for launch_file in launch_files:
+    for launch_file in args.launch_file:
         launch_descriptor = LaunchDescriptor()
-        load_launch_file(launch_file, launch_descriptor, args.args)
+        load_launch_file(args.launch_file, launch_descriptor, args.args)
         launcher.add_launch_descriptor(launch_descriptor)
     rc = launcher.launch()
     return rc

--- a/launch/launch/main.py
+++ b/launch/launch/main.py
@@ -22,9 +22,16 @@ from launch.loader import load_launch_file
 
 
 def file_exists(filename):
-    if not os.path.exists(filename) or not os.path.isfile(filename):
-        raise argparse.ArgumentError("'%s' does not exist" % filename)
-    return filename
+    return os.path.exists(filename) and os.path.isfile(filename)
+
+
+def get_launch_arg(arg, separator=":="):
+    # Split the arg into a key value pair
+    parts = arg.split(separator)
+    if len(parts) != 2:
+        return None
+
+    return tuple(parts)
 
 
 def main(argv=sys.argv[1:]):
@@ -32,15 +39,65 @@ def main(argv=sys.argv[1:]):
         description='Launch the processes specified in a launch file.')
     parser.add_argument(
         'launch_file',
-        type=file_exists,
+        type=str,
         nargs='+',
         help='The launch file.')
+    parser.add_argument(
+        'arg',
+        type=str,
+        nargs='*',
+        help='An argument to the launch file (e.g., arg_name:=value).')
     args = parser.parse_args(argv)
 
-    arguments = {}
+    launch_files = []
+    launch_args = []
+
+    # Validate the list of arguments
+    # NOTE: since both the launch files and launch arguments are consecutive
+    # lists of arguments, argparse will put all arguments into the launch_file
+    # list, and the arg list will be empty. This is because the '+' list is
+    # greedy and consumes the remaining arguments. Therefore the arguments
+    # need to be validated afterward
+    for arg in args.launch_file:
+        if len(launch_files) == 0:
+            # Found no launch files yet, therefore this must be a launch file
+            if file_exists(arg):
+                launch_files.append(arg)
+            else:
+                print("ERROR: '%s' is not a valid launch file" % arg)
+                parser.print_help()
+                sys.exit(2)
+        else:
+            # Found at least one launch file before this, need to know
+            # if arguments have been found yet
+            arg_pair = get_launch_arg(arg)
+            if len(launch_args) > 0:
+                # Found a previous launch argument, therefore
+                # this must also be a launch argument
+                if arg_pair is None:
+                    print("ERROR: '%s' is not a valid launch argument" % arg)
+                    parser.print_help()
+                    sys.exit(2)
+                else:
+                    launch_args.append(arg_pair)
+            else:
+                # Found no arguments yet, so the argument can
+                # be either a launch file, or a launch argument
+                if arg_pair is None:
+                    # Must be a file
+                    if file_exists(arg):
+                        launch_files.append(arg)
+                    else:
+                        print("ERROR: '%s' is not a valid launch file or argument" % arg)
+                        parser.print_help()
+                        sys.exit(2)
+                else:
+                    launch_args.append(arg_pair)
+
+    arguments = dict(launch_args)
 
     launcher = DefaultLauncher()
-    for launch_file in args.launch_file:
+    for launch_file in launch_files:
         launch_descriptor = LaunchDescriptor()
         load_launch_file(launch_file, launch_descriptor, arguments)
         launcher.add_launch_descriptor(launch_descriptor)

--- a/launch/launch/main.py
+++ b/launch/launch/main.py
@@ -41,7 +41,7 @@ def main(argv=sys.argv[1:]):
         type=str,
         nargs='+',
         help='An argument to the launch file (e.g., arg_name:=value). All '
-        'arguments will be passed to each launch file.')
+             'arguments will be passed to each launch file.')
     args = parser.parse_args(argv)
 
     launcher = DefaultLauncher()

--- a/launch/launch/main.py
+++ b/launch/launch/main.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Open Source Robotics Foundation, Inc.
+# Copyright 2015-2017 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,6 @@ import sys
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
 from launch.loader import load_launch_file
-
-
-def file_exists(filename):
-    return os.path.exists(filename) and os.path.isfile(filename)
 
 
 def main(argv=sys.argv[1:]):
@@ -50,15 +46,14 @@ def main(argv=sys.argv[1:]):
     for arg in args.launch_file:
         # Store consecutive existing files and stop once a
         # non-existing file is found
-        if file_exists(arg):
+        if os.path.isfile(arg):
             launch_files.append(arg)
         else:
             break
 
     # Ensure that at least one existing launch file was given
     if len(launch_files) == 0:
-        print('error: you must pass at least one valid launch file', file=sys.stderr)
-        parser.print_help()
+        parser.error('you must pass at least one valid launch file')
         sys.exit(2)
 
     launcher = DefaultLauncher()

--- a/launch/test/test_launch_args.py
+++ b/launch/test/test_launch_args.py
@@ -18,89 +18,95 @@ def test_launch_args():
     # Test empty arguments
     argv = []
     args = get_launch_args(argv)
-    assert len(args) == 0, "Failed empty list"
+    assert len(args) == 0, 'Failed empty list'
 
     # Test single argument with no launch arg
-    argv = ["/path/to/my/executable"]
+    argv = ['/path/to/my/executable']
     args = get_launch_args(argv)
-    assert len(args) == 0, "Failed single non-launch arg"
+    assert len(args) == 0, 'Failed single non-launch arg'
 
     # Test single argument with launch arg
-    argv = ["my_arg:=12345"]
+    argv = ['my_arg:=12345']
     args = get_launch_args(argv)
-    assert len(args) == 1, "Failed single launch arg"
-    assert "my_arg" in args, "Did not find my_arg"
-    assert "12345" == args["my_arg"], "my_arg has invalid value"
+    assert len(args) == 1, 'Failed single launch arg'
+    assert 'my_arg' in args, 'Did not find my_arg'
+    assert '12345' == args['my_arg'], 'my_arg has invalid value'
 
     # Test multiple non-launch args
-    argv = ["/path/to/file", "hello", "123", "abcdefg"]
+    argv = ['/path/to/file', 'hello', '123', 'abcdefg']
     args = get_launch_args(argv)
-    assert len(args) == 0, "Failed multiple non-launch args"
+    assert len(args) == 0, 'Failed multiple non-launch args'
 
     # Test multiple launch arguments
-    argv = ["arg1:=12345", "arg2:=true", "arg3:=whatever", "arg4:=yes"]
+    argv = ['arg1:=12345', 'arg2:=true', 'arg3:=whatever', 'arg4:=yes']
     args = get_launch_args(argv)
-    assert len(args) == 4, "Failed multiple launch args"
-    assert "arg1" in args, "Did not find arg1"
-    assert "arg2" in args, "Did not find arg2"
-    assert "arg3" in args, "Did not find arg3"
-    assert "arg4" in args, "Did not find arg4"
-    assert "12345" == args["arg1"], "arg1 has invalid value"
-    assert "true" == args["arg2"], "arg2 has invalid value"
-    assert "whatever" == args["arg3"], "arg3 has invalid value"
-    assert "yes" == args["arg4"], "arg4 has invalid value"
+    assert len(args) == 4, 'Failed multiple launch args'
+    assert 'arg1' in args, 'Did not find arg1'
+    assert 'arg2' in args, 'Did not find arg2'
+    assert 'arg3' in args, 'Did not find arg3'
+    assert 'arg4' in args, 'Did not find arg4'
+    assert '12345' == args['arg1'], 'arg1 has invalid value'
+    assert 'true' == args['arg2'], 'arg2 has invalid value'
+    assert 'whatever' == args['arg3'], 'arg3 has invalid value'
+    assert 'yes' == args['arg4'], 'arg4 has invalid value'
 
     # Test list of both non-launch args and args
     argv = [
-        "/path/to/file",
-        "arg5:=HELLO",
-        "--help",
-        "my_fancy_arg:=/cmd_vel",
-        "-v",
-        "verbose:=false",
+        '/path/to/file',
+        'arg5:=HELLO',
+        '--help',
+        'my_fancy_arg:=/cmd_vel',
+        '-v',
+        'verbose:=false',
     ]
     args = get_launch_args(argv)
-    assert len(args) == 3, "Failed list of both non-launch args and args"
-    assert "arg5" in args, "Did not find arg5"
-    assert "my_fancy_arg" in args, "Did not find my_fancy_arg"
-    assert "verbose" in args, "Did not find verbose"
-    assert "HELLO" == args["arg5"], "arg5 has invalid value"
-    assert "/cmd_vel" == args["my_fancy_arg"], "my_fancy_arg has invalid value"
-    assert "false" == args["verbose"], "verbose has invalid value"
+    assert len(args) == 3, 'Failed list of both non-launch args and args'
+    assert 'arg5' in args, 'Did not find arg5'
+    assert 'my_fancy_arg' in args, 'Did not find my_fancy_arg'
+    assert 'verbose' in args, 'Did not find verbose'
+    assert 'HELLO' == args['arg5'], 'arg5 has invalid value'
+    assert '/cmd_vel' == args['my_fancy_arg'], 'my_fancy_arg has invalid value'
+    assert 'false' == args['verbose'], 'verbose has invalid value'
 
     # Test custom separator
     argv = [
-        "/path/to/file",
-        "arg5->HELLO",
-        "--help",
-        "my_fancy_arg->/cmd_vel",
-        "-v", "verbose:=false",
+        '/path/to/file',
+        'arg5->HELLO',
+        '--help',
+        'my_fancy_arg->/cmd_vel',
+        '-v', 'verbose:=false',
     ]
-    args = get_launch_args(argv, separator="->")
-    assert len(args) == 2, "Failed custom separator"
-    assert "arg5" in args, "Did not find arg5"
-    assert "my_fancy_arg" in args, "Did not find my_fancy_arg"
-    assert "verbose" not in args, "Found verbose but should not have"
-    assert "HELLO" == args["arg5"], "arg5 has invalid value"
-    assert "/cmd_vel" == args["my_fancy_arg"], "my_fancy_arg has invalid value"
+    args = get_launch_args(argv, separator='->')
+    assert len(args) == 2, 'Failed custom separator'
+    assert 'arg5' in args, 'Did not find arg5'
+    assert 'my_fancy_arg' in args, 'Did not find my_fancy_arg'
+    assert 'verbose' not in args, 'Found verbose but should not have'
+    assert 'HELLO' == args['arg5'], 'arg5 has invalid value'
+    assert '/cmd_vel' == args['my_fancy_arg'], 'my_fancy_arg has invalid value'
 
     # Test pair without key
-    argv = [":=my_value"]
+    argv = [':=my_value']
     args = get_launch_args(argv)
-    assert len(args) == 0, "Failed pair without key"
+    assert len(args) == 0, 'Failed pair without key'
 
     # Test pair without value
-    argv = ["my_key:="]
+    argv = ['my_key:=']
     args = get_launch_args(argv)
-    assert len(args) == 1, "Failed pair without value"
-    assert "my_key" in args, "Did not find my_key argument"
-    assert "" == args["my_key"], "my_key arg has incorrect value"
+    assert len(args) == 1, 'Failed pair without value'
+    assert 'my_key' in args, 'Did not find my_key argument'
+    assert '' == args['my_key'], 'my_key arg has incorrect value'
 
     # Test pair without key and value
-    argv = [":="]
+    argv = [':=']
     args = get_launch_args(argv)
-    assert len(args) == 0, "Failed pair without key and value"
+    assert len(args) == 0, 'Failed pair without key and value'
 
+    # Test value containing separator
+    argv = ['key:=value:=another_value']
+    args = get_launch_args(argv)
+    assert len(args) == 1, 'Failed value containing separator'
+    assert 'key' in args, 'Did not find key'
+    assert 'value:=another_value' == args['key'], 'key had incorrect value'
 
 if __name__ == '__main__':
     test_launch_args()

--- a/launch/test/test_launch_args.py
+++ b/launch/test/test_launch_args.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Open Source Robotics Foundation, Inc.
+# Copyright 2017 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,33 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from launch.arguments import get_launch_args
-from launch.main import main
 
 
 def test_launch_args():
-    ## Test empty arguments
+    # Test empty arguments
     argv = []
     args = get_launch_args(argv)
     assert len(args) == 0, "Failed empty list"
 
-    ## Test single argument with no launch arg
+    # Test single argument with no launch arg
     argv = ["/path/to/my/executable"]
     args = get_launch_args(argv)
     assert len(args) == 0, "Failed single non-launch arg"
 
-    ## Test single argument with launch arg
+    # Test single argument with launch arg
     argv = ["my_arg:=12345"]
     args = get_launch_args(argv)
     assert len(args) == 1, "Failed single launch arg"
     assert "my_arg" in args, "Did not find my_arg"
     assert "12345" == args["my_arg"], "my_arg has invalid value"
 
-    ## Test multiple non-launch args
+    # Test multiple non-launch args
     argv = ["/path/to/file", "hello", "123", "abcdefg"]
     args = get_launch_args(argv)
     assert len(args) == 0, "Failed multiple non-launch args"
 
-    ## Test multiple launch arguments
+    # Test multiple launch arguments
     argv = ["arg1:=12345", "arg2:=true", "arg3:=whatever", "arg4:=yes"]
     args = get_launch_args(argv)
     assert len(args) == 4, "Failed multiple launch args"
@@ -51,8 +50,15 @@ def test_launch_args():
     assert "whatever" == args["arg3"], "arg3 has invalid value"
     assert "yes" == args["arg4"], "arg4 has invalid value"
 
-    ## Test list of both non-launch args and args
-    argv = ["/path/to/file", "arg5:=HELLO", "--help", "my_fancy_arg:=/cmd_vel", "-v", "verbose:=false"]
+    # Test list of both non-launch args and args
+    argv = [
+        "/path/to/file",
+        "arg5:=HELLO",
+        "--help",
+        "my_fancy_arg:=/cmd_vel",
+        "-v",
+        "verbose:=false",
+    ]
     args = get_launch_args(argv)
     assert len(args) == 3, "Failed list of both non-launch args and args"
     assert "arg5" in args, "Did not find arg5"
@@ -62,8 +68,14 @@ def test_launch_args():
     assert "/cmd_vel" == args["my_fancy_arg"], "my_fancy_arg has invalid value"
     assert "false" == args["verbose"], "verbose has invalid value"
 
-    ## Test custom separator
-    argv = ["/path/to/file", "arg5->HELLO", "--help", "my_fancy_arg->/cmd_vel", "-v", "verbose:=false"]
+    # Test custom separator
+    argv = [
+        "/path/to/file",
+        "arg5->HELLO",
+        "--help",
+        "my_fancy_arg->/cmd_vel",
+        "-v", "verbose:=false",
+    ]
     args = get_launch_args(argv, separator="->")
     assert len(args) == 2, "Failed custom separator"
     assert "arg5" in args, "Did not find arg5"
@@ -72,19 +84,19 @@ def test_launch_args():
     assert "HELLO" == args["arg5"], "arg5 has invalid value"
     assert "/cmd_vel" == args["my_fancy_arg"], "my_fancy_arg has invalid value"
 
-    ## Test pair without key
+    # Test pair without key
     argv = [":=my_value"]
     args = get_launch_args(argv)
     assert len(args) == 0, "Failed pair without key"
 
-    ## Test pair without value
+    # Test pair without value
     argv = ["my_key:="]
     args = get_launch_args(argv)
     assert len(args) == 1, "Failed pair without value"
     assert "my_key" in args, "Did not find my_key argument"
     assert "" == args["my_key"], "my_key arg has incorrect value"
 
-    ## Test pair without key and value
+    # Test pair without key and value
     argv = [":="]
     args = get_launch_args(argv)
     assert len(args) == 0, "Failed pair without key and value"

--- a/launch/test/test_launch_args.py
+++ b/launch/test/test_launch_args.py
@@ -108,5 +108,6 @@ def test_launch_args():
     assert 'key' in args, 'Did not find key'
     assert 'value:=another_value' == args['key'], 'key had incorrect value'
 
+
 if __name__ == '__main__':
     test_launch_args()

--- a/launch/test/test_launch_args.py
+++ b/launch/test/test_launch_args.py
@@ -1,0 +1,94 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from launch.arguments import get_launch_args
+from launch.main import main
+
+
+def test_launch_args():
+    ## Test empty arguments
+    argv = []
+    args = get_launch_args(argv)
+    assert len(args) == 0, "Failed empty list"
+
+    ## Test single argument with no launch arg
+    argv = ["/path/to/my/executable"]
+    args = get_launch_args(argv)
+    assert len(args) == 0, "Failed single non-launch arg"
+
+    ## Test single argument with launch arg
+    argv = ["my_arg:=12345"]
+    args = get_launch_args(argv)
+    assert len(args) == 1, "Failed single launch arg"
+    assert "my_arg" in args, "Did not find my_arg"
+    assert "12345" == args["my_arg"], "my_arg has invalid value"
+
+    ## Test multiple non-launch args
+    argv = ["/path/to/file", "hello", "123", "abcdefg"]
+    args = get_launch_args(argv)
+    assert len(args) == 0, "Failed multiple non-launch args"
+
+    ## Test multiple launch arguments
+    argv = ["arg1:=12345", "arg2:=true", "arg3:=whatever", "arg4:=yes"]
+    args = get_launch_args(argv)
+    assert len(args) == 4, "Failed multiple launch args"
+    assert "arg1" in args, "Did not find arg1"
+    assert "arg2" in args, "Did not find arg2"
+    assert "arg3" in args, "Did not find arg3"
+    assert "arg4" in args, "Did not find arg4"
+    assert "12345" == args["arg1"], "arg1 has invalid value"
+    assert "true" == args["arg2"], "arg2 has invalid value"
+    assert "whatever" == args["arg3"], "arg3 has invalid value"
+    assert "yes" == args["arg4"], "arg4 has invalid value"
+
+    ## Test list of both non-launch args and args
+    argv = ["/path/to/file", "arg5:=HELLO", "--help", "my_fancy_arg:=/cmd_vel", "-v", "verbose:=false"]
+    args = get_launch_args(argv)
+    assert len(args) == 3, "Failed list of both non-launch args and args"
+    assert "arg5" in args, "Did not find arg5"
+    assert "my_fancy_arg" in args, "Did not find my_fancy_arg"
+    assert "verbose" in args, "Did not find verbose"
+    assert "HELLO" == args["arg5"], "arg5 has invalid value"
+    assert "/cmd_vel" == args["my_fancy_arg"], "my_fancy_arg has invalid value"
+    assert "false" == args["verbose"], "verbose has invalid value"
+
+    ## Test custom separator
+    argv = ["/path/to/file", "arg5->HELLO", "--help", "my_fancy_arg->/cmd_vel", "-v", "verbose:=false"]
+    args = get_launch_args(argv, separator="->")
+    assert len(args) == 2, "Failed custom separator"
+    assert "arg5" in args, "Did not find arg5"
+    assert "my_fancy_arg" in args, "Did not find my_fancy_arg"
+    assert "verbose" not in args, "Found verbose but should not have"
+    assert "HELLO" == args["arg5"], "arg5 has invalid value"
+    assert "/cmd_vel" == args["my_fancy_arg"], "my_fancy_arg has invalid value"
+
+    ## Test pair without key
+    argv = [":=my_value"]
+    args = get_launch_args(argv)
+    assert len(args) == 0, "Failed pair without key"
+
+    ## Test pair without value
+    argv = ["my_key:="]
+    args = get_launch_args(argv)
+    assert len(args) == 1, "Failed pair without value"
+    assert "my_key" in args, "Did not find my_key argument"
+    assert "" == args["my_key"], "my_key arg has incorrect value"
+
+    ## Test pair without key and value
+    argv = [":="]
+    args = get_launch_args(argv)
+    assert len(args) == 0, "Failed pair without key and value"
+
+
+if __name__ == '__main__':
+    test_launch_args()


### PR DESCRIPTION
Updated to support passing in command line arguments in the same format used by roslaunch (i.e., arg_name:=value). This supports zero or more arguments added after one or more launch files passed on the command line.

Updated usage:

    usage: launch [-h] launch_file [launch_file ...] [arg [arg ...]]
    
    Launch the processes specified in a launch file.
    
    positional arguments:
      launch_file  The launch file.
      arg          An argument to the launch file (e.g., arg_name:=value).
    
    optional arguments:
      -h, --help   show this help message and exit