### PR TITLE
avoid SIGINT on Windows

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -17,6 +17,7 @@
 import asyncio
 import logging
 import os
+import platform
 import shlex
 import signal
 import threading
@@ -240,6 +241,14 @@ class ExecuteProcess(Action):
                 typed_event.signal_name, self.process_details['name']
             ))
             return None
+        if platform.system() == 'Windows' and typed_event.signal_name == 'SIGINT':
+            # TODO(wjwwood): remove this when/if SIGINT is fixed on Windows
+            _logger.warn(
+                "'SIGINT' sent to process[{}] not supported on Windows, escalating to 'SIGTERM'"
+                .format(self.process_details['name']))
+            typed_event = SignalProcess(
+                signal_number=signal.SIGTERM,
+                process_matcher=lambda process: True)
         _logger.info("sending signal '{}' to process[{}]".format(
             typed_event.signal_name, self.process_details['name']
         ))


### PR DESCRIPTION
This is required to avoid a (non-fatal, but annoying) traceback on Windows when launch tries to send SIGINT to it's children.

This patch automatically escalates to SIGTERM (which does work), which is what the old launch did, and is also what eventually happens with launch now, but only after waiting five seconds. This removes the wait as well.

Eventually this might be fixed with some combination of `creationflags` and `signal.CTRL_C_EVENT`, but that's an ongoing issue with subprocess on Windows.