### PR TITLE
suppress repeated SIGINTs in order to cleanly shutdown

### DIFF
--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -95,6 +95,8 @@ class DefaultLauncher(object):
                 ' '.join(self.task_descriptors[e.task_descriptor_index].cmd), file=sys.stderr)
             raise e.exception
         except KeyboardInterrupt:
+            # ignore further keyboard interrupts to cleanly shutdown
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
             self.interrupt_launch_non_threadsafe()
             loop.run_forever()
             returncode = 1


### PR DESCRIPTION
Fixes #56.

After the first `KeyboardInterrupt` has been catched suppress any further SIGINTs. This will ensure that all processes are cleaned up correctly. The user can still choose to `Ctrl+\` (rather than `Ctrl+C`).