### PR TITLE
Support passing parameters as a dictionary

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -138,6 +138,9 @@ class Node(ExecuteProcess):
             i = 0
             for param in parameters:
                 ensure_argument_type(param, parameter_types, 'parameters[{}]'.format(i), 'Node')
+                if isinstance(param, dict) and node_name is None:
+                    raise RuntimeError('If a dictionary of parameters is specified, the node name '
+                        'must also be specified. See https://github.com/ros2/launch/issues/139')
                 i += 1
                 cmd += [LocalSubstitution(
                     'ros_specific_arguments[{}]'.format(ros_args_index),

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -185,6 +185,7 @@ class Node(ExecuteProcess):
     def _create_params_file_from_dict(self, context, params):
         with NamedTemporaryFile(mode='w', prefix='launch_params_', delete=False) as h:
             param_file_path = h.name
+            # TODO(dhood): clean up generated parameter files.
 
             def perform_substitution_if_applicable(context, var):
                 if isinstance(var, (int, float, str)):

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -180,7 +180,6 @@ class Node(ExecuteProcess):
                     # Key can only be a string (parameter/group name).
                     expanded_key = perform_substitutions(
                         context, normalize_to_list_of_substitutions(k))
-                    expanded_value = v
                     if isinstance(v, dict):
                         # Expand the nested dict.
                         expanded_value = expand_dict(v)
@@ -201,6 +200,8 @@ class Node(ExecuteProcess):
                                 'parameter dictionary tuple entry', 'Node')
                         expanded_value = perform_substitutions(
                             context, normalize_to_list_of_substitutions(v))
+                    else:
+                        expanded_value = perform_substitution_if_applicable(context, v)
                     expanded_dict[expanded_key] = expanded_value
                 return expanded_dict
 

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -139,8 +139,9 @@ class Node(ExecuteProcess):
             for param in parameters:
                 ensure_argument_type(param, parameter_types, 'parameters[{}]'.format(i), 'Node')
                 if isinstance(param, dict) and node_name is None:
-                    raise RuntimeError('If a dictionary of parameters is specified, the node name '
-                        'must also be specified. See https://github.com/ros2/launch/issues/139')
+                    raise RuntimeError(
+                        'If a dictionary of parameters is specified, the node name must also be '
+                        'specified. See https://github.com/ros2/launch/issues/139')
                 i += 1
                 cmd += [LocalSubstitution(
                     'ros_specific_arguments[{}]'.format(ros_args_index),
@@ -196,10 +197,12 @@ class Node(ExecuteProcess):
                         return perform_substitutions(
                             context, normalize_to_list_of_substitutions(var))
                     except TypeError as e:
-                        raise TypeError('Invalid element received in parameters dictionary '
-                           '(not all tuple elements are Substitutions): {}'.format(var))
+                        raise TypeError(
+                            'Invalid element received in parameters dictionary '
+                            '(not all tuple elements are Substitutions): {}'.format(var))
                 else:
-                    raise TypeError('Unsupported type received in parameters dictionary: {}'
+                    raise TypeError(
+                        'Unsupported type received in parameters dictionary: {}'
                         .format(type(var)))
 
             def expand_dict(input_dict):

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -180,16 +180,20 @@ class Node(ExecuteProcess):
                     # Key can only be a string (parameter/group name).
                     expanded_key = perform_substitutions(
                         context, normalize_to_list_of_substitutions(k))
+                    expanded_value = v
                     if isinstance(v, dict):
                         # Expand the nested dict.
                         expanded_value = expand_dict(v)
                     elif isinstance(v, list):
                         # Expand each element.
-                        # NOTE(dhood): Nested lists are not supported for paramters.
-                        # TODO(dhood): Error on nested lists.
-                        expanded_value = [
-                            perform_substitution_if_applicable(context, e) for e in v]
-                    # NOTE(dhood): Tuples are treated as Substitution(s) to be concatenated.
+                        expanded_value = []
+                        for e in v:
+                            if isinstance(e, list):
+                                raise TypeError(
+                                    'Nested lists are not supported for parameters: {} found in {}'
+                                    .format(e, v))
+                            expanded_value.append(perform_substitution_if_applicable(context, e))
+                    # Tuples are treated as Substitution(s) to be concatenated.
                     elif isinstance(v, tuple):
                         for e in v:
                             ensure_argument_type(

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -197,7 +197,7 @@ class Node(ExecuteProcess):
                     try:
                         return perform_substitutions(
                             context, normalize_to_list_of_substitutions(var))
-                    except TypeError as e:
+                    except TypeError:
                         raise TypeError(
                             'Invalid element received in parameters dictionary '
                             '(not all tuple elements are Substitutions): {}'.format(var))

--- a/launch_ros/package.xml
+++ b/launch_ros/package.xml
@@ -14,6 +14,7 @@
   <depend>lifecycle_msgs</depend>
   <depend>osrf_pycommon</depend>
   <depend>rclpy</depend>
+  <depend>python3-yaml</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/launch_ros/setup.py
+++ b/launch_ros/setup.py
@@ -10,6 +10,7 @@ setup(
         'ament_index_python',
         'launch',
         'osrf_pycommon',
+        'pyyaml',
     ],
     zip_safe=True,
     author='William Woodall',

--- a/test_launch_ros/package.xml
+++ b/test_launch_ros/package.xml
@@ -15,6 +15,7 @@
   <test_depend>demo_nodes_py</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-yaml</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/test_launch_ros/setup.py
+++ b/test_launch_ros/setup.py
@@ -9,6 +9,7 @@ setup(
         'setuptools',
         'demo_nodes_py',
         'launch_ros',
+        'pyyaml',
     ],
     zip_safe=True,
     author='William Woodall',

--- a/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
+++ b/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
@@ -1,8 +1,9 @@
-talker:
-    ros__parameters:
-        some_int: 42
-        a_string: "Hello world"
-        some_list:
-            sub_list:
-                some_integers: [1, 2, 3, 4]
-                some_doubles : [3.14, 2.718]
+/my_ns:
+    my_node:
+        ros__parameters:
+            some_int: 42
+            a_string: "Hello world"
+            some_list:
+                sub_list:
+                    some_integers: [1, 2, 3, 4]
+                    some_doubles : [3.14, 2.718]

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -225,13 +225,13 @@ class TestNode(unittest.TestCase):
 
         # Other types are not supported.
         self._assert_launch_errors(actions=[
-            self._create_node(parameters=[{'param': set([1, 2])}])
+            self._create_node(parameters=[{'param': {1, 2}}])
         ])
         self._assert_launch_errors(actions=[
             self._create_node(parameters=[{
                 'param_group': {
                     'param_subgroup': {
-                        'param': set([1, 2]),
+                        'param': {1, 2},
                     },
                 },
             }])

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -118,10 +118,18 @@ class TestNode(unittest.TestCase):
     def test_launch_node_with_parameter_dict(self):
         """Test launching a node with parameters specified in a dictionary."""
         os.environ['PARAM1_VALUE'] = 'param1_value'
+        os.environ['PARAM2'] = 'param2'
         node_action = self._create_node(
-            parameters=[
-                {'param1': EnvironmentVariable(name='PARAM1_VALUE')},
-            ],
+            parameters=[{
+                'param1': EnvironmentVariable(name='PARAM1_VALUE'),
+                EnvironmentVariable(name='PARAM2'): (EnvironmentVariable(name='PARAM2'), '_value'),
+                'param_group1': {
+                    'list_params': [1.2, 3.4],
+                    'param_group2': {
+                        (EnvironmentVariable('PARAM2'), '_values'): ['param2_value'],
+                    }
+                }
+            }],
         )
         self._assert_launch_no_errors([node_action])
 
@@ -134,7 +142,14 @@ class TestNode(unittest.TestCase):
                 '/my_ns': {
                     'my_node': {
                         'ros__parameters': {
-                            'param1': 'param1_value'
+                            'param1': 'param1_value',
+                            'param2': 'param2_value',
+                            'param_group1': {
+                                'list_params': [1.2, 3.4],
+                                'param_group2': {
+                                    'param2_values': ['param2_value'],
+                                }
+                            }
                         }
                     }
                 }

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -104,6 +104,7 @@ class TestNode(unittest.TestCase):
                 parameters_file_path,
                 str(parameters_file_path),
                 [EnvironmentVariable(name='FILE_PATH'), os.sep, 'example_parameters.yaml'],
+                {'param1': 5},
             ],
         )
         ld = LaunchDescription([node_action])

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -212,3 +212,29 @@ class TestNode(unittest.TestCase):
                 },
             }])
         ])
+
+        # Other types are not supported.
+        self._assert_launch_errors(actions=[
+            self._create_node(parameters=[{'param': set([1, 2])}])
+        ])
+        self._assert_launch_errors(actions=[
+            self._create_node(parameters=[{
+                'param_group': {
+                    'param_subgroup': {
+                        'param': set([1, 2]),
+                    },
+                },
+            }])
+        ])
+        self._assert_launch_errors(actions=[
+            self._create_node(parameters=[{'param': self}])
+        ])
+        self._assert_launch_errors(actions=[
+            self._create_node(parameters=[{
+                'param_group': {
+                    'param_subgroup': {
+                        'param': self,
+                    },
+                },
+            }])
+        ])


### PR DESCRIPTION
Closes ros2/launch#117
Requires ros2/rcl#299

The dictionary can be nested (to specify different groups of parameters) and can have substitutions at each level.

A yaml file is written following [this structure](https://github.com/ros2/rcl/blob/c9fe312674f8c5a2c5b40b6208c830f4ca8c40ff/rcl_yaml_param_parser/README.md). It always specifies the namespace and node name (requires ros2/rcl#299). Scoped out: deleting the file(s).

Design decisions:
1. Typically "iterables" of substitutions will be concatenated into a single string. However, a user may have been trying to specify a parameter array with each element a substitution. To distinguish these two cases, only Tuples of substitutions will be concatenated into a string, not any Iterable. Lists of substitutions will be treated as a parameter array.
1. Parameter files only work if the node name is specified, so if a parameter dict is passed, the node name must be specified also (https://github.com/ros2/launch/issues/139).