### PR TITLE
Use variable typing in comments to support python 3.5

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -21,7 +21,7 @@ import shlex
 import signal
 import threading
 import traceback
-from typing import Any
+from typing import Any  # noqa: F401
 from typing import cast
 from typing import Dict
 from typing import Iterable
@@ -52,7 +52,7 @@ from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
 from ..some_actions_type import SomeActionsType
 from ..some_substitutions_type import SomeSubstitutionsType
-from ..substitution import Substitution
+from ..substitution import Substitution  # noqa: F401
 from ..substitutions import LaunchConfiguration
 from ..substitutions import PythonExpression
 from ..utilities import create_future
@@ -156,7 +156,7 @@ class ExecuteProcess(Action):
         super().__init__()
         self.__cmd = [normalize_to_list_of_substitutions(x) for x in cmd]
         self.__cwd = cwd if cwd is None else normalize_to_list_of_substitutions(cwd)
-        self.__env: Optional[Dict[List[Substitution], List[Substitution]]] = None
+        self.__env = None  # type: Optional[Dict[List[Substitution], List[Substitution]]]
         if env is not None:
             self.__env = {}
             for key, value in env.items():
@@ -179,12 +179,12 @@ class ExecuteProcess(Action):
             )
         self.__log_cmd = log_cmd
 
-        self.__process_event_args: Optional[Dict[Text, Any]] = None
-        self._subprocess_protocol: Optional[Any] = None
+        self.__process_event_args = None  # type: Optional[Dict[Text, Any]]
+        self._subprocess_protocol = None  # type: Optional[Any]
         self._subprocess_transport = None
-        self.__completed_future: Optional[asyncio.Future] = None
-        self.__sigterm_timer: Optional[TimerAction] = None
-        self.__sigkill_timer: Optional[TimerAction] = None
+        self.__completed_future = None  # type: Optional[asyncio.Future]
+        self.__sigterm_timer = None  # type: Optional[TimerAction]
+        self.__sigkill_timer = None  # type: Optional[TimerAction]
         self.__shutdown_received = False
 
     @property

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -79,7 +79,7 @@ class ExecuteProcess(Action):
         sigkill_timeout: SomeSubstitutionsType = LaunchConfiguration('sigkill_timeout', default=5),
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Optional[Text] = None,
-        log_cmd: bool = False,
+        log_cmd: bool = False
     ) -> None:
         """
         Construct an ExecuteProcess action.

--- a/launch/launch/actions/opaque_function.py
+++ b/launch/launch/actions/opaque_function.py
@@ -49,7 +49,7 @@ class OpaqueFunction(Action):
         self, *,
         function: Callable,
         args: Optional[Iterable[Any]] = None,
-        kwargs: Optional[Dict[Text, Any]] = None,
+        kwargs: Optional[Dict[Text, Any]] = None
     ) -> None:
         """Constructor."""
         super().__init__()

--- a/launch/launch/actions/opaque_function.py
+++ b/launch/launch/actions/opaque_function.py
@@ -60,10 +60,10 @@ class OpaqueFunction(Action):
         ensure_argument_type(args, (collections.Iterable, type(None)), 'args', 'OpaqueFunction')
         ensure_argument_type(kwargs, (dict, type(None)), 'kwargs', 'OpaqueFunction')
         self.__function = function
-        self.__args: Iterable = []
+        self.__args = []  # type: Iterable
         if args is not None:
             self.__args = args
-        self.__kwargs: Dict[Text, Any] = {}
+        self.__kwargs = {}  # type: Dict[Text, Any]
         if kwargs is not None:
             self.__kwargs = kwargs
 

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -55,7 +55,7 @@ class TimerAction(Action):
     def __init__(
         self, *,
         period: Union[float, SomeSubstitutionsType],
-        actions: Iterable[LaunchDescriptionEntity],
+        actions: Iterable[LaunchDescriptionEntity]
     ) -> None:
         """Constructor."""
         super().__init__()

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -17,9 +17,9 @@
 import asyncio
 import collections
 import logging
-from typing import Any
+from typing import Any  # noqa: F401
 from typing import cast
-from typing import Dict
+from typing import Dict  # noqa: F401
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -67,10 +67,10 @@ class TimerAction(Action):
         else:
             self.__period = normalize_to_list_of_substitutions(period)
         self.__actions = actions
-        self.__context_locals: Dict[Text, Any] = {}
-        self.__completed_future: Optional[asyncio.Future] = None
+        self.__context_locals = {}  # type: Dict[Text, Any]
+        self.__completed_future = None  # type: Optional[asyncio.Future]
         self.__canceled = False
-        self.__canceled_future: Optional[asyncio.Future] = None
+        self.__canceled_future = None  # type: Optional[asyncio.Future]
 
     async def __wait_to_fire_event(self, context):
         done, pending = await asyncio.wait(

--- a/launch/launch/event_handler.py
+++ b/launch/launch/event_handler.py
@@ -39,7 +39,7 @@ class EventHandler:
         self,
         *,
         matcher: Callable[[Event], bool],
-        entities: Optional[SomeActionsType] = None,
+        entities: Optional[SomeActionsType] = None
     ) -> None:
         """
         Constructor.

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -83,7 +83,7 @@ class OnProcessExit(EventHandler):
         # TODO(wjwwood) check that it is not only callable, but also a callable that matches
         # the correct signature for a handler in this case
         self.__on_exit = on_exit
-        self.__actions_on_exit: List[LaunchDescriptionEntity] = []
+        self.__actions_on_exit = []  # type: List[LaunchDescriptionEntity]
         if callable(on_exit):
             # Then on_exit is a function or lambda, so we can just call it, but
             # we don't put anything in self.__actions_on_exit because we cannot

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -44,7 +44,7 @@ class OnProcessIO(EventHandler):
         target_action: Optional['ExecuteProcess'] = None,
         on_stdin: Callable[[ProcessIO], Optional[SomeActionsType]] = None,
         on_stdout: Callable[[ProcessIO], Optional[SomeActionsType]] = None,
-        on_stderr: Callable[[ProcessIO], Optional[SomeActionsType]] = None,
+        on_stderr: Callable[[ProcessIO], Optional[SomeActionsType]] = None
     ) -> None:
         """Constructor."""
         from ..actions import ExecuteProcess  # noqa

--- a/launch/launch/events/process/process_exited.py
+++ b/launch/launch/events/process/process_exited.py
@@ -27,7 +27,7 @@ class ProcessExited(RunningProcessEvent):
         *,
         returncode: int,
         **kwargs
-    ):
+    ) -> None:
         """
         Constructor.
 

--- a/launch/launch/events/process/process_stdout.py
+++ b/launch/launch/events/process/process_stdout.py
@@ -22,7 +22,7 @@ class ProcessStdout(ProcessIO):
 
     name = 'launch.events.process.ProcessStdout'
 
-    def __init__(self, *, text: bytes, **kwargs):
+    def __init__(self, *, text: bytes, **kwargs) -> None:
         """
         Constructor.
 

--- a/launch/launch/events/process/running_process_event.py
+++ b/launch/launch/events/process/running_process_event.py
@@ -39,7 +39,7 @@ class RunningProcessEvent(Event):
         cmd: List[Text],
         cwd: Optional[Text],
         env: Optional[Dict[Text, Text]],
-        pid: int,
+        pid: int
     ) -> None:
         """
         Constructor.

--- a/launch/launch/events/process/running_process_event.py
+++ b/launch/launch/events/process/running_process_event.py
@@ -89,6 +89,6 @@ class RunningProcessEvent(Event):
         return self.__env
 
     @property
-    def pid(self) -> Optional[Dict[Text, Text]]:
+    def pid(self) -> int:
         """Getter for pid."""
         return self.__pid

--- a/launch/launch/events/process/shutdown_process.py
+++ b/launch/launch/events/process/shutdown_process.py
@@ -36,6 +36,6 @@ class ShutdownProcess(ProcessTargetedEvent):
 
     name = 'launch.events.process.ShutdownProcess'
 
-    def __init__(self, *, process_matcher: Callable[['ExecuteProcess'], bool]):
+    def __init__(self, *, process_matcher: Callable[['ExecuteProcess'], bool]) -> None:
         """Constructor."""
         super().__init__(process_matcher=process_matcher)

--- a/launch/launch/events/process/shutdown_process.py
+++ b/launch/launch/events/process/shutdown_process.py
@@ -18,6 +18,10 @@ from typing import Callable
 
 from .process_targeted_event import ProcessTargetedEvent
 
+if False:
+    # imports here would cause loops, but are only used as forward-references for type-checking
+    from ...actions import ExecuteProcess  # noqa
+
 
 class ShutdownProcess(ProcessTargetedEvent):
     """

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -20,7 +20,7 @@ import logging
 from typing import Any
 from typing import Dict
 from typing import Iterable
-from typing import List
+from typing import List  # noqa: F401
 from typing import Optional
 from typing import Text
 
@@ -42,20 +42,20 @@ class LaunchContext:
         """
         self.__argv = argv if argv is not None else []
 
-        self._event_queue: asyncio.Queue = asyncio.Queue()
-        self._event_handlers: collections.deque = collections.deque()
-        self._completion_futures: List[asyncio.Future] = []
+        self._event_queue = asyncio.Queue()  # type: asyncio.Queue
+        self._event_handlers = collections.deque()  # type: collections.deque
+        self._completion_futures = []  # type: List[asyncio.Future]
 
-        self.__globals: Dict[Text, Any] = {}
-        self.__locals_stack: List[Dict[Text, Any]] = []
-        self.__locals: Dict[Text, Any] = {}
-        self.__combined_locals_cache: Optional[Dict[Text, Any]] = None
+        self.__globals = {}  # type: Dict[Text, Any]
+        self.__locals_stack = []  # type: List[Dict[Text, Any]]
+        self.__locals = {}  # type: Dict[Text, Any]
+        self.__combined_locals_cache = None  # type: Optional[Dict[Text, Any]]
 
-        self.__launch_configurations_stack: List[Dict[Text, Text]] = []
-        self.__launch_configurations: Dict[Text, Text] = {}
+        self.__launch_configurations_stack = []  # type: List[Dict[Text, Text]]
+        self.__launch_configurations = {}  # type: Dict[Text, Text]
 
         self.__is_shutdown = False
-        self.__asyncio_loop: Optional[asyncio.AbstractEventLoop] = None
+        self.__asyncio_loop = None  # type: Optional[asyncio.AbstractEventLoop]
 
     @property
     def argv(self):

--- a/launch/launch/launch_introspector.py
+++ b/launch/launch/launch_introspector.py
@@ -131,6 +131,7 @@ def format_action(action: Action) -> List[Text]:
         )
         return [msg]
     elif is_a(action, RegisterEventHandler):
+        # Different variable name used to assist with type checking.
         typed_action2 = cast(RegisterEventHandler, action)
         result = ["RegisterEventHandler('{}'):".format(typed_action2.event_handler)]
         result.extend(indent(format_event_handler(typed_action2.event_handler)))

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -19,11 +19,11 @@ import collections
 import logging
 import threading
 from typing import Iterable
-from typing import List
+from typing import List  # noqa: F401
 from typing import Optional
-from typing import Set
+from typing import Set  # noqa: F401
 from typing import Text
-from typing import Tuple
+from typing import Tuple  # noqa: F401
 
 import osrf_pycommon.process_utils
 
@@ -88,7 +88,8 @@ class LaunchService:
         self.__context.register_event_handler(OnShutdown(on_shutdown=self.__on_shutdown))
 
         # Setup storage for state.
-        self._entity_future_pairs: List[Tuple[LaunchDescriptionEntity, asyncio.Future]] = []
+        self._entity_future_pairs = \
+            []  # type: List[Tuple[LaunchDescriptionEntity, asyncio.Future]]
 
         # Used to prevent run() being called from multiple threads.
         self.__running_lock = threading.Lock()
@@ -202,7 +203,7 @@ class LaunchService:
                     entity_futures = [pair[1] for pair in self._entity_future_pairs]
                     entity_futures.append(process_one_event_task)
                     entity_futures.extend(self.__context._completion_futures)
-                    done: Set[asyncio.Future] = set()
+                    done = set()  # type: Set[asyncio.Future]
                     while not done:
                         done, pending = await asyncio.wait(
                             entity_futures,

--- a/launch/launch/substitutions/launch_configuration.py
+++ b/launch/launch/substitutions/launch_configuration.py
@@ -49,8 +49,8 @@ class LaunchConfiguration(Substitution):
             self.__default = default
         else:
             # convert any items in default that are not a Substitution or str to a str
-            str_normalized_default: List[Union[Text, Substitution]] = []
-            definitely_iterable_default: Iterable[Any]  # noqa
+            str_normalized_default = []  # type: List[Union[Text, Substitution]]
+            definitely_iterable_default = ((),)  # type: Iterable[Any]
             if isinstance(default, collections.Iterable):
                 definitely_iterable_default = default
             else:
@@ -61,8 +61,9 @@ class LaunchConfiguration(Substitution):
                 else:
                     str_normalized_default.append(str(item))
             # use normalize_to_list_of_substitutions to convert str to TextSubstitution's too
-            self.__default: List[Substitution] = \
-                normalize_to_list_of_substitutions(str_normalized_default)
+            self.__default = \
+                normalize_to_list_of_substitutions(
+                    str_normalized_default)  # type: List[Substitution]
 
     @property
     def variable_name(self) -> List[Substitution]:

--- a/launch/launch/substitutions/launch_configuration.py
+++ b/launch/launch/substitutions/launch_configuration.py
@@ -36,7 +36,7 @@ class LaunchConfiguration(Substitution):
         self,
         variable_name: SomeSubstitutionsType,
         *,
-        default: Optional[Union[Any, Iterable[Any]]] = None,
+        default: Optional[Union[Any, Iterable[Any]]] = None
     ) -> None:
         """Constructor."""
         super().__init__()

--- a/launch/launch/substitutions/text_substitution.py
+++ b/launch/launch/substitutions/text_substitution.py
@@ -23,7 +23,7 @@ from ..substitution import Substitution
 class TextSubstitution(Substitution):
     """Substitution that wraps a single string text."""
 
-    def __init__(self, *, text: Text):
+    def __init__(self, *, text: Text) -> None:
         """Constructor."""
         super().__init__()
 

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -15,11 +15,11 @@
 """Module for the Node action."""
 
 import logging
-from typing import Dict
+from typing import Dict  # noqa: F401
 from typing import Iterable
 from typing import List
 from typing import Optional
-from typing import Text
+from typing import Text  # noqa: F401
 from typing import Tuple
 
 from launch.action import Action
@@ -49,7 +49,7 @@ class Node(ExecuteProcess):
         node_namespace: Optional[SomeSubstitutionsType] = None,
         remappings: Optional[Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
-        **kwargs,
+        **kwargs
     ) -> None:
         """
         Construct an Node action.

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -115,8 +115,8 @@ class Node(ExecuteProcess):
 
         self.__expanded_node_name = '<node_name_unspecified>'
         self.__expanded_node_namespace = '/'
-        self.__final_node_name: Optional[Text] = None
-        self.__expanded_remappings: Optional[Dict[Text, Text]] = None
+        self.__final_node_name = None  # type: Optional[Text]
+        self.__expanded_remappings = None  # type: Optional[Dict[Text, Text]]
 
         self.__substitutions_performed = False
 
@@ -175,7 +175,7 @@ class Node(ExecuteProcess):
         self._perform_substitutions(context)
         # Prepare the ros_specific_arguments list and add it to the context so that the
         # LocalSubstitution placeholders added to the the cmd can be expanded using the contents.
-        ros_specific_arguments: List[Text] = []
+        ros_specific_arguments = []  # type: List[Text]
         if self.__node_name is not None:
             ros_specific_arguments.append('__node:={}'.format(self.__expanded_node_name))
         if self.__node_namespace is not None:

--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -18,9 +18,9 @@ import functools
 import logging
 import threading
 from typing import cast
-from typing import Dict
+from typing import Dict  # noqa: F401
 from typing import Text
-from typing import TextIO
+from typing import TextIO  # noqa: F401
 
 import launch
 import launch.actions

--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -29,7 +29,7 @@ import launch.events
 import rclpy
 
 _logger = logging.getLogger('launch_ros')
-_process_log_files: Dict[Text, TextIO] = {}
+_process_log_files = {}  # type: Dict[Text, TextIO]
 
 
 def _on_process_started(context: launch.LaunchContext):

--- a/launch_ros/launch_ros/event_handlers/on_state_transition.py
+++ b/launch_ros/launch_ros/event_handlers/on_state_transition.py
@@ -41,7 +41,7 @@ class OnStateTransition(EventHandler):
         transition: Optional[SomeSubstitutionsType] = None,
         start_state: Optional[SomeSubstitutionsType] = None,
         goal_state: Optional[SomeSubstitutionsType] = None,
-        matcher: Optional[Callable[[Event], bool]] = None,
+        matcher: Optional[Callable[[Event], bool]] = None
     ) -> None:
         """
         Constructor.

--- a/launch_ros/launch_ros/events/lifecycle/change_state.py
+++ b/launch_ros/launch_ros/events/lifecycle/change_state.py
@@ -60,7 +60,7 @@ class ChangeState(Event):
         self,
         *,
         lifecycle_node_matcher: Callable[['LifecycleNode'], bool],
-        transition_id: int,
+        transition_id: int
     ) -> None:
         """
         Constructor.

--- a/launch_ros/launch_ros/events/lifecycle/state_transition.py
+++ b/launch_ros/launch_ros/events/lifecycle/state_transition.py
@@ -34,7 +34,7 @@ class StateTransition(Event):
         self,
         *,
         action: 'LifecycleNode',
-        msg: lifecycle_msgs.msg.TransitionEvent,
+        msg: lifecycle_msgs.msg.TransitionEvent
     ) -> None:
         """
         Constructor.


### PR DESCRIPTION
Fixes https://github.com/ros2/launch/issues/78

This fixes the build on xenial.


@wjwwood there are a few lines that are too long (https://ci.ros2.org/job/ci_linux/4703/testReport/) but I haven't got mypy setup to check what wrapping will be supported. What invocation do you use? I get `Can't find package 'launch'`  when calling `python3 -m mypy --package launch`...
