### PR TITLE
Filter regex patterns in addition to prefixes

### DIFF
--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -78,7 +78,7 @@ class InMemoryHandler(LineOutput):
         for line in lines.splitlines():
             # Filter out stdout that comes from underlying DDS implementation
             # Note: we do not currently support matching filters across multiple stdout lines.
-            if any(re.fullmatch(pattern, line) for pattern in self.filtered_patterns):
+            if any(re.match(pattern, line) for pattern in self.filtered_patterns):
                 continue
             if any(line.startswith(prefix) for prefix in self.filtered_prefixes):
                 continue

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -50,10 +50,10 @@ class InMemoryHandler(LineOutput):
         self.filtered_patterns = filtered_patterns or get_default_filtered_patterns()
 
         if filtered_rmw_implementation:
-            self.filtered_patterns.extend(
-                get_rmw_output_filter(filtered_rmw_implementation, 'patterns'))
             self.filtered_prefixes.extend(
                 get_rmw_output_filter(filtered_rmw_implementation, 'prefixes'))
+            self.filtered_patterns.extend(
+                get_rmw_output_filter(filtered_rmw_implementation, 'patterns'))
 
         self.name = name
         self.launch_descriptor = launch_descriptor

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -123,7 +123,7 @@ def get_default_filtered_patterns():
 
 
 def get_rmw_output_filter(rmw_implementation, filter_type):
-    supported_filter_types = ['patterns', 'prefixes']
+    supported_filter_types = ['prefixes', 'patterns']
     if filter_type not in supported_filter_types:
         raise TypeError(
             'Unsupported filter_type "{0}". Supported types: {1}'

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -23,11 +23,13 @@ class InMemoryHandler(LineOutput):
         that will only need one line to match, instead of the entire output.
     :param regex_match: If true, treat the expected_lines as a regular expression in match
         accordingly.
+    :param filtered_prefixes: A list of byte strings representing prefixes that will cause output
+        lines to be ignored if they start with one of the prefixes. By default lines starting with
+        the process ID (`b'pid'`) and return code (`b'rc'`) will be ignored.
     :param filtered_patterns: A list of byte strings representing regexes that will cause output
-        lines to be ignored if they completely match one of the regexes. By default lines starting
-        with the process ID (`b'pid'`) and return code (`b'rc'`) will be ignored.
+        lines to be ignored if they completely match one of the regexes.
     :param filtered_rmw_implementation: RMW implementation for which the output will be ignored
-        in addition to the default/`filtered_patterns`.
+        in addition to the `filtered_prefixes`/`filtered_patterns`.
     :param exit_on_match: If True, then when its output is matched, this handler
         will terminate; otherwise it will simply keep track of the match.
     :raises: :py:class:`UnmatchedOutputError` if :py:meth:`check` does not find that the output
@@ -40,9 +42,14 @@ class InMemoryHandler(LineOutput):
 
     def __init__(
         self, name, launch_descriptor, expected_lines, regex_match=False,
-        filtered_patterns=None, filtered_rmw_implementation=None, exit_on_match=True
+        filtered_prefixes=None, filtered_patterns=None, filtered_rmw_implementation=None,
+        exit_on_match=True,
     ):
         super(LineOutput, self).__init__()
+        if filtered_prefixes is None:
+            self.filtered_prefixes = get_default_filtered_prefixes()
+        else:
+            self.filtered_prefixes = filtered_prefixes
         if filtered_patterns is None:
             self.filtered_patterns = get_default_filtered_patterns()
         else:
@@ -70,8 +77,10 @@ class InMemoryHandler(LineOutput):
 
         for line in lines.splitlines():
             # Filter out stdout that comes from underlying DDS implementation
-            # TODO (dhood): support matching filters across multiple stdout lines.
+            # Note: we do not currently support matching filters across multiple stdout lines.
             if any(re.fullmatch(pattern, line) for pattern in self.filtered_patterns):
+                continue
+            if any(line.startswith(prefix) for prefix in self.filtered_prefixes):
                 continue
             self.stdout_data.write(line + b'\n')
             if not self.regex_match and not self.matched:
@@ -107,10 +116,14 @@ class InMemoryHandler(LineOutput):
                 (output_lines, self.expected_lines))
 
 
-def get_default_filtered_patterns():
+def get_default_filtered_prefixes():
     return [
-        b'pid.*$', b'rc.*$',
+        b'pid', b'rc',
     ]
+
+
+def get_default_filtered_patterns():
+    return []
 
 
 def get_rmw_output_filter(rmw_implementation):
@@ -127,8 +140,8 @@ def get_rmw_output_filter(rmw_implementation):
 
 
 def create_handler(
-    name, launch_descriptor, output_file, exit_on_match=True, filtered_patterns=None,
-    filtered_rmw_implementation=None
+    name, launch_descriptor, output_file, exit_on_match=True, filtered_prefixes=None,
+    filtered_patterns=None, filtered_rmw_implementation=None
 ):
     literal_file = output_file + '.txt'
     if os.path.isfile(literal_file):
@@ -136,7 +149,8 @@ def create_handler(
             expected_output = f.read().splitlines()
         return InMemoryHandler(
             name, launch_descriptor, expected_output, regex_match=False,
-            exit_on_match=exit_on_match, filtered_patterns=filtered_patterns,
+            exit_on_match=exit_on_match,
+            filtered_prefixes=filtered_prefixes, filtered_patterns=filtered_patterns,
             filtered_rmw_implementation=filtered_rmw_implementation)
     regex_file = output_file + '.regex'
     if os.path.isfile(regex_file):
@@ -144,7 +158,8 @@ def create_handler(
             expected_output = f.read().splitlines()
         return InMemoryHandler(
             name, launch_descriptor, expected_output, regex_match=True,
-            exit_on_match=exit_on_match, filtered_patterns=filtered_patterns,
+            exit_on_match=exit_on_match,
+            filtered_prefixes=filtered_prefixes, filtered_patterns=filtered_patterns,
             filtered_rmw_implementation=filtered_rmw_implementation)
     py_file = output_file + '.py'
     if os.path.isfile(py_file):


### PR DESCRIPTION
this will allow us to filter out lines based on regexes instead of just prefixes. note that even if you specify a multiline regex it will only ever be matched against one line of console output at a time (this was also true how we were matching the prefixes before)

this was motivated by wanting to filter things like the fastrtps error message in 
http://ci.ros2.org/view/nightly/job/nightly_osx_repeated/772/testReport/(root)/projectroot/test_tutorial_add_two_ints_server_add_two_ints_client_async__rmw_fastrtps_cpp/
where prefix matching wouldn't be sufficient. Even though we probably don't want to filter that error message _in general_, I found this useful while investigating flaky tests. Using this I could run tests N times ignoring this error, preventing unrelated test failures from its output.

CI including relevant changes in dependencies (for which I'll open PRs if this change looks OK conceptually)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3049)](http://ci.ros2.org/job/ci_linux/3049/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=446)](http://ci.ros2.org/job/ci_linux-aarch64/446/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2451)](http://ci.ros2.org/job/ci_osx/2451/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3123)](http://ci.ros2.org/job/ci_windows/3123/)