### PR TITLE
add a new pair of actions for pushing and popping launch configurations

### DIFF
--- a/launch/launch/actions/__init__.py
+++ b/launch/launch/actions/__init__.py
@@ -19,6 +19,8 @@ from .execute_process import ExecuteProcess
 from .include_launch_description import IncludeLaunchDescription
 from .log_info import LogInfo
 from .opaque_function import OpaqueFunction
+from .pop_launch_configurations import PopLaunchConfigurations
+from .push_launch_configurations import PushLaunchConfigurations
 from .register_event_handler import RegisterEventHandler
 from .set_launch_configuration import SetLaunchConfiguration
 from .timer_action import TimerAction
@@ -29,6 +31,8 @@ __all__ = [
     'IncludeLaunchDescription',
     'LogInfo',
     'OpaqueFunction',
+    'PopLaunchConfigurations',
+    'PushLaunchConfigurations',
     'RegisterEventHandler',
     'SetLaunchConfiguration',
     'TimerAction',

--- a/launch/launch/actions/pop_launch_configurations.py
+++ b/launch/launch/actions/pop_launch_configurations.py
@@ -20,9 +20,9 @@ from ..launch_context import LaunchContext
 
 class PopLaunchConfigurations(Action):
     """
-    Action that pushes the current state of launch configurations to a stack.
+    Action that pops the state of launch configurations from a stack.
 
-    The state can be restored by popping the stack with the
+    The state can be stored initially by pushing onto the stack with the
     :py:class:`launch.actions.PopLaunchConfigurations` action.
     """
 

--- a/launch/launch/actions/pop_launch_configurations.py
+++ b/launch/launch/actions/pop_launch_configurations.py
@@ -23,7 +23,7 @@ class PopLaunchConfigurations(Action):
     Action that pops the state of launch configurations from a stack.
 
     The state can be stored initially by pushing onto the stack with the
-    :py:class:`launch.actions.PopLaunchConfigurations` action.
+    :py:class:`launch.actions.PushLaunchConfigurations` action.
     """
 
     def __init__(self, **kwargs) -> None:

--- a/launch/launch/actions/pop_launch_configurations.py
+++ b/launch/launch/actions/pop_launch_configurations.py
@@ -1,0 +1,35 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the PopLaunchConfigurations action."""
+
+from ..action import Action
+from ..launch_context import LaunchContext
+
+
+class PopLaunchConfigurations(Action):
+    """
+    Action that pushes the current state of launch configurations to a stack.
+
+    The state can be restored by popping the stack with the
+    :py:class:`launch.actions.PopLaunchConfigurations` action.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Constructor."""
+        super().__init__(**kwargs)
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._pop_launch_configurations()

--- a/launch/launch/actions/push_launch_configurations.py
+++ b/launch/launch/actions/push_launch_configurations.py
@@ -1,0 +1,35 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the PushLaunchConfigurations action."""
+
+from ..action import Action
+from ..launch_context import LaunchContext
+
+
+class PushLaunchConfigurations(Action):
+    """
+    Action that pushes the current state of launch configurations to a stack.
+
+    The state can be restored by popping the stack with the
+    :py:class:`launch.actions.PopLaunchConfigurations` action.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Constructor."""
+        super().__init__(**kwargs)
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._push_launch_configurations()

--- a/launch/test/launch/actions/test_push_and_pop_launch_configurations.py
+++ b/launch/test/launch/actions/test_push_and_pop_launch_configurations.py
@@ -1,0 +1,75 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PopLaunchConfigurations and PushLaunchConfigurations action classes."""
+
+from launch import LaunchContext
+from launch.actions import PopLaunchConfigurations
+from launch.actions import PushLaunchConfigurations
+
+
+def test_push_and_pop_launch_configuration_constructors():
+    """Test the constructors for PopLaunchConfigurations and PushLaunchConfigurations classes."""
+    PopLaunchConfigurations()
+    PushLaunchConfigurations()
+
+
+def test_push_and_pop_launch_configuration_execute():
+    """Test the execute() of the PopLaunchConfigurations and PushLaunchConfigurations classes."""
+    lc1 = LaunchContext()
+
+    # does not change empty state
+    assert len(lc1.launch_configurations) == 0
+    PushLaunchConfigurations().visit(lc1)
+    PopLaunchConfigurations().visit(lc1)
+    assert len(lc1.launch_configurations) == 0
+
+    # does not change single config
+    lc1.launch_configurations['foo'] = 'FOO'
+    assert len(lc1.launch_configurations) == 1
+    assert 'foo' in lc1.launch_configurations
+    assert lc1.launch_configurations['foo'] == 'FOO'
+    PushLaunchConfigurations().visit(lc1)
+    PopLaunchConfigurations().visit(lc1)
+    assert len(lc1.launch_configurations) == 1
+    assert 'foo' in lc1.launch_configurations
+    assert lc1.launch_configurations['foo'] == 'FOO'
+
+    # does scope additions
+    lc2 = LaunchContext()
+    PushLaunchConfigurations().visit(lc2)
+    lc2.launch_configurations['foo'] = 'FOO'
+    PopLaunchConfigurations().visit(lc2)
+    assert len(lc2.launch_configurations) == 0
+    assert 'foo' not in lc2.launch_configurations
+
+    # does scope modifications
+    lc3 = LaunchContext()
+    lc3.launch_configurations['foo'] = 'FOO'
+    PushLaunchConfigurations().visit(lc3)
+    lc3.launch_configurations['foo'] = 'BAR'
+    PopLaunchConfigurations().visit(lc3)
+    assert len(lc3.launch_configurations) == 1
+    assert 'foo' in lc3.launch_configurations
+    assert lc3.launch_configurations['foo'] == 'FOO'
+
+    # does scope deletions
+    lc4 = LaunchContext()
+    lc4.launch_configurations['foo'] = 'FOO'
+    PushLaunchConfigurations().visit(lc4)
+    del lc4.launch_configurations['foo']
+    PopLaunchConfigurations().visit(lc4)
+    assert len(lc4.launch_configurations) == 1
+    assert 'foo' in lc4.launch_configurations
+    assert lc4.launch_configurations['foo'] == 'FOO'


### PR DESCRIPTION
This is a lead into supporting "scoping" with the `GroupAction` (https://github.com/ros2/launch/issues/106).