### PR TITLE
Return 1 on caught exceptions from launch

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -346,6 +346,7 @@ class LaunchService:
                     msg = 'Caught exception in launch (see debug for traceback): {}'.format(exc)
                     _logger.debug(traceback.format_exc())
                     _logger.error(msg)
+                    self.__return_code = 1
                     self._shutdown(reason=msg, due_to_sigint=False)
                     # restart run loop to let it shutdown properly
                     run_loop_task = self.__loop_from_run_thread.create_task(self.__run_loop())


### PR DESCRIPTION
Noticed this when writing tests that purposefully enter this case. (https://github.com/ros2/launch/pull/135/files#diff-25cebd7b45bcde9d178003dca93986abR30)