### PR TITLE
Fixes and tests for remappings passed to Node actions

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -126,7 +126,9 @@ class Node(ExecuteProcess):
         if remappings is not None:
             ensure_argument_type(remappings, (list), 'remappings', 'Node')
             i = 0
-            for k, v in remappings:
+            for remapping in remappings:
+                ensure_argument_type(remapping, (tuple), 'remappings[{}]'.format(i), 'Node')
+                k, v = remapping
                 i += 1
                 cmd += [LocalSubstitution(
                     'ros_specific_arguments[{}]'.format(ros_args_index),

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -203,11 +203,11 @@ class Node(ExecuteProcess):
                 self.__expanded_parameters.append(expanded_param_file_path)
         # expand remappings too
         if self.__remappings is not None:
-            self.__expanded_remappings = {}
+            self.__expanded_remappings = []
             for k, v in self.__remappings:
                 key = perform_substitutions(context, normalize_to_list_of_substitutions(k))
                 value = perform_substitutions(context, normalize_to_list_of_substitutions(v))
-                self.__expanded_remappings[key] = value
+                self.__expanded_remappings.append((key, value))
 
     def execute(self, context: LaunchContext) -> Optional[List[Action]]:
         """

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -227,7 +227,7 @@ class Node(ExecuteProcess):
             for param_file_path in self.__expanded_parameters:
                 ros_specific_arguments.append('__params:={}'.format(param_file_path))
         if self.__expanded_remappings is not None:
-            for remapping_from, remapping_to in self.__remappings:
+            for remapping_from, remapping_to in self.__expanded_remappings:
                 ros_specific_arguments.append('{}:={}'.format(remapping_from, remapping_to))
         context.extend_locals({'ros_specific_arguments': ros_specific_arguments})
         return super().execute(context)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -52,7 +52,7 @@ class Node(ExecuteProcess):
         node_name: Optional[SomeSubstitutionsType] = None,
         node_namespace: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[List[SomeSubstitutionsType]] = None,
-        remappings: Optional[Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]] = None,
+        remappings: Optional[List[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         **kwargs
     ) -> None:
@@ -124,6 +124,7 @@ class Node(ExecuteProcess):
                     description='parameter {}'.format(i))]
                 ros_args_index += 1
         if remappings is not None:
+            ensure_argument_type(remappings, (list), 'remappings', 'Node')
             i = 0
             for k, v in remappings:
                 i += 1

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -145,7 +145,7 @@ class Node(ExecuteProcess):
         self.__expanded_node_namespace = '/'
         self.__final_node_name = None  # type: Optional[Text]
         self.__expanded_parameters = None  # type: Optional[List[Text]]
-        self.__expanded_remappings = None  # type: Optional[Dict[Text, Text]]
+        self.__expanded_remappings = None  # type: Optional[List[Tuple[Text, Text]]]
 
         self.__substitutions_performed = False
 

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -129,7 +129,7 @@ class Node(ExecuteProcess):
                 i += 1
                 cmd += [LocalSubstitution(
                     'ros_specific_arguments[{}]'.format(ros_args_index),
-                    description='remppaing {}'.format(i))]
+                    description='remapping {}'.format(i))]
                 ros_args_index += 1
         super().__init__(cmd=cmd, **kwargs)
         self.__package = package

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -80,7 +80,14 @@ class TestNode(unittest.TestCase):
             launch_ros.actions.Node(
                 package='demo_nodes_py', node_executable='talker_qos', output='screen',
                 arguments=['--number_of_cycles', '5'],
-                remappings={'chatter': 'new_chatter'},
+                remappings={'chatter': 'new_chatter'},  # Not a list.
+            )
+
+        with self.assertRaises(TypeError):
+            launch_ros.actions.Node(
+                package='demo_nodes_py', node_executable='talker_qos', output='screen',
+                arguments=['--number_of_cycles', '5'],
+                remappings=[{'chatter': 'new_chatter'}],  # List with elements of wrong type.
             )
 
     def test_launch_node_with_parameters(self):

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -48,6 +48,32 @@ class TestNode(unittest.TestCase):
         ls.include_launch_description(ld)
         assert 0 == ls.run()
 
+    def test_launch_node_with_remappings(self):
+        """Test launching a node with remappings."""
+        # Pass remapping rules to node in a variety of forms.
+        # It is redundant to pass the same rule, but the goal is to test different parameter types.
+        os.environ['TOPIC_NAME'] = 'chatter'
+        topic_prefix = 'new_'
+        node_action = launch_ros.actions.Node(
+            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            arguments=['--number_of_cycles', '5'],
+            remappings=[
+                ('chatter', 'new_chatter'),
+                (EnvironmentVariable(name='TOPIC_NAME'), [
+                    topic_prefix, EnvironmentVariable(name='TOPIC_NAME')])
+            ],
+        )
+        ld = LaunchDescription([node_action])
+        ls = LaunchService()
+        ls.include_launch_description(ld)
+        assert 0 == ls.run()
+
+        # Check the expanded parameters.
+        expanded_remappings = node_action._Node__expanded_remappings
+        assert len(expanded_remappings) == 2
+        for i in range(2):
+            assert expanded_remappings[i] == ('chatter', 'new_chatter')
+
     def test_launch_node_with_parameters(self):
         """Test launching a node with parameters."""
         parameters_file_dir = pathlib.Path(__file__).resolve().parent

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -74,6 +74,15 @@ class TestNode(unittest.TestCase):
         for i in range(2):
             assert expanded_remappings[i] == ('chatter', 'new_chatter')
 
+    def test_launch_node_with_invalid_remappings(self):
+        """Test launching a node with invalid remappings."""
+        with self.assertRaises(TypeError):
+            launch_ros.actions.Node(
+                package='demo_nodes_py', node_executable='talker_qos', output='screen',
+                arguments=['--number_of_cycles', '5'],
+                remappings={'chatter': 'new_chatter'},
+            )
+
     def test_launch_node_with_parameters(self):
         """Test launching a node with parameters."""
         parameters_file_dir = pathlib.Path(__file__).resolve().parent


### PR DESCRIPTION
Some issues I noticed while working on ros2/launch#135 (kept as separate commits).

Most significant change is that, without this PR, something like:
```
def generate_launch_description():
    os.environ['TOPIC_NAME'] ='chatter'
    return LaunchDescription([
        launch_ros.actions.Node(
            package='demo_nodes_cpp', node_executable='talker', output='screen',
            remappings=[
                (EnvironmentVariable(name='TOPIC_NAME'), [
                    'new_', EnvironmentVariable(name='TOPIC_NAME')])
            ],
            log_cmd=True,
        ),
    ])
```

would not remap properly, and would output:
```
[INFO] [launch]: process[talker-1] details: cmd=[/home/dhood/ros2_ws/install/demo_nodes_cpp/lib/demo_nodes_cpp/talker, <launch.substitutions.environment_variable.EnvironmentVariable object at 0x7f239d09ea20>:=['new_', <launch.substitutions.environment_variable.EnvironmentVariable object at 0x7f239d09e9b0>]], cwd='None', custom_env?=False
```
whereas now it evaluates the substitutions and gives:
```
[INFO] [launch]: process[talker-1] details: cmd=[/home/dhood/ros2_ws/install/demo_nodes_cpp/lib/demo_nodes_cpp/talker, chatter:=new_chatter], cwd='None', custom_env?=False
```
This PR currently targets the branch used for ros2/launch#135 because it builds on top of it; will be retargeted at master once that PR's merged.