### PR TITLE
improve error handling in ros2 launch command line tool

### DIFF
--- a/ros2launch/ros2launch/api/__init__.py
+++ b/ros2launch/ros2launch/api/__init__.py
@@ -15,6 +15,7 @@
 """Python package for the ros2 launch api."""
 
 from .api import get_share_file_path_from_package
+from .api import InvalidPythonLaunchFileError
 from .api import launch_a_python_launch_file
 from .api import LaunchFileNameCompleter
 from .api import MultipleLaunchFilesError
@@ -22,6 +23,7 @@ from .api import print_a_python_launch_file
 
 __all__ = [
     'get_share_file_path_from_package',
+    'InvalidPythonLaunchFileError',
     'LaunchFileNameCompleter',
     'launch_a_python_launch_file',
     'MultipleLaunchFilesError',

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -14,10 +14,12 @@
 
 from argparse import REMAINDER
 import os
+import sys
 
 from ament_index_python.packages import PackageNotFoundError
 from ros2cli.command import CommandExtension
 from ros2launch.api import get_share_file_path_from_package
+from ros2launch.api import InvalidPythonLaunchFileError
 from ros2launch.api import launch_a_python_launch_file
 from ros2launch.api import LaunchFileNameCompleter
 from ros2launch.api import MultipleLaunchFilesError
@@ -69,11 +71,29 @@ class LaunchCommand(CommandExtension):
                     "Package '{}' not found: {}".format(args.package_name, exc))
             except (FileNotFoundError, MultipleLaunchFilesError) as exc:
                 raise RuntimeError(str(exc))
-        if args.print:
-            return print_a_python_launch_file(python_launch_file_path=path)
-        else:
-            return launch_a_python_launch_file(
-                python_launch_file_path=path,
-                launch_file_arguments=args.argv,
-                debug=args.debug
-            )
+        try:
+            if args.print:
+                return print_a_python_launch_file(python_launch_file_path=path)
+            else:
+                return launch_a_python_launch_file(
+                    python_launch_file_path=path,
+                    launch_file_arguments=args.argv,
+                    debug=args.debug
+                )
+        except SyntaxError as exc:
+            print("""
+Notice: SyntaxError (or related errors) can occur if your launch file ('{}') is not a Python file.
+""".format(path), file=sys.stderr)
+            raise  # raise so the user can see the traceback in useful SyntaxError's
+        except ValueError as exc:
+            print("""
+Notice: ValueError can occur if your launch file ('{}') is a binary file and not a Python file.
+""".format(path), file=sys.stderr)
+            raise RuntimeError('ValueError: {}'.format(str(exc)))
+        except InvalidPythonLaunchFileError as exc:
+            # TODO(wjwwood): refactor this after we deprecate and then remove the old launch
+            print("""
+Notice: Your launch file may have been designed to be used with an older version of ROS 2.
+Or that the file you specified is Python code, but not a launch file.
+""", file=sys.stderr)
+            raise RuntimeError('InvalidPythonLaunchFileError: {}'.format(str(exc)))

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -80,7 +80,7 @@ class LaunchCommand(CommandExtension):
                     launch_file_arguments=args.argv,
                     debug=args.debug
                 )
-        except SyntaxError as exc:
+        except SyntaxError:
             print("""
 Notice: SyntaxError (or related errors) can occur if your launch file ('{}') is not a Python file.
 """.format(path), file=sys.stderr)


### PR DESCRIPTION
This pull request improves the error messages when you give `ros2 launch` things that aren't up-to-date launch files.

Some examples:

- An old launch file:

```
$ ros2 launch dummy_robot_bringup dummy_robot_bringup.py

Notice: Your launch file may have been designed to be used with an older version of ROS 2.
Or that the file you specified is Python code, but not a launch file.

InvalidPythonLaunchFileError: launch file at '/Users/william/ros2_ws/install/dummy_robot_bringup/share/dummy_robot_bringup/launch/dummy_robot_bringup.py' does not contain the required function 'generate_launch_description()'
```

- A python script (not new or old launch):

```
$ ros2 launch /Users/william/ros2_ws/install/demo_nodes_py/lib/demo_nodes_py/talker

Notice: Your launch file may have been designed to be used with an older version of ROS 2.
Or that the file you specified is Python code, but not a launch file.

InvalidPythonLaunchFileError: launch file at '/Users/william/ros2_ws/install/demo_nodes_py/lib/demo_nodes_py/talker' does not contain the required function 'generate_launch_description()'
```

- A binary file (executable):

```
$ ros2 launch /Users/william/ros2_ws/install/demo_nodes_cpp/lib/demo_nodes_cpp/talker

Notice: ValueError can occur if your launch file ('/Users/william/ros2_ws/install/demo_nodes_cpp/lib/demo_nodes_cpp/talker') is a binary file and not a Python file.

ValueError: source code string cannot contain null bytes
```

- A random file:

```
$ ros2 launch /Users/william/ros2_ws/install/dummy_robot_bringup/share/dummy_robot_bringup/launch/single_rrbot.urdf

Notice: SyntaxError can occur if your launch file ('/Users/william/ros2_ws/install/dummy_robot_bringup/share/dummy_robot_bringup/launch/single_rrbot.urdf') is not a Python file.

Traceback (most recent call last):
  File "/Users/william/ros2_ws/install/ros2cli/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli', 'console_scripts', 'ros2')()
  File "/Users/william/ros2_ws/build/ros2cli/ros2cli/cli.py", line 69, in main
    rc = extension.main(parser=parser, args=args)
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/command/launch.py", line 81, in main
    debug=args.debug
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/api/api.py", line 123, in launch_a_python_launch_file
    launch_description = get_launch_description_from_python_launch_file(python_launch_file_path)
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/api/api.py", line 106, in get_launch_description_from_python_launch_file
    launch_file_module = load_python_launch_file_as_module(python_launch_file_path)
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/api/api.py", line 84, in load_python_launch_file_as_module
    return loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 399, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 823, in load_module
  File "<frozen importlib._bootstrap_external>", line 682, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/william/ros2_ws/install/dummy_robot_bringup/share/dummy_robot_bringup/launch/single_rrbot.urdf", line 1
    <?xml version="1.0" ?>
    ^
SyntaxError: invalid syntax
```

or 

```
$ ros2 launch LICENSE

Notice: SyntaxError can occur if your launch file ('LICENSE') is not a Python file.

Traceback (most recent call last):
  File "/Users/william/ros2_ws/install/ros2cli/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli', 'console_scripts', 'ros2')()
  File "/Users/william/ros2_ws/build/ros2cli/ros2cli/cli.py", line 69, in main
    rc = extension.main(parser=parser, args=args)
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/command/launch.py", line 81, in main
    debug=args.debug
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/api/api.py", line 123, in launch_a_python_launch_file
    launch_description = get_launch_description_from_python_launch_file(python_launch_file_path)
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/api/api.py", line 106, in get_launch_description_from_python_launch_file
    launch_file_module = load_python_launch_file_as_module(python_launch_file_path)
  File "/Users/william/ros2_ws/build/ros2launch/ros2launch/api/api.py", line 84, in load_python_launch_file_as_module
    return loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 399, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 823, in load_module
  File "<frozen importlib._bootstrap_external>", line 682, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "LICENSE", line 2
    Apache License
    ^
IndentationError: unexpected indent
```