### PR TITLE
destroy node on shutdown to avoid hang

### DIFF
--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -76,6 +76,7 @@ class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
     def _shutdown(self, event: launch.Event, context: launch.LaunchContext):
         self.__shutting_down = True
         self.__rclpy_spin_thread.join()
+        self.__launch_ros_node.destroy_node()
 
     def _run(self):
         executor = rclpy.get_global_executor()


### PR DESCRIPTION
fixes #89 

At least it fixes the issue on bionic x86_64. I didn't try aarch64 yet, but I believe it's the same issue and so the same fix. If anyone has easy access to aarch64 and could test it, that would be great.

I cannot fully explain the reason for why this is necessary or why it results in the hang. There's more work to be done here (in my opinion) so that this doesn't happen to typical users. There's no reason that I should have to manually destroy the node.

Thanks to @nuclearsandwich for giving me the last hint I needed to find this workaround. We discussed that a potential better solution would be to have shutdown enforce the destruction of all nodes and services before shutdown finishes. That has it's own thread-safety issues and potential for deadlock, but I think that's what needs to happen to avoid this issue.

There might be another solution which address the deadlock directly or at least throws an error rather than deadlocking. I think this because I still cannot explain why this issue doesn't manifest on macOS or Xenial.