### PR TITLE
avoid race in emitting event by using loop.call_soon_threadsafe()

### DIFF
--- a/launch_ros/examples/lifecycle_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_pub_sub_launch.py
@@ -93,7 +93,7 @@ def main(argv=sys.argv[1:]):
     print('Starting launch of launch description...')
     print('')
 
-    # ls = LaunchService(argv=argv, debug=True)
+    # ls = launch.LaunchService(argv=argv, debug=True)
     ls = launch.LaunchService(argv=argv)
     ls.include_launch_description(get_default_launch_description(prefix_output_with_name=False))
     ls.include_launch_description(ld)

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -70,9 +70,10 @@ class LifecycleNode(Node):
         try:
             event = StateTransition(action=self, msg=msg)
             self.__current_state = ChangeState.valid_states[msg.goal_state.id]
-            context.emit_event_sync(event)
+            context.asyncio_loop.call_soon_threadsafe(lambda: context.emit_event_sync(event))
         except Exception as exc:
-            print("Exception in handling of 'lifecycle.msg.TransitionEvent': {}".format(exc))
+            _logger.error(
+                "Exception in handling of 'lifecycle.msg.TransitionEvent': {}".format(exc))
 
     def _call_change_state(self, request, context: launch.LaunchContext):
         while not self.__rclpy_change_state_client.wait_for_service(timeout_sec=1.0):


### PR DESCRIPTION
This could result in an error like this:

```
[DEBUG] [launch]: emitting event synchronously: 'launch.events.IncludeLaunchDescription'
[DEBUG] [launch]: emitting event synchronously: 'launch.events.IncludeLaunchDescription'
[DEBUG] [launch.LaunchService]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x101fadd30>'
[DEBUG] [launch.LaunchService]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x101fadd30>' ✓ '<launch.event_handlers.on_include_launch_description.OnIncludeLaunchDescription object at 0x101fad978>'
[DEBUG] [launch.LaunchService]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x101fadd68>'
[DEBUG] [launch.LaunchService]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x101fadd68>' ✓ '<launch.event_handlers.on_include_launch_description.OnIncludeLaunchDescription object at 0x101fad978>'
[INFO] [launch]: process[lifecycle_talker-1]: started with pid [69139]
[INFO] [asyncio]: %s: %r
[DEBUG] [launch]: emitting event: 'launch.events.process.ProcessStarted'
[DEBUG] [launch.LaunchService]: processing event: '<launch.events.process.process_started.ProcessStarted object at 0x1021a6588>'
[DEBUG] [launch.LaunchService]: processing event: '<launch.events.process.process_started.ProcessStarted object at 0x1021a6588>' ✓ '<launch.event_handler.EventHandler object at 0x101fadb38>'
[DEBUG] [launch]: emitting event synchronously: 'launch_ros.events.lifecycle.StateTransition'
Exception in handling of 'lifecycle.msg.TransitionEvent': Non-thread-safe operation invoked on an event loop other than the current one
[DEBUG] [launch]: emitting event synchronously: 'launch_ros.events.lifecycle.StateTransition'
^C[WARNING] [launch.LaunchService]: user interrupted with ctrl-c (SIGINT)
```

If a data race failed, which was more common if the lifecycle node (in this case `talker` from the package `lifecycle`) did not print anything to stdout.