### PR TITLE
Fix exception when launch process with environment variables

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -159,10 +159,11 @@ class ExecuteProcess(Action):
         self.__cwd = cwd if cwd is None else normalize_to_list_of_substitutions(cwd)
         self.__env = None  # type: Optional[Dict[List[Substitution], List[Substitution]]]
         if env is not None:
-            self.__env = {}
+            self.__env = []
             for key, value in env.items():
-                self.__env[normalize_to_list_of_substitutions(key)] = \
-                    normalize_to_list_of_substitutions(value)
+                self.__env.append((
+                    normalize_to_list_of_substitutions(key),
+                    normalize_to_list_of_substitutions(value)))
         self.__shell = shell
         self.__sigterm_timeout = normalize_to_list_of_substitutions(sigterm_timeout)
         self.__sigkill_timeout = normalize_to_list_of_substitutions(sigkill_timeout)
@@ -372,7 +373,7 @@ class ExecuteProcess(Action):
         env = None
         if self.__env is not None:
             env = {}
-            for key, value in self.__env.items():
+            for key, value in self.__env:
                 env[''.join([context.perform_substitution(x) for x in key])] = \
                     ''.join([context.perform_substitution(x) for x in value])
 

--- a/launch/test/launch/env_echo.py
+++ b/launch/test/launch/env_echo.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+
+def print_env(var_list):
+    for var in var_list:
+        value = os.getenv(var)
+        if value is None:
+            raise EnvironmentError('No such env ' + var)
+        print(var, value)
+
+
+if __name__ == '__main__':
+    print_env(sys.argv[1:])

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ExecuteProcess Action."""
+
+import sys
+
+from launch import LaunchDescription
+from launch import LaunchService
+from launch.actions.execute_process import ExecuteProcess
+
+
+def test_execute_process_with_env():
+    """Test launching a process with an environment variable."""
+    ld = LaunchDescription([
+        ExecuteProcess(
+            cmd=[sys.executable, 'TEST_PROCESS_WITH_ENV'], output='screen',
+            env={'TEST_PROCESS_WITH_ENV': 'Hello World'},
+        )
+    ])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()


### PR DESCRIPTION
Launching a process with an environment variable using ros2-bouncy raises an exception.

```
  File "/opt/ros/bouncy/lib/python3.6/site-packages/launch/actions/execute_process.py", line 165, in __init__
    normalize_to_list_of_substitutions(value)
TypeError: unhashable type: 'list'
```

`ExecuteProcess` tries to store a list of substitutions as a dictionary key. This PR adds a test and changes `__env` to be a list of 2-tuple instead.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4847)](http://ci.ros2.org/job/ci_linux/4847/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1700)](http://ci.ros2.org/job/ci_linux-aarch64/1700/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4025)](http://ci.ros2.org/job/ci_osx/4025/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4891)](http://ci.ros2.org/job/ci_windows/4891/)
