### PR TITLE
Fix hang on keyboard interrupt

### DIFF
--- a/launch/launch/launcher.py
+++ b/launch/launch/launcher.py
@@ -219,6 +219,7 @@ class DefaultLauncher:
         if launch_state.returncode is None:
             launch_state.returncode = 0
         self.launch_complete.set()
+        self.loop.stop()
         return launch_state.returncode
 
     async def _terminate_processes(self, launch_state, all_futures):


### PR DESCRIPTION
Relates to #64

When keyboard interrupt exception occurs loop.run_forever is
called, but there is no loop.stop call. This causes a hang.

I don't have a windows machine to test on.