### PR TITLE
add ability to define and pass launch arguments to launch files

### DIFF
--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -44,6 +44,11 @@ class Action(LaunchDescriptionEntity):
         """
         self.__condition = condition
 
+    @property
+    def condition(self) -> Optional[Condition]:
+        """Getter for condition."""
+        return self.__condition
+
     def describe(self) -> Text:
         """Return a description of this Action."""
         return self.__repr__()

--- a/launch/launch/actions/__init__.py
+++ b/launch/launch/actions/__init__.py
@@ -14,6 +14,7 @@
 
 """actions Module."""
 
+from .declare_launch_argument import DeclareLaunchArgument
 from .emit_event import EmitEvent
 from .execute_process import ExecuteProcess
 from .include_launch_description import IncludeLaunchDescription
@@ -24,6 +25,7 @@ from .set_launch_configuration import SetLaunchConfiguration
 from .timer_action import TimerAction
 
 __all__ = [
+    'DeclareLaunchArgument',
     'EmitEvent',
     'ExecuteProcess',
     'IncludeLaunchDescription',

--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -1,0 +1,124 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the DeclareLaunchArgument action."""
+
+import logging
+from typing import List
+from typing import Optional
+from typing import Text
+
+from ..action import Action
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+from ..utilities import normalize_to_list_of_substitutions
+from ..utilities import perform_substitutions
+
+_logger = logging.getLogger('launch.actions.DeclareLaunchArgument')
+
+
+class DeclareLaunchArgument(Action):
+    """
+    Action that declares a new launch argument.
+
+    A launch arguments are stored in a "launch configuration" of the same name.
+    See :py:class:`launch.actions.SetLaunchConfiguration` and
+    :py:class:`launch.substitutions.LaunchConfiguration`.
+
+    Any launch arguments declared within a :py:class:`launch.LaunchDescription`
+    will be exposed as arguments when that launch description is included, e.g.
+    as additional parameters in the
+    :py:class:`launch.actions.IncludeLaunchDescription` action or as
+    command-line arguments when launch with ``ros2 launch ...``.
+
+    In addition to the name, which is also where the argument result is stored,
+    launch arguments may have a default value and a description.
+    If a default value is given, then the argument becomes optional and the
+    default value is placed in the launch configuration instead.
+    If no default value is given and no value is given when including the
+    launch description, then an error occurs.
+
+    The default value may use Substitutions, but the name and description can
+    only be Text, since they need a meaningful value before launching, e.g.
+    when listing the command-line arguments.
+
+    Note that declaring a launch argument needs to be in a part of the launch
+    description that is describable without launching.
+    For example, if you declare a launch argument with this action from within
+    a condition group or as a callback to an event handler, then it may not be
+    possible for a tool like ``ros2 launch`` to know about the argument before
+    launching the launch description.
+    In such cases, the argument will not be visible on the command line but
+    may raise an exception if that argument is not satisfied once visited (and
+    has no default value).
+
+    Put another way, the post-condition of this action being visited is either
+    that a launch configuration of the same name is set with a value or an
+    exception is raised because none is set and there is no default value.
+    However, the pre-condition does not guarantee that the argument was visible
+    if behind condition or situational inclusions.
+    """
+
+    def __init__(
+        self,
+        name: Text,
+        *,
+        default_value: Optional[SomeSubstitutionsType] = None,
+        description: Text = 'no description given',
+        **kwargs
+    ) -> None:
+        """Constructor."""
+        super().__init__(**kwargs)
+        self.__name = name
+        if default_value is None:
+            self.__default_value = default_value
+        else:
+            self.__default_value = normalize_to_list_of_substitutions(default_value)
+        self.__description = description
+
+        # This is used later to determine if this launch argument will be
+        # conditionally visited.
+        # Its value will be read and set at different times and so the value
+        # may change depending at different times based on the context.
+        self._conditionally_included = False
+
+    @property
+    def name(self) -> Text:
+        """Getter for self.__name."""
+        return self.__name
+
+    @property
+    def default_value(self) -> Optional[List[Substitution]]:
+        """Getter for self.__default_value."""
+        return self.__default_value
+
+    @property
+    def description(self) -> Text:
+        """Getter for self.__description."""
+        return self.__description
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        if self.name not in context.launch_configurations:
+            if self.default_value is None:
+                # Argument not already set and no default value given, error.
+                _logger.error(
+                    "Required launch argument '{}' (description: '{}') was not provided"
+                    .format(self.name, self.description)
+                )
+                raise RuntimeError(
+                    "Required launch argument '{}' was not provided.".format(self.name))
+            context.launch_configurations[self.name] = \
+                perform_substitutions(context, self.default_value)

--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -41,7 +41,7 @@ class DeclareLaunchArgument(Action):
     will be exposed as arguments when that launch description is included, e.g.
     as additional parameters in the
     :py:class:`launch.actions.IncludeLaunchDescription` action or as
-    command-line arguments when launch with ``ros2 launch ...``.
+    command-line arguments when launched with ``ros2 launch ...``.
 
     In addition to the name, which is also where the argument result is stored,
     launch arguments may have a default value and a description.

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -82,9 +82,7 @@ class IncludeLaunchDescription(Action):
         else:
             return self.__launch_arguments
 
-    def visit(self, context: LaunchContext) -> List[LaunchDescriptionEntity]:
-        """Override visit to return an Entity rather than an action."""
-        launch_description = self.__launch_description_source.get_launch_description(context)
+    def _get_launch_file_location(self):
         launch_file_location = os.path.abspath(self.__launch_description_source.location)
         if os.path.exists(launch_file_location):
             launch_file_location = os.path.dirname(launch_file_location)
@@ -92,8 +90,13 @@ class IncludeLaunchDescription(Action):
             # If the location does not exist, then it's likely set to '<script>' or something
             # so just pass it along.
             launch_file_location = self.__launch_description_source.location
+        return launch_file_location
+
+    def visit(self, context: LaunchContext) -> List[LaunchDescriptionEntity]:
+        """Override visit to return an Entity rather than an action."""
+        launch_description = self.__launch_description_source.get_launch_description(context)
         context.extend_locals({
-            'current_launch_file_directory': launch_file_location,
+            'current_launch_file_directory': self._get_launch_file_location(),
         })
 
         # Do best effort checking to see if non-optional, non-default declared arguments

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -15,26 +15,74 @@
 """Module for the IncludeLaunchDescription action."""
 
 import os
+from typing import Iterable
 from typing import List
+from typing import Optional
+from typing import Tuple
 
+from .pop_launch_configurations import PopLaunchConfigurations
+from .push_launch_configurations import PushLaunchConfigurations
+from .set_launch_configuration import SetLaunchConfiguration
 from ..action import Action
 from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
 from ..launch_description_source import LaunchDescriptionSource
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..utilities import normalize_to_list_of_substitutions
+from ..utilities import perform_substitutions
 
 
 class IncludeLaunchDescription(Action):
-    """Action that includes a launch description source and yields its entities when visited."""
+    """
+    Action that includes a launch description source and yields its entities when visited.
 
-    def __init__(self, launch_description_source: LaunchDescriptionSource) -> None:
+    It is possible to pass arguments to the launch description, which it
+    declared with the :py:class:`launch.actions.DeclareLaunchArgument` action.
+
+    If any given arguments do not match the name of any declared launch
+    arguments, then they will still be set as Launch Configurations using the
+    :py:class:`launch.actions.SetLaunchConfiguration` action.
+    This is done because it's not always possible to detect all instances of
+    the declare launch argument class in the given launch description.
+
+    On the other side, an error will sometimes be raised if the given launch
+    description declares a launch argument and its value is not provided to
+    this action.
+    It will only produce this error, however, if the declared launch argument
+    is unconditional (sometimes the action that declares the launch argument
+    will only be visited in certain circumstances) and if it does not have a
+    default value on which to fall back.
+
+    Conditionally included launch arguments that do not have a default value
+    will eventually raise an error if this best effort argument checking is
+    unable to see an unsatisfied argument ahead of time.
+    """
+
+    def __init__(
+        self,
+        launch_description_source: LaunchDescriptionSource,
+        *,
+        launch_arguments: Optional[
+            Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]
+        ] = None,
+    ) -> None:
         """Constructor."""
         super().__init__()
         self.__launch_description_source = launch_description_source
+        self.__launch_arguments = launch_arguments
 
     @property
     def launch_description_source(self) -> LaunchDescriptionSource:
         """Getter for self.__launch_description_source."""
         return self.__launch_description_source
+
+    @property
+    def launch_arguments(self) -> Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]:
+        """Getter for self.__launch_arguments."""
+        if self.__launch_arguments is None:
+            return []
+        else:
+            return self.__launch_arguments
 
     def visit(self, context: LaunchContext) -> List[LaunchDescriptionEntity]:
         """Override visit to return an Entity rather than an action."""
@@ -49,4 +97,33 @@ class IncludeLaunchDescription(Action):
         context.extend_locals({
             'current_launch_file_directory': launch_file_location,
         })
-        return [launch_description]
+
+        # Do best effort checking to see if non-optional, non-default declared arguments
+        # are being satisfied.
+        argument_names = [
+            perform_substitutions(context, normalize_to_list_of_substitutions(arg_name))
+            for arg_name, arg_value in self.launch_arguments
+        ]
+        declared_launch_arguments = launch_description.get_launch_arguments()
+        for argument in declared_launch_arguments:
+            if argument._conditionally_included or argument.default_value is not None:
+                continue
+            if argument.name not in argument_names:
+                raise RuntimeError(
+                    "Included launch description missing required argument '{}' "
+                    "(description: '{}'), given: [{}]"
+                    .format(argument.name, argument.description, ', '.join(argument_names))
+                )
+
+        # Create actions to set the launch arguments into the launch configurations.
+        set_launch_configuration_actions = []
+        for name, value in self.launch_arguments:
+            set_launch_configuration_actions.append(SetLaunchConfiguration(name, value))
+
+        # Push configs, set arguments as configs, include launch description, pop configs.
+        return [
+            PushLaunchConfigurations(),
+            *set_launch_configuration_actions,
+            launch_description,
+            PopLaunchConfigurations()
+        ]

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -64,7 +64,7 @@ class IncludeLaunchDescription(Action):
         *,
         launch_arguments: Optional[
             Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]
-        ] = None,
+        ] = None
     ) -> None:
         """Constructor."""
         super().__init__()

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -20,8 +20,6 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from .pop_launch_configurations import PopLaunchConfigurations
-from .push_launch_configurations import PushLaunchConfigurations
 from .set_launch_configuration import SetLaunchConfiguration
 from ..action import Action
 from ..launch_context import LaunchContext
@@ -120,10 +118,5 @@ class IncludeLaunchDescription(Action):
         for name, value in self.launch_arguments:
             set_launch_configuration_actions.append(SetLaunchConfiguration(name, value))
 
-        # Push configs, set arguments as configs, include launch description, pop configs.
-        return [
-            PushLaunchConfigurations(),
-            *set_launch_configuration_actions,
-            launch_description,
-            PopLaunchConfigurations()
-        ]
+        # Set launch arguments as launch configurations and then include the launch description.
+        return [*set_launch_configuration_actions, launch_description]

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -92,6 +92,11 @@ class IncludeLaunchDescription(Action):
             launch_file_location = self.__launch_description_source.location
         return launch_file_location
 
+    def describe_sub_entities(self) -> List[LaunchDescriptionEntity]:
+        """Override describe_sub_entities from LaunchDescriptionEntity to return sub entities."""
+        ret = self.__launch_description_source.try_get_launch_description_without_context()
+        return [ret] if ret is not None else []
+
     def visit(self, context: LaunchContext) -> List[LaunchDescriptionEntity]:
         """Override visit to return an Entity rather than an action."""
         launch_description = self.__launch_description_source.get_launch_description(context)

--- a/launch/launch/launch_description_source.py
+++ b/launch/launch/launch_description_source.py
@@ -44,6 +44,15 @@ class LaunchDescriptionSource:
         self.__location = location
         self.__method = method
 
+    def try_get_launch_description_without_context(self) -> Optional[LaunchDescription]:
+        """
+        Attempt to load the LaunchDescription without a context, return None if unsuccessful.
+
+        This method is useful for trying to introspect the included launch
+        description without visiting the user of this source.
+        """
+        return self.__launch_description
+
     def get_launch_description(self, context: LaunchContext) -> LaunchDescription:
         """Get the LaunchDescription, loading it if necessary."""
         if self.__launch_description is None:

--- a/launch/launch/launch_introspector.py
+++ b/launch/launch/launch_introspector.py
@@ -28,9 +28,6 @@ from .event_handler import EventHandler
 from .launch_description import LaunchDescription
 from .launch_description_entity import LaunchDescriptionEntity
 from .some_substitutions_type import SomeSubstitutionsType
-from .substitutions import EnvironmentVariable
-from .substitutions import FindExecutable
-from .substitutions import TextSubstitution
 from .utilities import is_a
 from .utilities import normalize_to_list_of_substitutions
 

--- a/launch/launch/launch_introspector.py
+++ b/launch/launch/launch_introspector.py
@@ -83,20 +83,7 @@ def format_entities(entities: List[LaunchDescriptionEntity]) -> List[Text]:
 def format_substitutions(substitutions: SomeSubstitutionsType) -> Text:
     """Return a text representation of some set of substitutions."""
     normalized_substitutions = normalize_to_list_of_substitutions(substitutions)
-    result = ''
-    for sub in normalized_substitutions:
-        result += ' + '
-        if is_a(sub, TextSubstitution):
-            result += "'{}'".format(cast(TextSubstitution, sub).text)
-        elif is_a(sub, EnvironmentVariable):
-            result += 'EnvVarSub({})'.format(
-                format_substitutions(cast(EnvironmentVariable, sub).name))
-        elif is_a(sub, FindExecutable):
-            result += 'FindExecSub({})'.format(
-                format_substitutions(cast(FindExecutable, sub).name))
-        else:
-            result += "Substitution('{}')".format(sub)
-    return result[3:]
+    return ' + '.join([sub.describe() for sub in normalized_substitutions])
 
 
 def format_event_handler(event_handler: EventHandler) -> List[Text]:
@@ -126,7 +113,7 @@ def format_action(action: Action) -> List[Text]:
             ),
             typed_action.env if typed_action.env is None else '{' + ', '.join(
                 ['{}: {}'.format(format_substitutions(k), format_substitutions(v))
-                 for k, v in typed_action.env.items()] + '}'),
+                 for k, v in typed_action.env.items()]) + '}',
             typed_action.shell,
         )
         return [msg]

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -344,8 +344,8 @@ class LaunchService:
                     _logger.error('asyncio run loop was canceled')
                 except Exception as exc:
                     msg = 'Caught exception in launch (see debug for traceback): {}'.format(exc)
+                    _logger.error(traceback.format_exc())
                     _logger.error(msg)
-                    _logger.debug(traceback.format_exc())
                     self._shutdown(reason=msg, due_to_sigint=False)
         finally:
             # No matter what happens, unset the loop and set running to false.

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -235,7 +235,7 @@ class LaunchService:
             else:
                 await process_one_event_task
 
-    def run(self, *, shutdown_when_idle=True) -> None:
+    def run(self, *, shutdown_when_idle=True) -> int:
         """
         Start the event loop and visit all entities of all included LaunchDescriptions.
 

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -347,6 +347,8 @@ class LaunchService:
                     _logger.error(traceback.format_exc())
                     _logger.error(msg)
                     self._shutdown(reason=msg, due_to_sigint=False)
+                    # restart run loop to let it shutdown properly
+                    run_loop_task = self.__loop_from_run_thread.create_task(self.__run_loop())
         finally:
             # No matter what happens, unset the loop and set running to false.
             with self.__loop_from_run_thread_lock:

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -344,7 +344,7 @@ class LaunchService:
                     _logger.error('asyncio run loop was canceled')
                 except Exception as exc:
                     msg = 'Caught exception in launch (see debug for traceback): {}'.format(exc)
-                    _logger.error(traceback.format_exc())
+                    _logger.debug(traceback.format_exc())
                     _logger.error(msg)
                     self._shutdown(reason=msg, due_to_sigint=False)
                     # restart run loop to let it shutdown properly

--- a/launch/launch/substitution.py
+++ b/launch/launch/substitution.py
@@ -24,6 +24,15 @@ if False:
 class Substitution:
     """Encapsulates a substitution to be performed at runtime."""
 
+    def describe(self) -> Text:
+        """
+        Return a description of this substitution as a string.
+
+        When inherited from, calling this base class's default method is not
+        required.
+        """
+        return repr(self)
+
     # Note: LaunchContext is in a string here to break a circular import.
     def perform(self, context: 'LaunchContext') -> Text:
         """

--- a/launch/launch/substitutions/environment_variable.py
+++ b/launch/launch/substitutions/environment_variable.py
@@ -16,11 +16,10 @@
 
 import os
 from typing import List
-from typing import overload
 from typing import Text
-from typing import Union
 
 from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 
 
@@ -31,17 +30,7 @@ class EnvironmentVariable(Substitution):
     If the environment variable is not found, it returns empty string.
     """
 
-    @overload
-    def __init__(self, *, name: Text) -> None:
-        """Construct with just Text (unicode string)."""
-        ...
-
-    @overload  # noqa: F811
-    def __init__(self, *, name: List[Union[Text, Substitution]]) -> None:
-        """Construct with list of Text and Substitutions."""
-        ...
-
-    def __init__(self, *, name):  # noqa: F811
+    def __init__(self, name: SomeSubstitutionsType) -> None:
         """Constructor."""
         super().__init__()
 
@@ -52,6 +41,10 @@ class EnvironmentVariable(Substitution):
     def name(self) -> List[Substitution]:
         """Getter for name."""
         return self.__name
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return 'EnvVar({})'.format(' + '.join([sub.describe() for sub in self.name]))
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by looking up the environment variable."""

--- a/launch/launch/substitutions/find_executable.py
+++ b/launch/launch/substitutions/find_executable.py
@@ -15,14 +15,13 @@
 """Module for the FindExecutable substitution."""
 
 from typing import List
-from typing import overload
 from typing import Text
-from typing import Union
 
 from osrf_pycommon.process_utils import which
 
 from .substitution_failure import SubstitutionFailure
 from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 
 
@@ -33,17 +32,7 @@ class FindExecutable(Substitution):
     :raise: SubstitutionFailure when executable not found
     """
 
-    @overload
-    def __init__(self, *, name: Text) -> None:
-        """Construct with just Text (unicode string)."""
-        ...
-
-    @overload  # noqa: F811
-    def __init__(self, *, name: List[Union[Text, Substitution]]) -> None:
-        """Construct with list of Text and Substitutions."""
-        ...
-
-    def __init__(self, *, name):  # noqa: F811
+    def __init__(self, *, name: SomeSubstitutionsType) -> None:
         """Constructor."""
         super().__init__()
 
@@ -54,6 +43,10 @@ class FindExecutable(Substitution):
     def name(self) -> List[Substitution]:
         """Getter for name."""
         return self.__name
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return 'FindExec({})'.format(' + '.join([sub.describe() for sub in self.name]))
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by locating the executable on the PATH."""

--- a/launch/launch/substitutions/launch_configuration.py
+++ b/launch/launch/substitutions/launch_configuration.py
@@ -36,7 +36,7 @@ class LaunchConfiguration(Substitution):
         self,
         variable_name: SomeSubstitutionsType,
         *,
-        default: Optional[Union[Any, Iterable[Any]]] = None,
+        default: Optional[Union[Any, Iterable[Any]]] = None
     ) -> None:
         """Constructor."""
         super().__init__()

--- a/launch/launch/substitutions/launch_configuration.py
+++ b/launch/launch/substitutions/launch_configuration.py
@@ -36,7 +36,7 @@ class LaunchConfiguration(Substitution):
         self,
         variable_name: SomeSubstitutionsType,
         *,
-        default: Optional[Union[Any, Iterable[Any]]] = None
+        default: Optional[Union[Any, Iterable[Any]]] = None,
     ) -> None:
         """Constructor."""
         super().__init__()
@@ -69,6 +69,10 @@ class LaunchConfiguration(Substitution):
     def variable_name(self) -> List[Substitution]:
         """Getter for variable_name."""
         return self.__variable_name
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return 'LaunchConfig({})'.format(' + '.join([s.describe() for s in self.variable_name]))
 
     def perform(self, context: LaunchContext) -> Text:
         """

--- a/launch/launch/substitutions/local_substitution.py
+++ b/launch/launch/substitutions/local_substitution.py
@@ -14,6 +14,7 @@
 
 """Module for the LocalSubstitution substitution."""
 
+from typing import Optional
 from typing import Text
 
 from ..launch_context import LaunchContext
@@ -24,18 +25,29 @@ from ..utilities import ensure_argument_type
 class LocalSubstitution(Substitution):
     """Substitution that can access contextual local variables."""
 
-    def __init__(self, expression: Text) -> None:
+    def __init__(self, expression: Text, description: Optional[Text] = None) -> None:
         """Constructor."""
         super().__init__()
 
         ensure_argument_type(expression, str, 'expression', 'LocalSubstitution')
 
         self.__expression = expression
+        self.__description = description
 
     @property
     def expression(self) -> Text:
         """Getter for expression."""
         return self.__expression
+
+    @property
+    def description(self) -> Optional[Text]:
+        """Getter for description."""
+        return self.__description
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        msg = self.expression if self.description is None else self.description
+        return "LocalVar('{}')".format(msg)
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by retrieving the local variable."""

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -50,6 +50,10 @@ class PythonExpression(Substitution):
         """Getter for expression."""
         return self.__expression
 
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return 'PythonExpr({})'.format(' + '.join([sub.describe() for sub in self.expression]))
+
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by evaluating the expression."""
         from ..utilities import perform_substitutions

--- a/launch/launch/substitutions/text_substitution.py
+++ b/launch/launch/substitutions/text_substitution.py
@@ -39,6 +39,10 @@ class TextSubstitution(Substitution):
         """Getter for text."""
         return self.__text
 
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return "'{}'".format(self.text)
+
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by returning the string itself."""
         return self.text

--- a/launch/launch/substitutions/this_launch_file_dir.py
+++ b/launch/launch/substitutions/this_launch_file_dir.py
@@ -28,6 +28,10 @@ class ThisLaunchFileDir(Substitution):
         """Constructor."""
         super().__init__()
 
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return 'ThisLaunchFileDir()'
+
     def perform(self, context: LaunchContext) -> Text:
         """
         Perform the substitution by returning the path to the current launch file.

--- a/launch/test/launch/actions/test_declare_launch_argument.py
+++ b/launch/test/launch/actions/test_declare_launch_argument.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the DeclareLaunchArgument action class."""
+
+from launch import LaunchContext
+from launch.actions import DeclareLaunchArgument
+
+import pytest
+
+
+def test_declare_launch_argument_constructors():
+    """Test the constructors for DeclareLaunchArgument class."""
+    DeclareLaunchArgument('name')
+    DeclareLaunchArgument('name', default_value='default value')
+    DeclareLaunchArgument('name', default_value='default value', description='description')
+
+
+def test_declare_launch_argument_methods():
+    """Test the methods of the DeclareLaunchArgument class."""
+    dla1 = DeclareLaunchArgument('name', default_value='default value', description='description')
+    assert dla1.name == 'name'
+    assert isinstance(dla1.default_value, list)
+    assert dla1.description == 'description'
+    assert 'DeclareLaunchArgument' in dla1.describe()
+    assert isinstance(dla1.describe_sub_entities(), list)
+    assert isinstance(dla1.describe_conditional_sub_entities(), list)
+
+    dla2 = DeclareLaunchArgument('name')
+    assert dla2.default_value is None
+    assert dla2.description, 'description does not have a non-empty default value'
+
+
+def test_declare_launch_argument_execute():
+    """Test the execute (or visit) of the DeclareLaunchArgument class."""
+    action1 = DeclareLaunchArgument('name')
+    lc1 = LaunchContext()
+    with pytest.raises(RuntimeError) as excinfo:
+        action1.visit(lc1)
+    assert 'Required launch argument' in str(excinfo.value)
+
+    lc1.launch_configurations['name'] = 'value'
+    assert action1.visit(lc1) is None
+
+    action2 = DeclareLaunchArgument('name', default_value='value')
+    lc2 = LaunchContext()
+    assert action2.visit(lc2) is None
+    assert lc1.launch_configurations['name'] == 'value'

--- a/launch/test/launch/actions/test_include_launch_description.py
+++ b/launch/test/launch/actions/test_include_launch_description.py
@@ -19,12 +19,20 @@ import os
 from launch import LaunchContext
 from launch import LaunchDescription
 from launch import LaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.actions import SetLaunchConfiguration
+from launch.utilities import perform_substitutions
+
+import pytest
 
 
 def test_include_launch_description_constructors():
     """Test the constructors for IncludeLaunchDescription class."""
     IncludeLaunchDescription(LaunchDescriptionSource(LaunchDescription()))
+    IncludeLaunchDescription(
+        LaunchDescriptionSource(LaunchDescription()),
+        launch_arguments={'foo': 'FOO'}.items())
 
 
 def test_include_launch_description_methods():
@@ -34,16 +42,20 @@ def test_include_launch_description_methods():
     assert 'IncludeLaunchDescription' in action.describe()
     assert isinstance(action.describe_sub_entities(), list)
     assert isinstance(action.describe_conditional_sub_entities(), list)
+    # Result should only contain the launch description as there are no launch arguments.
     assert action.visit(LaunchContext()) == [ld]
     assert action.get_asyncio_future() is None
+    assert len(action.launch_arguments) == 0
 
     ld2 = LaunchDescription([action])
     action2 = IncludeLaunchDescription(LaunchDescriptionSource(ld2))
     assert 'IncludeLaunchDescription' in action2.describe()
     assert isinstance(action2.describe_sub_entities(), list)
     assert isinstance(action2.describe_conditional_sub_entities(), list)
+    # Result should only contain the launch description as there are no launch arguments.
     assert action2.visit(LaunchContext()) == [ld2]
     assert action2.get_asyncio_future() is None
+    assert len(action2.launch_arguments) == 0
 
 
 def test_include_launch_description_launch_file_location():
@@ -54,6 +66,7 @@ def test_include_launch_description_launch_file_location():
     assert isinstance(action.describe_sub_entities(), list)
     assert isinstance(action.describe_conditional_sub_entities(), list)
     lc1 = LaunchContext()
+    # Result should only contain the launch description as there are no launch arguments.
     assert action.visit(lc1) == [ld]
     assert lc1.locals.current_launch_file_directory == '<script>'
     assert action.get_asyncio_future() is None
@@ -65,6 +78,55 @@ def test_include_launch_description_launch_file_location():
     assert isinstance(action2.describe_sub_entities(), list)
     assert isinstance(action2.describe_conditional_sub_entities(), list)
     lc2 = LaunchContext()
+    # Result should only contain the launch description as there are no launch arguments.
     assert action2.visit(lc2) == [ld2]
     assert lc2.locals.current_launch_file_directory == os.path.dirname(this_file)
     assert action2.get_asyncio_future() is None
+
+
+def test_include_launch_description_launch_arguments():
+    """Test the interactions between declared launch arguments and IncludeLaunchDescription."""
+    # test that arguments are set when given, even if they are not declared
+    ld1 = LaunchDescription([])
+    action1 = IncludeLaunchDescription(
+        LaunchDescriptionSource(ld1),
+        launch_arguments={'foo': 'FOO'}.items(),
+    )
+    assert len(action1.launch_arguments) == 1
+    lc1 = LaunchContext()
+    result1 = action1.visit(lc1)
+    assert len(result1) == 2
+    assert isinstance(result1[0], SetLaunchConfiguration)
+    assert perform_substitutions(lc1, result1[0].name) == 'foo'
+    assert perform_substitutions(lc1, result1[0].value) == 'FOO'
+    assert result1[1] == ld1
+
+    # test that a declared argument that is not provided raises an error
+    ld2 = LaunchDescription([DeclareLaunchArgument('foo')])
+    action2 = IncludeLaunchDescription(
+        LaunchDescriptionSource(ld2)
+    )
+    lc2 = LaunchContext()
+    with pytest.raises(RuntimeError) as excinfo2:
+        action2.visit(lc2)
+    assert 'Included launch description missing required argument' in str(excinfo2)
+
+    # test that a declared argument that is not provided raises an error, but with other args set
+    ld2 = LaunchDescription([DeclareLaunchArgument('foo')])
+    action2 = IncludeLaunchDescription(
+        LaunchDescriptionSource(ld2),
+        launch_arguments={'not_foo': 'NOT_FOO'}.items(),
+    )
+    lc2 = LaunchContext()
+    with pytest.raises(RuntimeError) as excinfo2:
+        action2.visit(lc2)
+    assert 'Included launch description missing required argument' in str(excinfo2)
+    assert 'not_foo' in str(excinfo2)
+
+    # test that a declared argument with a default value that is not provided does not raise
+    ld2 = LaunchDescription([DeclareLaunchArgument('foo', default_value='FOO')])
+    action2 = IncludeLaunchDescription(
+        LaunchDescriptionSource(ld2)
+    )
+    lc2 = LaunchContext()
+    action2.visit(lc2)

--- a/launch/test/launch/launch_file_with_argument.launch.py
+++ b/launch/test/launch/launch_file_with_argument.launch.py
@@ -1,0 +1,28 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fixture for tests."""
+
+from launch import LaunchDescription
+import launch.actions
+
+
+def generate_launch_description():
+    """Fixture for tests."""
+    return LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'example',
+            default_value='example',
+            description='example argument'),
+    ])

--- a/launch/test/launch/test_launch_description.py
+++ b/launch/test/launch/test_launch_description.py
@@ -15,10 +15,20 @@
 """Tests for the LaunchDescription class."""
 
 import collections
+import logging
+import os
 
 from launch import Action
 from launch import LaunchDescription
 from launch import LaunchDescriptionEntity
+from launch import LaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import ThisLaunchFileDir
+
+logging.getLogger('launch').setLevel(logging.DEBUG)
 
 
 def test_launch_description_constructors():
@@ -28,6 +38,50 @@ def test_launch_description_constructors():
     LaunchDescription([])
     ld = LaunchDescription([LaunchDescriptionEntity()])
     assert len(ld.entities) == 1
+
+
+def test_launch_description_get_launch_arguments():
+    """Test the get_launch_arguments() method of the LaunchDescription class."""
+    ld = LaunchDescription([])
+    assert len(ld.get_launch_arguments()) == 0
+
+    ld = LaunchDescription([DeclareLaunchArgument('foo')])
+    la = ld.get_launch_arguments()
+    assert len(la) == 1
+    assert la[0]._conditionally_included is False
+
+    ld = LaunchDescription([DeclareLaunchArgument('foo', condition=IfCondition('True'))])
+    la = ld.get_launch_arguments()
+    assert len(la) == 1
+    assert la[0]._conditionally_included is True
+
+    ld = LaunchDescription([
+        IncludeLaunchDescription(LaunchDescriptionSource(LaunchDescription([
+            DeclareLaunchArgument('foo'),
+        ]))),
+    ])
+    la = ld.get_launch_arguments()
+    assert len(la) == 1
+    assert la[0]._conditionally_included is False
+
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    ld = LaunchDescription([
+        IncludeLaunchDescription(PythonLaunchDescriptionSource(
+            os.path.join(this_dir, 'launch_file_with_argument.launch.py'))),
+    ])
+    la = ld.get_launch_arguments()
+    assert len(la) == 1
+    assert la[0]._conditionally_included is False
+
+    ld = LaunchDescription([
+        IncludeLaunchDescription(PythonLaunchDescriptionSource([
+            # This will prevent loading of this launch file to find arguments in it.
+            ThisLaunchFileDir(),
+            'launch_file_with_argument.launch.py',
+        ])),
+    ])
+    la = ld.get_launch_arguments()
+    assert len(la) == 0
 
 
 def test_launch_description_add_things():

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -96,14 +96,20 @@ class Node(ExecuteProcess):
         # The substitutions will get expanded when the action is executed.
         ros_args_index = 0
         if node_name is not None:
-            cmd += [LocalSubstitution('ros_specific_arguments[{}]'.format(ros_args_index))]
+            cmd += [LocalSubstitution(
+                'ros_specific_arguments[{}]'.format(ros_args_index), description='node name')]
             ros_args_index += 1
         if node_namespace is not None:
-            cmd += [LocalSubstitution('ros_specific_arguments[{}]'.format(ros_args_index))]
+            cmd += [LocalSubstitution(
+                'ros_specific_arguments[{}]'.format(ros_args_index), description='node namespace')]
             ros_args_index += 1
         if remappings is not None:
+            i = 0
             for k, v in remappings:
-                cmd += [LocalSubstitution('ros_specific_arguments[{}]'.format(ros_args_index))]
+                i += 1
+                cmd += [LocalSubstitution(
+                    'ros_specific_arguments[{}]'.format(ros_args_index),
+                    description='remppaing {}'.format(i))]
                 ros_args_index += 1
         super().__init__(cmd=cmd, **kwargs)
         self.__package = package

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -151,14 +151,15 @@ class Node(ExecuteProcess):
                 self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
             validate_namespace(self.__expanded_node_namespace)
         except Exception:
-            print("Error while expanding or validating node name or namespace for '{}':".format(
-                'package={}, node_executable={}, name={}, namespace={}'.format(
+            _logger.error(
+                "Error while expanding or validating node name or namespace for '{}':"
+                .format('package={}, node_executable={}, name={}, namespace={}'.format(
                     self.__package,
                     self.__node_executable,
                     self.__node_name,
                     self.__node_namespace,
-                )
-            ))
+                ))
+            )
             raise
         self.__final_node_name = ''
         if self.__expanded_node_namespace not in ['', '/']:

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -142,7 +142,7 @@ class Node(ExecuteProcess):
             if self.__node_name is not None:
                 self.__expanded_node_name = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_name))
-                validate_node_name(self.__node_name)
+                validate_node_name(self.__expanded_node_name)
             self.__expanded_node_name.lstrip('/')
             if self.__node_namespace is not None:
                 self.__expanded_node_namespace = perform_substitutions(

--- a/launch_ros/launch_ros/substitutions/executable_in_package.py
+++ b/launch_ros/launch_ros/substitutions/executable_in_package.py
@@ -58,6 +58,12 @@ class ExecutableInPackage(Substitution):
         """Getter for package."""
         return self.__package
 
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        exec_str = ' + '.join([sub.describe() for sub in self.executable])
+        pkg_str = ' + '.join([sub.describe() for sub in self.package])
+        return 'ExecInPkg(pkg={}, exec={})'.format(pkg_str, exec_str)
+
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by locating the executable."""
         executable = perform_substitutions(context, self.executable)

--- a/ros2launch/examples/example.launch.py
+++ b/ros2launch/examples/example.launch.py
@@ -15,14 +15,22 @@
 """Launch a talker and a listener."""
 
 from launch import LaunchDescription
+import launch.actions
+import launch.substitutions
 import launch_ros.actions
 
 
 def generate_launch_description():
     """Launch a talker and a listener."""
     return LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'node_prefix',
+            default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
+            description='prefix for node names'),
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='talker', output='screen'),
+            package='demo_nodes_cpp', node_executable='talker', output='screen',
+            node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='listener', output='screen'),
+            package='demo_nodes_cpp', node_executable='listener', output='screen',
+            node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'listener']),
     ])

--- a/ros2launch/examples/includes_example.launch.py
+++ b/ros2launch/examples/includes_example.launch.py
@@ -27,7 +27,8 @@ def generate_launch_description():
         LogInfo(msg=[
             'Including launch file located at: ', ThisLaunchFileDir(), '/example.launch.py'
         ]),
-        IncludeLaunchDescription(PythonLaunchDescriptionSource(
-            [ThisLaunchFileDir(), '/example.launch.py']
-        )),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/example.launch.py']),
+            launch_arguments={'node_prefix': 'FOO'}.items(),
+        ),
     ])

--- a/ros2launch/ros2launch/api/__init__.py
+++ b/ros2launch/ros2launch/api/__init__.py
@@ -20,6 +20,7 @@ from .api import launch_a_python_launch_file
 from .api import LaunchFileNameCompleter
 from .api import MultipleLaunchFilesError
 from .api import print_a_python_launch_file
+from .api import print_arguments_of_python_launch_file
 
 __all__ = [
     'get_share_file_path_from_package',
@@ -28,4 +29,5 @@ __all__ = [
     'launch_a_python_launch_file',
     'MultipleLaunchFilesError',
     'print_a_python_launch_file',
+    'print_arguments_of_python_launch_file',
 ]

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -91,18 +91,28 @@ def print_a_python_launch_file(*, python_launch_file_path):
 def print_arguments_of_python_launch_file(*, python_launch_file_path):
     """Print the arguments of a Python launch file to the console."""
     launch_description = get_launch_description_from_python_launch_file(python_launch_file_path)
-    print(
-        "Arguments for launch file '{}' (pass arguments as '<name>:=<value>'):"
-        .format(os.path.basename(python_launch_file_path)))
-    for argument_action in launch_description.get_launch_arguments():
-        msg = '  '
+    print("Arguments (pass arguments as '<name>:=<value>'):")
+    launch_arguments = launch_description.get_launch_arguments()
+    any_conditional_arguments = False
+    for argument_action in launch_arguments:
+        msg = "\n    '"
         msg += argument_action.name
+        msg += "':"
+        if argument_action._conditionally_included:
+            any_conditional_arguments = True
+            msg += '*'
+        msg += '\n        '
+        msg += argument_action.description
         if argument_action.default_value is not None:
             default_str = ' + '.join([token.describe() for token in argument_action.default_value])
-            msg += ' (default: {})'.format(default_str)
-        msg += ':\n    '
-        msg += argument_action.description
+            msg += '\n        (default: {})'.format(default_str)
         print(msg)
+
+    if len(launch_arguments) > 0:
+        if any_conditional_arguments:
+            print('\n* argument(s) which are only used if specific conditions occur')
+    else:
+        print('\n  No arguments.')
 
 
 def parse_launch_arguments(launch_arguments: List[Text]) -> List[Tuple[Text, Text]]:


### PR DESCRIPTION
This pull request is ready for review.

To try it, you can use the example files in `ros2launch`, e.g.:

```
% ros2 launch --show-args ./path/to/ros2launch/examples/example.launch.py
...

% ros2 launch ./path/to/ros2launch/examples/example.launch.py
...

% ros2 launch ./path/to/ros2launch/examples/example.launch.py node_prefix:=foo_
...
```

fixes #107 