### PR TITLE
Add ability to pass parameter files to Node actions

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import pathlib
 from typing import Dict  # noqa: F401
 from typing import Iterable
 from typing import List
@@ -113,7 +114,7 @@ class Node(ExecuteProcess):
             # All arguments are paths to files with parameters (or substitutions that evaluate
             # to paths).
             # TODO(dhood): add support for parameter dicts.
-            parameter_types = SomeSubstitutionsType_types_tuple
+            parameter_types = list(SomeSubstitutionsType_types_tuple) + [pathlib.Path]
             i = 0
             for param in parameters:
                 ensure_argument_type(param, parameter_types, 'parameters[{}]'.format(i), 'Node')
@@ -190,6 +191,8 @@ class Node(ExecuteProcess):
         if self.__parameters is not None:
             self.__expanded_parameters = []
             for param_file_path in self.__parameters:
+                if isinstance(param_file_path, pathlib.Path):
+                    param_file_path = str(param_file_path)
                 expanded_param_file_path = perform_substitutions(
                     context, normalize_to_list_of_substitutions(param_file_path))
                 if not os.path.isfile(expanded_param_file_path):

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -15,6 +15,7 @@
 """Module for the Node action."""
 
 import logging
+import os
 from typing import Dict  # noqa: F401
 from typing import Iterable
 from typing import List
@@ -26,7 +27,9 @@ from launch.action import Action
 from launch.actions import ExecuteProcess
 from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
 from launch.substitutions import LocalSubstitution
+from launch.utilities import ensure_argument_type
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 
@@ -47,6 +50,7 @@ class Node(ExecuteProcess):
         node_executable: SomeSubstitutionsType,
         node_name: Optional[SomeSubstitutionsType] = None,
         node_namespace: Optional[SomeSubstitutionsType] = None,
+        parameters: Optional[List[SomeSubstitutionsType]] = None,
         remappings: Optional[Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         **kwargs
@@ -86,6 +90,7 @@ class Node(ExecuteProcess):
         :param: node_executable the name of the executable to find
         :param: node_name the name of the node
         :param: node_namespace the ros namespace for this Node
+        :param: parameters list of names of yaml files with parameter rules
         :param: remappings ordered list of 'to' and 'from' string pairs to be
             passed to the node as ROS remapping rules
         :param: arguments list of extra arguments for the node
@@ -103,6 +108,20 @@ class Node(ExecuteProcess):
             cmd += [LocalSubstitution(
                 'ros_specific_arguments[{}]'.format(ros_args_index), description='node namespace')]
             ros_args_index += 1
+        if parameters is not None:
+            ensure_argument_type(parameters, (list), 'parameters', 'Node')
+            # All arguments are paths to files with parameters (or substitutions that evaluate
+            # to paths).
+            # TODO(dhood): add support for parameter dicts.
+            parameter_types = SomeSubstitutionsType_types_tuple
+            i = 0
+            for param in parameters:
+                ensure_argument_type(param, parameter_types, 'parameters[{}]'.format(i), 'Node')
+                i += 1
+                cmd += [LocalSubstitution(
+                    'ros_specific_arguments[{}]'.format(ros_args_index),
+                    description='parameter {}'.format(i))]
+                ros_args_index += 1
         if remappings is not None:
             i = 0
             for k, v in remappings:
@@ -116,12 +135,14 @@ class Node(ExecuteProcess):
         self.__node_executable = node_executable
         self.__node_name = node_name
         self.__node_namespace = node_namespace
+        self.__parameters = [] if parameters is None else parameters
         self.__remappings = [] if remappings is None else remappings
         self.__arguments = arguments
 
         self.__expanded_node_name = '<node_name_unspecified>'
         self.__expanded_node_namespace = '/'
         self.__final_node_name = None  # type: Optional[Text]
+        self.__expanded_parameters = None  # type: Optional[List[Text]]
         self.__expanded_remappings = None  # type: Optional[Dict[Text, Text]]
 
         self.__substitutions_performed = False
@@ -165,6 +186,18 @@ class Node(ExecuteProcess):
         if self.__expanded_node_namespace not in ['', '/']:
             self.__final_node_name += self.__expanded_node_namespace
         self.__final_node_name += '/' + self.__expanded_node_name
+        # expand parameters too
+        if self.__parameters is not None:
+            self.__expanded_parameters = []
+            for param_file_path in self.__parameters:
+                expanded_param_file_path = perform_substitutions(
+                    context, normalize_to_list_of_substitutions(param_file_path))
+                if not os.path.isfile(expanded_param_file_path):
+                    _logger.warn(
+                        'Parameter file path is not valid: {}'.format(expanded_param_file_path))
+                    # Don't skip adding the file to the parameter list since space has been
+                    # reserved for it in the ros_specific_arguments.
+                self.__expanded_parameters.append(expanded_param_file_path)
         # expand remappings too
         if self.__remappings is not None:
             self.__expanded_remappings = {}
@@ -187,6 +220,9 @@ class Node(ExecuteProcess):
             ros_specific_arguments.append('__node:={}'.format(self.__expanded_node_name))
         if self.__node_namespace is not None:
             ros_specific_arguments.append('__ns:={}'.format(self.__expanded_node_namespace))
+        if self.__expanded_parameters is not None:
+            for param_file_path in self.__expanded_parameters:
+                ros_specific_arguments.append('__params:={}'.format(param_file_path))
         if self.__expanded_remappings is not None:
             for remapping_from, remapping_to in self.__remappings:
                 ros_specific_arguments.append('{}:={}'.format(remapping_from, remapping_to))

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -197,7 +197,7 @@ class Node(ExecuteProcess):
                     context, normalize_to_list_of_substitutions(param_file_path))
                 if not os.path.isfile(expanded_param_file_path):
                     _logger.warn(
-                        'Parameter file path is not valid: {}'.format(expanded_param_file_path))
+                        'Parameter file path is not file: {}'.format(expanded_param_file_path))
                     # Don't skip adding the file to the parameter list since space has been
                     # reserved for it in the ros_specific_arguments.
                 self.__expanded_parameters.append(expanded_param_file_path)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -197,7 +197,7 @@ class Node(ExecuteProcess):
                     context, normalize_to_list_of_substitutions(param_file_path))
                 if not os.path.isfile(expanded_param_file_path):
                     _logger.warn(
-                        'Parameter file path is not file: {}'.format(expanded_param_file_path))
+                        'Parameter file path is not a file: {}'.format(expanded_param_file_path))
                     # Don't skip adding the file to the parameter list since space has been
                     # reserved for it in the ros_specific_arguments.
                 self.__expanded_parameters.append(expanded_param_file_path)

--- a/launch_ros/test/launch_ros/actions/test_node.py
+++ b/launch_ros/test/launch_ros/actions/test_node.py
@@ -1,0 +1,56 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Node Action."""
+
+from launch import LaunchDescription
+from launch import LaunchService
+import launch_ros.actions.node
+
+
+def test_launch_invalid_node():
+    """Test launching an invalid node."""
+    ld = LaunchDescription([
+        launch_ros.actions.Node(
+            package='nonexistent_package', node_executable='node', output='screen'),
+    ])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 != ls.run()
+
+
+def test_launch_node():
+    """Test launching a node."""
+    ld = LaunchDescription([
+        launch_ros.actions.Node(
+            # TODO(dhood): fix cyclical package dependency
+            package='demo_nodes_cpp', node_executable='talker', output='screen'),
+    ])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+
+
+def test_launch_node_with_parameters():
+    """Test launching a node with parameters."""
+    ld = LaunchDescription([
+        launch_ros.actions.Node(
+            # TODO(dhood): fix cyclical package dependency
+            package='demo_nodes_cpp', node_executable='talker', output='screen',
+            parameters=['/home/dhood/ros2_ws/demo_parameters.yaml'],
+        ),
+    ])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()

--- a/test_launch_ros/package.xml
+++ b/test_launch_ros/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>test_launch_ros</name>
+  <version>0.6.0</version>
+  <description>Tests for ROS specific extensions to the launch tool.</description>
+  <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
+  <license>Apache License 2.0</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>demo_nodes_py</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>ros2param</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/test_launch_ros/package.xml
+++ b/test_launch_ros/package.xml
@@ -15,7 +15,6 @@
   <test_depend>demo_nodes_py</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros2param</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/test_launch_ros/setup.py
+++ b/test_launch_ros/setup.py
@@ -1,0 +1,35 @@
+from setuptools import find_packages
+from setuptools import setup
+
+setup(
+    name='test_launch_ros',
+    version='0.5.1',
+    packages=find_packages(exclude=['test']),
+    install_requires=[
+        'setuptools',
+        'demo_nodes_py',
+        'launch_ros',
+        'ros2param',
+    ],
+    zip_safe=True,
+    author='William Woodall',
+    author_email='william@osrfoundation.org',
+    maintainer='William Woodall',
+    maintainer_email='william@osrfoundation.org',
+    url='https://github.com/ros2/launch',
+    download_url='https://github.com/ros2/launch/releases',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description='Tests for ROS specific extensions to `launch`.',
+    long_description=(
+        'This package provides tests for the ROS specific '
+        'extensions to the launch package.'
+    ),
+    license='Apache License, Version 2.0',
+    tests_require=['pytest'],
+)

--- a/test_launch_ros/setup.py
+++ b/test_launch_ros/setup.py
@@ -9,7 +9,6 @@ setup(
         'setuptools',
         'demo_nodes_py',
         'launch_ros',
-        'ros2param',
     ],
     zip_safe=True,
     author='William Woodall',

--- a/test_launch_ros/test/test_copyright.py
+++ b/test_launch_ros/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/test_launch_ros/test/test_flake8.py
+++ b/test_launch_ros/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
+++ b/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
@@ -4,5 +4,5 @@ talker:
         a_string: "Hello world"
         some_list:
             sub_list:
-                some._integers: [1, 2, 3, 4]
+                some_integers: [1, 2, 3, 4]
                 some_doubles : [3.14, 2.718]

--- a/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
+++ b/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
@@ -1,0 +1,8 @@
+talker:
+    ros__parameters:
+        some_int: 42
+        a_string: "Hello world"
+        some_list:
+            sub_list:
+                some._integers: [1, 2, 3, 4]
+                some_doubles : [3.14, 2.718]

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -34,8 +34,9 @@ def test_launch_node():
     """Test launching a node."""
     ld = LaunchDescription([
         launch_ros.actions.Node(
-            # TODO(dhood): fix cyclical package dependency
-            package='demo_nodes_cpp', node_executable='talker', output='screen'),
+            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            arguments=['--number_of_cycles', '5'],
+        ),
     ])
     ls = LaunchService()
     ls.include_launch_description(ld)
@@ -46,8 +47,8 @@ def test_launch_node_with_parameters():
     """Test launching a node with parameters."""
     ld = LaunchDescription([
         launch_ros.actions.Node(
-            # TODO(dhood): fix cyclical package dependency
-            package='demo_nodes_cpp', node_executable='talker', output='screen',
+            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            arguments=['--number_of_cycles', '5'],
             parameters=['/home/dhood/ros2_ws/demo_parameters.yaml'],
         ),
     ])

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -14,6 +14,8 @@
 
 """Tests for the Node Action."""
 
+import pathlib
+
 from launch import LaunchDescription
 from launch import LaunchService
 import launch_ros.actions.node
@@ -45,13 +47,15 @@ def test_launch_node():
 
 def test_launch_node_with_parameters():
     """Test launching a node with parameters."""
-    ld = LaunchDescription([
-        launch_ros.actions.Node(
-            package='demo_nodes_py', node_executable='talker_qos', output='screen',
-            arguments=['--number_of_cycles', '5'],
-            parameters=['/home/dhood/ros2_ws/demo_parameters.yaml'],
-        ),
-    ])
+    node_action = launch_ros.actions.Node(
+        package='demo_nodes_py', node_executable='talker_qos', output='screen',
+        arguments=['--number_of_cycles', '5'],
+        parameters=['/home/dhood/ros2_ws/demo_parameters.yaml'],
+    )
+    ld = LaunchDescription([node_action])
     ls = LaunchService()
     ls.include_launch_description(ld)
     assert 0 == ls.run()
+    # Check the expanded parameters.
+    expanded_parameters = node_action._Node__expanded_parameters
+    assert expanded_parameters is not None

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -16,6 +16,7 @@
 
 import os
 import pathlib
+import unittest
 
 from launch import LaunchDescription
 from launch import LaunchService
@@ -52,7 +53,7 @@ def test_launch_node_with_parameters():
     parameters_file_dir = pathlib.Path(__file__).resolve().parent
     parameters_file_path = parameters_file_dir / 'example_parameters.yaml'
     # Pass parameter files to node in a variety of forms.
-    # It is the same file because the objective is to test the different parameter types.
+    # It is redundant to pass the same file, but the goal is to test the different parameter types.
     os.environ['FILE_PATH'] = str(parameters_file_dir)
     node_action = launch_ros.actions.Node(
         package='demo_nodes_py', node_executable='talker_qos', output='screen',
@@ -73,3 +74,23 @@ def test_launch_node_with_parameters():
     assert len(expanded_parameters) == 3
     for i in range(3):
         assert expanded_parameters[i] == str(parameters_file_path)
+
+
+class TestNode(unittest.TestCase):
+
+    def test_launch_node_with_invalid_parameters(self):
+        """Test launching a node with invalid parameters."""
+        with self.assertRaises(TypeError):
+            launch_ros.actions.Node(
+                package='demo_nodes_py', node_executable='talker_qos', output='screen',
+                arguments=['--number_of_cycles', '5'],
+                parameters=[5.0],  # Invalid list values.
+            )
+
+        parameter_file_path = pathlib.Path(__file__).resolve().parent / 'example_parameters.yaml'
+        with self.assertRaises(TypeError):
+            launch_ros.actions.Node(
+                package='demo_nodes_py', node_executable='talker_qos', output='screen',
+                arguments=['--number_of_cycles', '5'],
+                parameters=str(parameter_file_path),  # Valid path, but not in a list.
+            )

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -53,6 +53,7 @@ def test_launch_node_with_parameters():
     parameters_file_path = parameters_file_dir / 'example_parameters.yaml'
     # Pass parameter files to node in a variety of forms.
     # It is the same file because the objective is to test the different parameter types.
+    os.environ['FILE_PATH'] = str(parameters_file_dir)
     node_action = launch_ros.actions.Node(
         package='demo_nodes_py', node_executable='talker_qos', output='screen',
         arguments=['--number_of_cycles', '5'],
@@ -61,7 +62,6 @@ def test_launch_node_with_parameters():
             str(parameters_file_path),
             [EnvironmentVariable(name='FILE_PATH'), os.sep, 'example_parameters.yaml'],
         ],
-        env={'FILE_PATH': str(parameters_file_path)},
     )
     ld = LaunchDescription([node_action])
     ls = LaunchService()

--- a/test_launch_ros/test/test_pep257.py
+++ b/test_launch_ros/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=[])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
Connects to ros2/launch#117

Scoped out: passing parameters as a dictionary

Still writing tests, but example usage is:
``` python3
def generate_launch_description():
    parameters_file = pathlib.Path(__file__).resolve().parent / 'demo_parameters.yaml'
    return LaunchDescription([
        launch_ros.actions.Node(
            package='demo_nodes_cpp', node_executable='talker', output='screen',
            parameters=[
                str(parameters_file),  # as string
                parameters_file,  # as pathlib.Path
                [ThisLaunchFileDir(), os.sep, 'demo_parameters.yaml'],  # as substitution
            ],
        ),
    ])
```