### PR TITLE
Integrate LaunchLogger

### DIFF
--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -14,19 +14,17 @@
 
 """Module for the DeclareLaunchArgument action."""
 
-import logging
 from typing import List
 from typing import Optional
 from typing import Text
 
 from ..action import Action
 from ..launch_context import LaunchContext
+from ..launch_logger import LaunchLogger
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
-
-_logger = logging.getLogger('launch.actions.DeclareLaunchArgument')
 
 
 class DeclareLaunchArgument(Action):
@@ -88,6 +86,8 @@ class DeclareLaunchArgument(Action):
             self.__default_value = normalize_to_list_of_substitutions(default_value)
         self.__description = description
 
+        self.__logger = LaunchLogger()
+
         # This is used later to determine if this launch argument will be
         # conditionally visited.
         # Its value will be read and set at different times and so the value
@@ -114,9 +114,10 @@ class DeclareLaunchArgument(Action):
         if self.name not in context.launch_configurations:
             if self.default_value is None:
                 # Argument not already set and no default value given, error.
-                _logger.error(
-                    "Required launch argument '{}' (description: '{}') was not provided"
-                    .format(self.name, self.description)
+                self.__logger.error(
+                    __name__,
+                    "Required launch argument '{}' (description: '{}') was not provided".format(
+                        self.name, self.description)
                 )
                 raise RuntimeError(
                     "Required launch argument '{}' was not provided.".format(self.name))

--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -18,9 +18,10 @@ from typing import List
 from typing import Optional
 from typing import Text
 
+from .. import logging
+
 from ..action import Action
 from ..launch_context import LaunchContext
-from ..launch_logger import LaunchLogger
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
@@ -86,7 +87,7 @@ class DeclareLaunchArgument(Action):
             self.__default_value = normalize_to_list_of_substitutions(default_value)
         self.__description = description
 
-        self.__logger = LaunchLogger()
+        self.__logger = logging.getLogger(__name__)
 
         # This is used later to determine if this launch argument will be
         # conditionally visited.
@@ -115,7 +116,6 @@ class DeclareLaunchArgument(Action):
             if self.default_value is None:
                 # Argument not already set and no default value given, error.
                 self.__logger.error(
-                    __name__,
                     "Required launch argument '{}' (description: '{}') was not provided".format(
                         self.name, self.description)
                 )

--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -18,7 +18,7 @@ from typing import List
 from typing import Optional
 from typing import Text
 
-from .. import logging
+import launch.logging
 
 from ..action import Action
 from ..launch_context import LaunchContext
@@ -87,7 +87,7 @@ class DeclareLaunchArgument(Action):
             self.__default_value = normalize_to_list_of_substitutions(default_value)
         self.__description = description
 
-        self.__logger = logging.getLogger(__name__)
+        self.__logger = launch.logging.getLogger(__name__)
 
         # This is used later to determine if this launch argument will be
         # conditionally visited.

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -71,10 +71,6 @@ _global_process_counter_lock = threading.Lock()
 _global_process_counter = 0  # in Python3, this number is unbounded (no rollover)
 
 
-def default_output_prefix(line: Text, action: 'ExecuteProcess') -> Text:
-    return '[{}] {}'.format(action.name, line)
-
-
 class ExecuteProcess(Action):
     """Action that begins executing a process and sets up event handlers for the process."""
 
@@ -92,7 +88,7 @@ class ExecuteProcess(Action):
             'sigkill_timeout', default = 5),
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Text = 'log',
-        output_prefix: Optional[Callable[[Text, Action], Text]] = None,
+        output_format: Text = '[{this.name}] {line}',
         log_cmd: bool = False,
         **kwargs
     ) -> None:
@@ -165,10 +161,11 @@ class ExecuteProcess(Action):
             called 'launch-prefix'
         :param: output configuration for process output logging. Default is 'log' i.e.
             log both stdout and stderr to launch main log file and stderr to the screen.
-            See launch.logging.getOutputLoggers() documentation for further reference
+            See `launch.logging.getOutputLoggers()` documentation for further reference
             on all available options.
-        :param: output_prefix to preprocess each output line before logging it. Defaults
-            to prepending each line with the process name.
+        :param: output_format for logging each output line, supporting `str.format()`
+            substitutions with the following keys in scope: `line` to reference the raw
+            output line and `this` to reference this action instance.
         :param: log_cmd if True, prints the final cmd before executing the
             process, which is useful for debugging when substitutions are
             involved.
@@ -191,10 +188,7 @@ class ExecuteProcess(Action):
             LaunchConfiguration('launch-prefix', default='') if prefix is None else prefix
         )
         self.__output = output
-        # TODO(hidmic): consider implementing this using logging.LoggerAdapter instead
-        if output_prefix is None:
-            output_prefix = default_output_prefix
-        self.__output_prefix = output_prefix
+        self.__output_format = output_format
 
         self.__log_cmd = log_cmd
 
@@ -292,13 +286,17 @@ class ExecuteProcess(Action):
         self, event: ProcessIO
     ) -> Optional[SomeActionsType]:
         for line in event.text.decode().splitlines():
-            self.__stdout_logger.info(self.__output_prefix(line, self))
+            self.__stdout_logger.info(
+                self.__output_format.format(line=line, this=self)
+            )
 
     def __on_process_stderr(
         self, event: ProcessIO
     ) -> Optional[SomeActionsType]:
         for line in event.text.decode().splitlines():
-            self.__stderr_logger.info(self.__output_prefix(line, self))
+            self.__stderr_logger.info(
+                self.__output_format.format(line=line, this=self)
+            )
 
     def __on_shutdown(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         return self.__shutdown_process(

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -31,6 +31,8 @@ from typing import Optional
 from typing import Text
 from typing import Tuple  # noqa: F401
 
+import launch.logging
+
 from osrf_pycommon.process_utils import async_execute_process
 from osrf_pycommon.process_utils import AsyncSubprocessProtocol
 
@@ -38,7 +40,6 @@ from .emit_event import EmitEvent
 from .opaque_function import OpaqueFunction
 from .timer_action import TimerAction
 
-from .. import logging
 from ..action import Action
 from ..event import Event
 from ..event_handler import EventHandler
@@ -373,7 +374,7 @@ class ExecuteProcess(Action):
             self.__context = context
             self.__action = action
             self.__process_event_args = process_event_args
-            self.__logger = logging.getLogger(process_event_args['name'])
+            self.__logger = launch.logging.getLogger(process_event_args['name'])
 
         def connection_made(self, transport):
             self.__logger.info(
@@ -502,11 +503,9 @@ class ExecuteProcess(Action):
         try:
             self.__completed_future = create_future(context.asyncio_loop)
             self.__expand_substitutions(context)
-            self.__logger = logging.getLogger(self.__name)
-            self.__logger.addHandler(logging.getScreenHandler())
-            self.__logger.addHandler(logging.getLogFileHandler())
+            self.__logger = launch.logging.getLogger(self.__name)
             self.__stdout_logger, self.__stderr_logger = \
-                logging.getOutputLoggers(self.__name, self.__output)
+                launch.logging.getOutputLoggers(self.__name, self.__output)
             context.asyncio_loop.create_task(self.__execute_process(context))
         except Exception:
             for event_handler in event_handlers:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -39,10 +39,12 @@ from .timer_action import TimerAction
 from ..action import Action
 from ..event import Event
 from ..event_handler import EventHandler
+from ..event_handlers import OnProcessIO
 from ..event_handlers import OnShutdown
 from ..events import Shutdown
 from ..events.process import matches_action
 from ..events.process import ProcessExited
+from ..events.process import ProcessIO
 from ..events.process import ProcessStarted
 from ..events.process import ProcessStderr
 from ..events.process import ProcessStdin
@@ -51,6 +53,7 @@ from ..events.process import ShutdownProcess
 from ..events.process import SignalProcess
 from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
+from ..launch_logger import LoggerLevel
 from ..launch_logger import LaunchLogger
 from ..some_actions_type import SomeActionsType
 from ..some_substitutions_type import SomeSubstitutionsType
@@ -153,11 +156,11 @@ class ExecuteProcess(Action):
         :param: prefix a set of commands/arguments to preceed the cmd, used for
             things like gdb/valgrind and defaults to the LaunchConfiguration
             called 'launch-prefix'
-        :param: output either 'log', 'screen', or 'both'; if 'screen' stderr is directed
-            to stdout and stdout is printed to the screen; if 'log' stderr is
-            directed to the screen and both stdout and stderr are directed to
-            a log file; if 'both' stdout and stderr are directed to screen and a log file;
-            the default is 'log'
+        :param: output either 'log', 'screen', or 'both'; if 'screen' stdout and
+            stderr are directed to the screen; if 'log' stderr is directed to the
+            screen and both stdout and stderr are directed to a log file; if 'both'
+            stdout and stderr are directed to screen and a log file; the default is
+           'log'
         :param: log_cmd if True, prints the final cmd before executing the
             process, which is useful for debugging when substitutions are
             involved.
@@ -265,17 +268,28 @@ class ExecuteProcess(Action):
         self._subprocess_transport.send_signal(typed_event.signal)
         return None
 
-    def __on_process_stdin_event(
+    def __on_process_input(
         self,
-        event: Event,
-        context: LaunchContext
-    ) -> Optional[LaunchDescription]:
+        event: ProcessIO
+    ) -> Optional[SomeActionsType]:
         self.__logger.warning(
             self.__name,
             "in ExecuteProcess('{}').__on_process_stdin_event()".format(id(self)),
         )
         cast(ProcessStdin, event)
         return None
+
+    def __on_process_output(
+        self, event: ProcessIO
+    ) -> Optional[SomeActionsType]:
+        name = self.process_details['name']
+        level = LoggerLevel.ERROR if event.from_stderr else LoggerLevel.INFO
+        output = '\n'.join(['---', *map(
+            lambda line: ' ' + line, event.text.decode().splitlines()
+        ), '---'])
+        self.__logger.log(name, level, 'process has {} output:\n{}'.format(
+            'stderr' if event.from_stderr else 'stdout', output
+        ))
 
     def __on_shutdown(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         return self.__shutdown_process(
@@ -420,7 +434,6 @@ class ExecuteProcess(Action):
                 env=env,
                 shell=self.__shell,
                 emulate_tty=False,
-                stderr_to_stdout=(self.__output == 'screen'),
             )
         except Exception:
             self.__logger.error(name, 'exception occurred while executing process:\n{}'.format(
@@ -467,9 +480,11 @@ class ExecuteProcess(Action):
                 matcher=lambda event: is_a_subclass(event, SignalProcess),
                 entities=OpaqueFunction(function=self.__on_signal_process_event),
             ),
-            EventHandler(
-                matcher=lambda event: is_a_subclass(event, ProcessStdin),
-                entities=OpaqueFunction(function=self.__on_process_stdin_event),
+            OnProcessIO(
+                target_action=self,
+                on_stdin=self.__on_process_input,
+                on_stdout=self.__on_process_output,
+                on_stderr=self.__on_process_output,
             ),
             OnShutdown(
                 on_shutdown=self.__on_shutdown,

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -22,6 +22,7 @@ import signal
 import threading
 import traceback
 from typing import Any  # noqa: F401
+from typing import Callable
 from typing import cast
 from typing import Dict
 from typing import Iterable
@@ -36,6 +37,8 @@ from osrf_pycommon.process_utils import AsyncSubprocessProtocol
 from .emit_event import EmitEvent
 from .opaque_function import OpaqueFunction
 from .timer_action import TimerAction
+
+from .. import logging
 from ..action import Action
 from ..event import Event
 from ..event_handler import EventHandler
@@ -53,8 +56,6 @@ from ..events.process import ShutdownProcess
 from ..events.process import SignalProcess
 from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
-from ..launch_logger import LoggerLevel
-from ..launch_logger import LaunchLogger
 from ..some_actions_type import SomeActionsType
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution  # noqa: F401
@@ -67,6 +68,10 @@ from ..utilities import perform_substitutions
 
 _global_process_counter_lock = threading.Lock()
 _global_process_counter = 0  # in Python3, this number is unbounded (no rollover)
+
+
+def default_output_prefix(line: Text, action: 'ExecuteProcess') -> Text:
+    return '[{}] {}'.format(action.name, line)
 
 
 class ExecuteProcess(Action):
@@ -86,6 +91,7 @@ class ExecuteProcess(Action):
             'sigkill_timeout', default = 5),
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Text = 'log',
+        output_prefix: Optional[Callable[[Text, Action], Text]] = None,
         log_cmd: bool = False,
         **kwargs
     ) -> None:
@@ -156,11 +162,12 @@ class ExecuteProcess(Action):
         :param: prefix a set of commands/arguments to preceed the cmd, used for
             things like gdb/valgrind and defaults to the LaunchConfiguration
             called 'launch-prefix'
-        :param: output either 'log', 'screen', or 'both'; if 'screen' stdout and
-            stderr are directed to the screen; if 'log' stderr is directed to the
-            screen and both stdout and stderr are directed to a log file; if 'both'
-            stdout and stderr are directed to screen and a log file; the default is
-           'log'
+        :param: output configuration for process output logging. Default is 'log' i.e.
+            log both stdout and stderr to launch main log file and stderr to the screen.
+            See launch.logging.getOutputLoggers() documentation for further reference
+            on all available options.
+        :param: output_prefix to preprocess each output line before logging it. Defaults
+            to prepending each line with the process name.
         :param: log_cmd if True, prints the final cmd before executing the
             process, which is useful for debugging when substitutions are
             involved.
@@ -183,6 +190,10 @@ class ExecuteProcess(Action):
             LaunchConfiguration('launch-prefix', default='') if prefix is None else prefix
         )
         self.__output = output
+        # TODO(hidmic): consider implementing this using logging.LoggerAdapter instead
+        if output_prefix is None:
+            output_prefix = default_output_prefix
+        self.__output_prefix = output_prefix
 
         self.__log_cmd = log_cmd
 
@@ -244,7 +255,6 @@ class ExecuteProcess(Action):
         if self._subprocess_protocol.complete.done():
             # the process is done or is cleaning up, no need to signal
             self.__logger.debug(
-                self.__name,
                 "signal '{}' not set to '{}' because it is already closing".format(
                     typed_event.signal_name, self.process_details['name']),
             )
@@ -252,14 +262,13 @@ class ExecuteProcess(Action):
         if platform.system() == 'Windows' and typed_event.signal_name == 'SIGINT':
             # TODO(wjwwood): remove this when/if SIGINT is fixed on Windows
             self.__logger.warning(
-                self.__name,
                 "'SIGINT' sent to process[{}] not supported on Windows, escalating to 'SIGTERM'"
-                    .format(self.process_details['name']),
+                .format(self.process_details['name']),
             )
             typed_event = SignalProcess(
                 signal_number=signal.SIGTERM,
                 process_matcher=lambda process: True)
-        self.__logger.info(self.__name, "sending signal '{}' to process[{}]".format(
+        self.__logger.info("sending signal '{}' to process[{}]".format(
             typed_event.signal_name, self.process_details['name']
         ))
         if typed_event.signal_name == 'SIGKILL':
@@ -268,28 +277,27 @@ class ExecuteProcess(Action):
         self._subprocess_transport.send_signal(typed_event.signal)
         return None
 
-    def __on_process_input(
+    def __on_process_stdin(
         self,
         event: ProcessIO
     ) -> Optional[SomeActionsType]:
         self.__logger.warning(
-            self.__name,
             "in ExecuteProcess('{}').__on_process_stdin_event()".format(id(self)),
         )
         cast(ProcessStdin, event)
         return None
 
-    def __on_process_output(
+    def __on_process_stdout(
         self, event: ProcessIO
     ) -> Optional[SomeActionsType]:
-        name = self.process_details['name']
-        level = LoggerLevel.ERROR if event.from_stderr else LoggerLevel.INFO
-        output = '\n'.join(['---', *map(
-            lambda line: ' ' + line, event.text.decode().splitlines()
-        ), '---'])
-        self.__logger.log(name, level, 'process has {} output:\n{}'.format(
-            'stderr' if event.from_stderr else 'stdout', output
-        ))
+        for line in event.text.decode().splitlines():
+            self.__stdout_logger.info(self.__output_prefix(line, self))
+
+    def __on_process_stderr(
+        self, event: ProcessIO
+    ) -> Optional[SomeActionsType]:
+        for line in event.text.decode().splitlines():
+            self.__stderr_logger.info(self.__output_prefix(line, self))
 
     def __on_shutdown(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         return self.__shutdown_process(
@@ -302,7 +310,7 @@ class ExecuteProcess(Action):
             "process[{}] failed to terminate '{}' seconds after receiving '{}', escalating to '{}'"
 
         def printer(context, msg, timeout_substitutions):
-            self.__logger.error(self.__name, msg.format(
+            self.__logger.error(msg.format(
                 context.locals.process_name,
                 perform_substitutions(context, timeout_substitutions),
             ))
@@ -365,11 +373,10 @@ class ExecuteProcess(Action):
             self.__context = context
             self.__action = action
             self.__process_event_args = process_event_args
-            self.__logger = LaunchLogger()
+            self.__logger = logging.getLogger(process_event_args['name'])
 
         def connection_made(self, transport):
             self.__logger.info(
-                self.__process_event_args['name'],
                 'process started with pid [{}]'.format(transport.get_pid()),
             )
             super().connection_made(transport)
@@ -416,12 +423,11 @@ class ExecuteProcess(Action):
         process_event_args = self.__process_event_args
         if process_event_args is None:
             raise RuntimeError('process_event_args unexpectedly None')
-        name = process_event_args['name']
         cmd = process_event_args['cmd']
         cwd = process_event_args['cwd']
         env = process_event_args['env']
         if self.__log_cmd:
-            self.__logger.info(name, "process details: cmd=[{}], cwd='{}', custom_env?={}".format(
+            self.__logger.info("process details: cmd=[{}], cwd='{}', custom_env?={}".format(
                 ', '.join(cmd), cwd, 'True' if env is not None else 'False'
             ))
         try:
@@ -436,7 +442,7 @@ class ExecuteProcess(Action):
                 emulate_tty=False,
             )
         except Exception:
-            self.__logger.error(name, 'exception occurred while executing process:\n{}'.format(
+            self.__logger.error('exception occurred while executing process:\n{}'.format(
                 traceback.format_exc()
             ))
             self.__cleanup()
@@ -448,9 +454,9 @@ class ExecuteProcess(Action):
 
         returncode = await self._subprocess_protocol.complete
         if returncode == 0:
-            self.__logger.info(name, 'process has finished cleanly [pid {}]'.format(pid))
+            self.__logger.info('process has finished cleanly [pid {}]'.format(pid))
         else:
-            self.__logger.error(name, "process has died [pid {}, exit code {}, cmd '{}'].".format(
+            self.__logger.error("process has died [pid {}, exit code {}, cmd '{}'].".format(
                 pid, returncode, ' '.join(cmd)
             ))
         await context.emit_event(ProcessExited(returncode=returncode, **process_event_args))
@@ -482,9 +488,9 @@ class ExecuteProcess(Action):
             ),
             OnProcessIO(
                 target_action=self,
-                on_stdin=self.__on_process_input,
-                on_stdout=self.__on_process_output,
-                on_stderr=self.__on_process_output,
+                on_stdin=self.__on_process_stdin,
+                on_stdout=self.__on_process_stdout,
+                on_stderr=self.__on_process_stderr
             ),
             OnShutdown(
                 on_shutdown=self.__on_shutdown,
@@ -496,8 +502,11 @@ class ExecuteProcess(Action):
         try:
             self.__completed_future = create_future(context.asyncio_loop)
             self.__expand_substitutions(context)
-            self.__logger = LaunchLogger()
-            self.__logger.configure_logger(self.__name, self.__output)
+            self.__logger = logging.getLogger(self.__name)
+            self.__logger.addHandler(logging.getScreenHandler())
+            self.__logger.addHandler(logging.getLogFileHandler())
+            self.__stdout_logger, self.__stderr_logger = \
+                logging.getOutputLoggers(self.__name, self.__output)
             context.asyncio_loop.create_task(self.__execute_process(context))
         except Exception:
             for event_handler in event_handlers:
@@ -508,6 +517,11 @@ class ExecuteProcess(Action):
     def get_asyncio_future(self) -> Optional[asyncio.Future]:
         """Return an asyncio Future, used to let the launch system know when we're done."""
         return self.__completed_future
+
+    @property
+    def name(self):
+        """Getter for name."""
+        return self.__name
 
     @property
     def cmd(self):

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -15,7 +15,6 @@
 """Module for the ExecuteProcess action."""
 
 import asyncio
-import logging
 import os
 import platform
 import shlex
@@ -52,6 +51,7 @@ from ..events.process import ShutdownProcess
 from ..events.process import SignalProcess
 from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
+from ..launch_logger import LaunchLogger
 from ..some_actions_type import SomeActionsType
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution  # noqa: F401
@@ -61,8 +61,6 @@ from ..utilities import create_future
 from ..utilities import is_a_subclass
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
-
-_logger = logging.getLogger(name='launch')
 
 _global_process_counter_lock = threading.Lock()
 _global_process_counter = 0  # in Python3, this number is unbounded (no rollover)
@@ -84,7 +82,7 @@ class ExecuteProcess(Action):
         sigkill_timeout: SomeSubstitutionsType = LaunchConfiguration(
             'sigkill_timeout', default = 5),
         prefix: Optional[SomeSubstitutionsType] = None,
-        output: Optional[Text] = None,
+        output: Text = 'log',
         log_cmd: bool = False,
         **kwargs
     ) -> None:
@@ -155,10 +153,11 @@ class ExecuteProcess(Action):
         :param: prefix a set of commands/arguments to preceed the cmd, used for
             things like gdb/valgrind and defaults to the LaunchConfiguration
             called 'launch-prefix'
-        :param: output either 'log' or 'screen'; if 'screen' stderr is directed
+        :param: output either 'log', 'screen', or 'both'; if 'screen' stderr is directed
             to stdout and stdout is printed to the screen; if 'log' stderr is
             directed to the screen and both stdout and stderr are directed to
-            a log file; the default is 'log'
+            a log file; if 'both' stdout and stderr are directed to screen and a log file;
+            the default is 'log'
         :param: log_cmd if True, prints the final cmd before executing the
             process, which is useful for debugging when substitutions are
             involved.
@@ -180,15 +179,8 @@ class ExecuteProcess(Action):
         self.__prefix = normalize_to_list_of_substitutions(
             LaunchConfiguration('launch-prefix', default='') if prefix is None else prefix
         )
-        self.__output = output if output is not None else 'log'
-        allowed_output_options = ['log', 'screen']
-        if self.__output not in allowed_output_options:
-            raise ValueError(
-                "output argument to ExecuteProcess is '{}', expected one of [{}]".format(
-                    self.__output,
-                    allowed_output_options,
-                )
-            )
+        self.__output = output
+
         self.__log_cmd = log_cmd
 
         self.__process_event_args = None  # type: Optional[Dict[Text, Any]]
@@ -248,19 +240,23 @@ class ExecuteProcess(Action):
             raise RuntimeError('Signal event received before subprocess transport available.')
         if self._subprocess_protocol.complete.done():
             # the process is done or is cleaning up, no need to signal
-            _logger.debug("signal '{}' not set to '{}' because it is already closing".format(
-                typed_event.signal_name, self.process_details['name']
-            ))
+            self.__logger.debug(
+                self.__name,
+                "signal '{}' not set to '{}' because it is already closing".format(
+                    typed_event.signal_name, self.process_details['name']),
+            )
             return None
         if platform.system() == 'Windows' and typed_event.signal_name == 'SIGINT':
             # TODO(wjwwood): remove this when/if SIGINT is fixed on Windows
-            _logger.warn(
+            self.__logger.warning(
+                self.__name,
                 "'SIGINT' sent to process[{}] not supported on Windows, escalating to 'SIGTERM'"
-                .format(self.process_details['name']))
+                    .format(self.process_details['name']),
+            )
             typed_event = SignalProcess(
                 signal_number=signal.SIGTERM,
                 process_matcher=lambda process: True)
-        _logger.info("sending signal '{}' to process[{}]".format(
+        self.__logger.info(self.__name, "sending signal '{}' to process[{}]".format(
             typed_event.signal_name, self.process_details['name']
         ))
         if typed_event.signal_name == 'SIGKILL':
@@ -274,7 +270,10 @@ class ExecuteProcess(Action):
         event: Event,
         context: LaunchContext
     ) -> Optional[LaunchDescription]:
-        _logger.warn("in ExecuteProcess('{}').__on_process_stdin_event()".format(id(self)))
+        self.__logger.warning(
+            self.__name,
+            "in ExecuteProcess('{}').__on_process_stdin_event()".format(id(self)),
+        )
         cast(ProcessStdin, event)
         return None
 
@@ -289,7 +288,7 @@ class ExecuteProcess(Action):
             "process[{}] failed to terminate '{}' seconds after receiving '{}', escalating to '{}'"
 
         def printer(context, msg, timeout_substitutions):
-            _logger.error(msg.format(
+            self.__logger.error(self.__name, msg.format(
                 context.locals.process_name,
                 perform_substitutions(context, timeout_substitutions),
             ))
@@ -352,12 +351,13 @@ class ExecuteProcess(Action):
             self.__context = context
             self.__action = action
             self.__process_event_args = process_event_args
+            self.__logger = LaunchLogger()
 
         def connection_made(self, transport):
-            _logger.info('process[{}]: started with pid [{}]'.format(
+            self.__logger.info(
                 self.__process_event_args['name'],
-                transport.get_pid(),
-            ))
+                'process started with pid [{}]'.format(transport.get_pid()),
+            )
             super().connection_made(transport)
             self.__process_event_args['pid'] = transport.get_pid()
             self.__action._subprocess_transport = transport
@@ -377,7 +377,7 @@ class ExecuteProcess(Action):
         with _global_process_counter_lock:
             global _global_process_counter
             _global_process_counter += 1
-            name = '{}-{}'.format(name, _global_process_counter)
+            self.__name = '{}-{}'.format(name, _global_process_counter)
         cwd = None
         if self.__cwd is not None:
             cwd = ''.join([context.perform_substitution(x) for x in self.__cwd])
@@ -391,7 +391,7 @@ class ExecuteProcess(Action):
         # store packed kwargs for all ProcessEvent based events
         self.__process_event_args = {
             'action': self,
-            'name': name,
+            'name': self.__name,
             'cmd': cmd,
             'cwd': cwd,
             'env': env,
@@ -407,8 +407,8 @@ class ExecuteProcess(Action):
         cwd = process_event_args['cwd']
         env = process_event_args['env']
         if self.__log_cmd:
-            _logger.info("process[{}] details: cmd=[{}], cwd='{}', custom_env?={}".format(
-                name, ', '.join(cmd), cwd, 'True' if env is not None else 'False'
+            self.__logger.info(name, "process details: cmd=[{}], cwd='{}', custom_env?={}".format(
+                ', '.join(cmd), cwd, 'True' if env is not None else 'False'
             ))
         try:
             transport, self._subprocess_protocol = await async_execute_process(
@@ -423,8 +423,7 @@ class ExecuteProcess(Action):
                 stderr_to_stdout=(self.__output == 'screen'),
             )
         except Exception:
-            _logger.error('exception occurred while executing process[{}]:\n{}'.format(
-                name,
+            self.__logger.error(name, 'exception occurred while executing process:\n{}'.format(
                 traceback.format_exc()
             ))
             self.__cleanup()
@@ -436,10 +435,10 @@ class ExecuteProcess(Action):
 
         returncode = await self._subprocess_protocol.complete
         if returncode == 0:
-            _logger.info('process[{}]: process has finished cleanly'.format(name, pid))
+            self.__logger.info(name, 'process has finished cleanly [pid {}]'.format(pid))
         else:
-            _logger.error("process[{}] process has died [pid {}, exit code {}, cmd '{}'].".format(
-                name, pid, returncode, ' '.join(cmd)
+            self.__logger.error(name, "process has died [pid {}, exit code {}, cmd '{}'].".format(
+                pid, returncode, ' '.join(cmd)
             ))
         await context.emit_event(ProcessExited(returncode=returncode, **process_event_args))
         self.__cleanup()
@@ -452,6 +451,7 @@ class ExecuteProcess(Action):
         - register an event handler for the shutdown process event
         - register an event handler for the signal process event
         - register an event handler for the stdin event
+        - configures logging for the IO process event
         - create a task for the coroutine that monitors the process
         """
         if self.__shutdown_received:
@@ -481,6 +481,8 @@ class ExecuteProcess(Action):
         try:
             self.__completed_future = create_future(context.asyncio_loop)
             self.__expand_substitutions(context)
+            self.__logger = LaunchLogger()
+            self.__logger.configure_logger(self.__name, self.__output)
             context.asyncio_loop.create_task(self.__execute_process(context))
         except Exception:
             for event_handler in event_handlers:

--- a/launch/launch/actions/log_info.py
+++ b/launch/launch/actions/log_info.py
@@ -19,7 +19,7 @@ from typing import overload
 from typing import Text
 from typing import Union
 
-from .. import logging
+import launch.logging
 
 from ..action import Action
 from ..launch_context import LaunchContext
@@ -45,7 +45,7 @@ class LogInfo(Action):
         super().__init__(**kwargs)
 
         self.__msg = normalize_to_list_of_substitutions(msg)
-        self.__logger = logging.getLogger(__name__)
+        self.__logger = launch.logging.getLogger(__name__)
 
     @property
     def msg(self) -> List[Substitution]:

--- a/launch/launch/actions/log_info.py
+++ b/launch/launch/actions/log_info.py
@@ -19,9 +19,10 @@ from typing import overload
 from typing import Text
 from typing import Union
 
+from .. import logging
+
 from ..action import Action
 from ..launch_context import LaunchContext
-from ..launch_logger import LaunchLogger
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
 
@@ -44,7 +45,7 @@ class LogInfo(Action):
         super().__init__(**kwargs)
 
         self.__msg = normalize_to_list_of_substitutions(msg)
-        self.__logger = LaunchLogger()
+        self.__logger = logging.getLogger(__name__)
 
     @property
     def msg(self) -> List[Substitution]:
@@ -54,7 +55,6 @@ class LogInfo(Action):
     def execute(self, context: LaunchContext) -> None:
         """Execute the action."""
         self.__logger.info(
-            __name__,
-            ''.join([context.perform_substitution(sub) for sub in self.msg]),
+            ''.join([context.perform_substitution(sub) for sub in self.msg])
         )
         return None

--- a/launch/launch/actions/log_info.py
+++ b/launch/launch/actions/log_info.py
@@ -14,7 +14,6 @@
 
 """Module for the LogInfo action."""
 
-import logging
 from typing import List
 from typing import overload
 from typing import Text
@@ -22,10 +21,9 @@ from typing import Union
 
 from ..action import Action
 from ..launch_context import LaunchContext
+from ..launch_logger import LaunchLogger
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
-
-_logger = logging.getLogger('launch.user')
 
 
 class LogInfo(Action):
@@ -46,6 +44,7 @@ class LogInfo(Action):
         super().__init__(**kwargs)
 
         self.__msg = normalize_to_list_of_substitutions(msg)
+        self.__logger = LaunchLogger()
 
     @property
     def msg(self) -> List[Substitution]:
@@ -54,5 +53,8 @@ class LogInfo(Action):
 
     def execute(self, context: LaunchContext) -> None:
         """Execute the action."""
-        _logger.info(''.join([context.perform_substitution(sub) for sub in self.msg]))
+        self.__logger.info(
+            __name__,
+            ''.join([context.perform_substitution(sub) for sub in self.msg]),
+        )
         return None

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -26,7 +26,7 @@ from typing import Text
 from typing import Tuple
 from typing import Union
 
-from .. import logging
+import launch.logging
 
 from ..action import Action
 from ..event_handler import EventHandler
@@ -73,7 +73,7 @@ class TimerAction(Action):
         self.__completed_future = None  # type: Optional[asyncio.Future]
         self.__canceled = False
         self.__canceled_future = None  # type: Optional[asyncio.Future]
-        self.__logger = logging.getLogger(__name__)
+        self.__logger = launch.logging.getLogger(__name__)
 
     async def __wait_to_fire_event(self, context):
         done, pending = await asyncio.wait(

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -15,8 +15,7 @@
 """Module for the TimerAction action."""
 
 import asyncio
-import collections.abc
-import logging
+import collections
 from typing import Any  # noqa: F401
 from typing import cast
 from typing import Dict  # noqa: F401
@@ -32,6 +31,7 @@ from ..event_handler import EventHandler
 from ..events import TimerEvent
 from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
+from ..launch_logger import LaunchLogger
 from ..some_actions_type import SomeActionsType
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..some_substitutions_type import SomeSubstitutionsType_types_tuple
@@ -42,7 +42,6 @@ from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
 
 _event_handler_has_been_installed = False
-_logger = logging.getLogger('launch.timer_action')
 
 
 class TimerAction(Action):
@@ -73,6 +72,7 @@ class TimerAction(Action):
         self.__completed_future = None  # type: Optional[asyncio.Future]
         self.__canceled = False
         self.__canceled_future = None  # type: Optional[asyncio.Future]
+        self.__logger = LaunchLogger()
 
     async def __wait_to_fire_event(self, context):
         done, pending = await asyncio.wait(
@@ -129,8 +129,9 @@ class TimerAction(Action):
 
         if self.__canceled:
             # In this case, the action was canceled before being executed.
-            _logger.debug(
-                'timer {} not waiting because it was canceled before being executed'.format(self)
+            self.__logger.debug(
+                __name__,
+                'timer {} not waiting because it was canceled before being executed'.format(self),
             )
             self.__completed_future.set_result(None)
             return None

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -26,12 +26,13 @@ from typing import Text
 from typing import Tuple
 from typing import Union
 
+from .. import logging
+
 from ..action import Action
 from ..event_handler import EventHandler
 from ..events import TimerEvent
 from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
-from ..launch_logger import LaunchLogger
 from ..some_actions_type import SomeActionsType
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..some_substitutions_type import SomeSubstitutionsType_types_tuple
@@ -72,7 +73,7 @@ class TimerAction(Action):
         self.__completed_future = None  # type: Optional[asyncio.Future]
         self.__canceled = False
         self.__canceled_future = None  # type: Optional[asyncio.Future]
-        self.__logger = LaunchLogger()
+        self.__logger = logging.getLogger(__name__)
 
     async def __wait_to_fire_event(self, context):
         done, pending = await asyncio.wait(
@@ -130,7 +131,6 @@ class TimerAction(Action):
         if self.__canceled:
             # In this case, the action was canceled before being executed.
             self.__logger.debug(
-                __name__,
                 'timer {} not waiting because it was canceled before being executed'.format(self),
             )
             self.__completed_future.set_result(None)

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -23,7 +23,7 @@ from typing import List  # noqa: F401
 from typing import Optional
 from typing import Text
 
-from . import logging
+import launch.logging
 
 from .event import Event
 from .event_handler import EventHandler
@@ -56,7 +56,7 @@ class LaunchContext:
         self.__is_shutdown = False
         self.__asyncio_loop = None  # type: Optional[asyncio.AbstractEventLoop]
 
-        self.__logger = logging.getLogger(__name__)
+        self.__logger = launch.logging.getLogger(__name__)
 
     @property
     def argv(self):

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -23,9 +23,10 @@ from typing import List  # noqa: F401
 from typing import Optional
 from typing import Text
 
+from . import logging
+
 from .event import Event
 from .event_handler import EventHandler
-from .launch_logger import LaunchLogger
 from .substitution import Substitution
 
 
@@ -55,7 +56,7 @@ class LaunchContext:
         self.__is_shutdown = False
         self.__asyncio_loop = None  # type: Optional[asyncio.AbstractEventLoop]
 
-        self.__logger = LaunchLogger()
+        self.__logger = logging.getLogger(__name__)
 
     @property
     def argv(self):
@@ -166,12 +167,12 @@ class LaunchContext:
 
     def emit_event_sync(self, event: Event) -> None:
         """Emit an event synchronously."""
-        self.__logger.debug(__name__, "emitting event synchronously: '{}'".format(event.name))
+        self.__logger.debug("emitting event synchronously: '{}'".format(event.name))
         self._event_queue.put_nowait(event)
 
     async def emit_event(self, event: Event) -> None:
         """Emit an event."""
-        self.__logger.debug(__name__, "emitting event: '{}'".format(event.name))
+        self.__logger.debug("emitting event: '{}'".format(event.name))
         await self._event_queue.put(event)
 
     def perform_substitution(self, substitution: Substitution) -> Text:

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import collections
-import logging
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -26,9 +25,8 @@ from typing import Text
 
 from .event import Event
 from .event_handler import EventHandler
+from .launch_logger import LaunchLogger
 from .substitution import Substitution
-
-_logger = logging.getLogger(name='launch')
 
 
 class LaunchContext:
@@ -56,6 +54,8 @@ class LaunchContext:
 
         self.__is_shutdown = False
         self.__asyncio_loop = None  # type: Optional[asyncio.AbstractEventLoop]
+
+        self.__logger = LaunchLogger()
 
     @property
     def argv(self):
@@ -166,12 +166,12 @@ class LaunchContext:
 
     def emit_event_sync(self, event: Event) -> None:
         """Emit an event synchronously."""
-        _logger.debug("emitting event synchronously: '{}'".format(event.name))
+        self.__logger.debug(__name__, "emitting event synchronously: '{}'".format(event.name))
         self._event_queue.put_nowait(event)
 
     async def emit_event(self, event: Event) -> None:
         """Emit an event."""
-        _logger.debug("emitting event: '{}'".format(event.name))
+        self.__logger.debug(__name__, "emitting event: '{}'".format(event.name))
         await self._event_queue.put(event)
 
     def perform_substitution(self, substitution: Substitution) -> Text:

--- a/launch/launch/launch_description_sources/python_launch_description_source.py
+++ b/launch/launch/launch_description_sources/python_launch_description_source.py
@@ -14,7 +14,6 @@
 
 """Module for the PythonLaunchDescriptionSource class."""
 
-import logging
 import traceback
 from typing import Optional
 from typing import Text  # noqa: F401
@@ -22,11 +21,10 @@ from typing import Text  # noqa: F401
 from .python_launch_file_utilities import get_launch_description_from_python_launch_file
 from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
+from ..launch_logger import LaunchLogger
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
-
-_logger = logging.getLogger('launch.launch_description_sources.PythonLaunchDescriptionSource')
 
 
 class PythonLaunchDescriptionSource:
@@ -53,6 +51,7 @@ class PythonLaunchDescriptionSource:
         self.__launch_file_path = normalize_to_list_of_substitutions(launch_file_path)
         self.__expanded_launch_file_path = None  # type: Optional[Text]
         self.__launch_description = None  # type: Optional[LaunchDescription]
+        self.__logger = LaunchLogger()
 
     def try_get_launch_description_without_context(self) -> Optional[LaunchDescription]:
         """Get the LaunchDescription, attempting to load it if necessary."""
@@ -64,8 +63,11 @@ class PythonLaunchDescriptionSource:
                     perform_substitutions(context, self.__launch_file_path)
                 return get_launch_description_from_python_launch_file(expanded_launch_file_path)
             except Exception as exc:
-                _logger.debug(traceback.format_exc())
-                _logger.debug('Failed to load the launch file without a context: ' + str(exc))
+                self.__logger.debug(__name__, traceback.format_exc())
+                self.__logger.debug(
+                    __name__,
+                    'Failed to load the launch file without a context: ' + str(exc),
+                )
         return self.__launch_description
 
     def get_launch_description(self, context: LaunchContext) -> LaunchDescription:

--- a/launch/launch/launch_description_sources/python_launch_description_source.py
+++ b/launch/launch/launch_description_sources/python_launch_description_source.py
@@ -19,9 +19,10 @@ from typing import Optional
 from typing import Text  # noqa: F401
 
 from .python_launch_file_utilities import get_launch_description_from_python_launch_file
+
+from .. import logging
 from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
-from ..launch_logger import LaunchLogger
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
@@ -51,7 +52,7 @@ class PythonLaunchDescriptionSource:
         self.__launch_file_path = normalize_to_list_of_substitutions(launch_file_path)
         self.__expanded_launch_file_path = None  # type: Optional[Text]
         self.__launch_description = None  # type: Optional[LaunchDescription]
-        self.__logger = LaunchLogger()
+        self.__logger = logging.getLogger(__name__)
 
     def try_get_launch_description_without_context(self) -> Optional[LaunchDescription]:
         """Get the LaunchDescription, attempting to load it if necessary."""
@@ -63,9 +64,8 @@ class PythonLaunchDescriptionSource:
                     perform_substitutions(context, self.__launch_file_path)
                 return get_launch_description_from_python_launch_file(expanded_launch_file_path)
             except Exception as exc:
-                self.__logger.debug(__name__, traceback.format_exc())
+                self.__logger.debug(traceback.format_exc())
                 self.__logger.debug(
-                    __name__,
                     'Failed to load the launch file without a context: ' + str(exc),
                 )
         return self.__launch_description

--- a/launch/launch/launch_description_sources/python_launch_description_source.py
+++ b/launch/launch/launch_description_sources/python_launch_description_source.py
@@ -18,9 +18,10 @@ import traceback
 from typing import Optional
 from typing import Text  # noqa: F401
 
+import launch.logging
+
 from .python_launch_file_utilities import get_launch_description_from_python_launch_file
 
-from .. import logging
 from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
 from ..some_substitutions_type import SomeSubstitutionsType
@@ -52,7 +53,7 @@ class PythonLaunchDescriptionSource:
         self.__launch_file_path = normalize_to_list_of_substitutions(launch_file_path)
         self.__expanded_launch_file_path = None  # type: Optional[Text]
         self.__launch_description = None  # type: Optional[LaunchDescription]
-        self.__logger = logging.getLogger(__name__)
+        self.__logger = launch.logging.getLogger(__name__)
 
     def try_get_launch_description_without_context(self) -> Optional[LaunchDescription]:
         """Get the LaunchDescription, attempting to load it if necessary."""

--- a/launch/launch/launch_introspector.py
+++ b/launch/launch/launch_introspector.py
@@ -14,7 +14,6 @@
 
 """Module for the LaunchIntrospector class."""
 
-import logging
 from typing import cast
 from typing import List
 from typing import Text
@@ -30,8 +29,6 @@ from .launch_description_entity import LaunchDescriptionEntity
 from .some_substitutions_type import SomeSubstitutionsType
 from .utilities import is_a
 from .utilities import normalize_to_list_of_substitutions
-
-_logger = logging.getLogger(name='launch')
 
 
 def indent(lines: List[Text], indention: Text = '    ') -> List[Text]:

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -368,9 +368,6 @@ class LaunchService:
             on_sigterm(None)
             on_sigquit(None)
 
-            # Flush the logging buffer
-            logging.reset()
-
             with self.__running_lock:
                 self.__running = False
 

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -14,18 +14,17 @@
 
 """Module for the signal management functionality."""
 
-import logging
 import platform
 import signal
 import threading
+
+from ..launch_logger import LaunchLogger
 
 __signal_handlers_installed_lock = threading.Lock()
 __signal_handlers_installed = False
 __custom_sigint_handler = None
 __custom_sigquit_handler = None
 __custom_sigterm_handler = None
-
-_logger = logging.getLogger('launch.utilities.signal_management')
 
 
 def on_sigint(handler):
@@ -143,6 +142,10 @@ def install_signal_handlers():
             # Windows does not support SIGQUIT
             signal.signal(signal.SIGQUIT, __on_sigquit)
     except ValueError:
-        _logger.error("failed to set signal handlers in 'launch.utilities.signal_management.py'")
-        _logger.error('this function must be called in the main thread')
+        logger = LaunchLogger()
+        logger.error(
+            __name__,
+            "failed to set signal handlers in 'launch.utilities.signal_management.py'",
+        )
+        logger.error(__name__, 'this function must be called in the main thread')
         raise

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -18,7 +18,7 @@ import platform
 import signal
 import threading
 
-from ..launch_logger import LaunchLogger
+from .. import logging
 
 __signal_handlers_installed_lock = threading.Lock()
 __signal_handlers_installed = False
@@ -142,10 +142,9 @@ def install_signal_handlers():
             # Windows does not support SIGQUIT
             signal.signal(signal.SIGQUIT, __on_sigquit)
     except ValueError:
-        logger = LaunchLogger()
+        logger = logging.getLogger(__name__)
         logger.error(
-            __name__,
             "failed to set signal handlers in 'launch.utilities.signal_management.py'",
         )
-        logger.error(__name__, 'this function must be called in the main thread')
+        logger.error('this function must be called in the main thread')
         raise

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -18,7 +18,7 @@ import platform
 import signal
 import threading
 
-from .. import logging
+import launch.logging
 
 __signal_handlers_installed_lock = threading.Lock()
 __signal_handlers_installed = False
@@ -142,9 +142,7 @@ def install_signal_handlers():
             # Windows does not support SIGQUIT
             signal.signal(signal.SIGQUIT, __on_sigquit)
     except ValueError:
-        logger = logging.getLogger(__name__)
-        logger.error(
-            "failed to set signal handlers in 'launch.utilities.signal_management.py'",
-        )
+        logger = launch.logging.getLogger(__name__)
+        logger.error("failed to set signal handlers in '{}'".format(__name__))
         logger.error('this function must be called in the main thread')
         raise

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -15,7 +15,6 @@
 """Module for the LifecycleNode action."""
 
 import functools
-import logging
 from typing import cast
 from typing import List
 from typing import Optional
@@ -23,6 +22,7 @@ from typing import Text
 
 import launch
 from launch.action import Action
+from launch.launch_logger import LaunchLogger
 
 import lifecycle_msgs.msg
 import lifecycle_msgs.srv
@@ -30,8 +30,6 @@ import lifecycle_msgs.srv
 from .node import Node
 from ..events.lifecycle import ChangeState
 from ..events.lifecycle import StateTransition
-
-_logger = logging.getLogger(name='launch_ros')
 
 
 class LifecycleNode(Node):
@@ -62,6 +60,7 @@ class LifecycleNode(Node):
             to change state, see its documentation for more details.
         """
         super().__init__(node_name=node_name, **kwargs)
+        self.__logger = LaunchLogger()
         self.__rclpy_subscription = None
         self.__current_state = \
             ChangeState.valid_states[lifecycle_msgs.msg.State.PRIMARY_STATE_UNKNOWN]
@@ -72,21 +71,28 @@ class LifecycleNode(Node):
             self.__current_state = ChangeState.valid_states[msg.goal_state.id]
             context.asyncio_loop.call_soon_threadsafe(lambda: context.emit_event_sync(event))
         except Exception as exc:
-            _logger.error(
+            self.__logger.error(
+                __name__,
                 "Exception in handling of 'lifecycle.msg.TransitionEvent': {}".format(exc))
 
     def _call_change_state(self, request, context: launch.LaunchContext):
         while not self.__rclpy_change_state_client.wait_for_service(timeout_sec=1.0):
             if context.is_shutdown:
-                _logger.warn("Abandoning wait for the '{}' service, due to shutdown.".format(
-                    self.__rclpy_change_state_client.srv_name))
+                self.___logger.warning(
+                    __name__,
+                    "Abandoning wait for the '{}' service, due to shutdown.".format(
+                        self.__rclpy_change_state_client.srv_name),
+                )
                 return
         response = self.__rclpy_change_state_client.call(request)
         if not response.success:
-            _logger.error("Failed to make transition '{}' for LifecycleNode '{}'".format(
-                ChangeState.valid_transitions[request.transition.id],
-                self.node_name,
-            ))
+            self.__logger.error(
+                __name__,
+                "Failed to make transition '{}' for LifecycleNode '{}'".format(
+                    ChangeState.valid_transitions[request.transition.id],
+                    self.node_name,
+                )
+            )
 
     def _on_change_state_event(self, context: launch.LaunchContext) -> None:
         typed_event = cast(ChangeState, context.locals.event)

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -22,7 +22,7 @@ from typing import Text
 
 import launch
 from launch.action import Action
-from launch.launch_logger import LaunchLogger
+import launch.logging
 
 import lifecycle_msgs.msg
 import lifecycle_msgs.srv
@@ -60,7 +60,7 @@ class LifecycleNode(Node):
             to change state, see its documentation for more details.
         """
         super().__init__(node_name=node_name, **kwargs)
-        self.__logger = LaunchLogger()
+        self.__logger = launch.logging.getLogger(__name__)
         self.__rclpy_subscription = None
         self.__current_state = \
             ChangeState.valid_states[lifecycle_msgs.msg.State.PRIMARY_STATE_UNKNOWN]
@@ -72,14 +72,12 @@ class LifecycleNode(Node):
             context.asyncio_loop.call_soon_threadsafe(lambda: context.emit_event_sync(event))
         except Exception as exc:
             self.__logger.error(
-                __name__,
                 "Exception in handling of 'lifecycle.msg.TransitionEvent': {}".format(exc))
 
     def _call_change_state(self, request, context: launch.LaunchContext):
         while not self.__rclpy_change_state_client.wait_for_service(timeout_sec=1.0):
             if context.is_shutdown:
                 self.___logger.warning(
-                    __name__,
                     "Abandoning wait for the '{}' service, due to shutdown.".format(
                         self.__rclpy_change_state_client.srv_name),
                 )
@@ -87,7 +85,6 @@ class LifecycleNode(Node):
         response = self.__rclpy_change_state_client.call(request)
         if not response.success:
             self.__logger.error(
-                __name__,
                 "Failed to make transition '{}' for LifecycleNode '{}'".format(
                     ChangeState.valid_transitions[request.transition.id],
                     self.node_name,

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -28,7 +28,9 @@ from launch import Substitution
 from launch.action import Action
 from launch.actions import ExecuteProcess
 from launch.launch_context import LaunchContext
-from launch.launch_logger import LaunchLogger
+
+import launch.logging
+
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
 from launch.substitutions import LocalSubstitution
@@ -173,7 +175,7 @@ class Node(ExecuteProcess):
 
         self.__substitutions_performed = False
 
-        self.__logger = LaunchLogger()
+        self.__logger = launch.logging.getLogger(__name__)
 
     @property
     def node_name(self):
@@ -265,7 +267,6 @@ class Node(ExecuteProcess):
             validate_namespace(self.__expanded_node_namespace)
         except Exception:
             self.__logger.error(
-                __name__,
                 "Error while expanding or validating node name or namespace for '{}':"
                 .format('package={}, node_executable={}, name={}, namespace={}'.format(
                     self.__package,
@@ -293,7 +294,6 @@ class Node(ExecuteProcess):
                             context, normalize_to_list_of_substitutions(params))
                 if not os.path.isfile(param_file_path):
                     self.__logger.warning(
-                        __name__,
                         'Parameter file path is not a file: {}'.format(param_file_path),
                     )
                     # Don't skip adding the file to the parameter list since space has been

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -14,7 +14,6 @@
 
 """Module for the Node action."""
 
-import logging
 import os
 import pathlib
 from tempfile import NamedTemporaryFile
@@ -29,6 +28,7 @@ from launch import Substitution
 from launch.action import Action
 from launch.actions import ExecuteProcess
 from launch.launch_context import LaunchContext
+from launch.launch_logger import LaunchLogger
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
 from launch.substitutions import LocalSubstitution
@@ -42,8 +42,6 @@ from rclpy.validate_namespace import validate_namespace
 from rclpy.validate_node_name import validate_node_name
 
 import yaml
-
-_logger = logging.getLogger(name='launch_ros')
 
 
 class Node(ExecuteProcess):
@@ -175,6 +173,8 @@ class Node(ExecuteProcess):
 
         self.__substitutions_performed = False
 
+        self.__logger = LaunchLogger()
+
     @property
     def node_name(self):
         """Getter for node_name."""
@@ -264,7 +264,8 @@ class Node(ExecuteProcess):
                 self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
             validate_namespace(self.__expanded_node_namespace)
         except Exception:
-            _logger.error(
+            self.__logger.error(
+                __name__,
                 "Error while expanding or validating node name or namespace for '{}':"
                 .format('package={}, node_executable={}, name={}, namespace={}'.format(
                     self.__package,
@@ -291,8 +292,10 @@ class Node(ExecuteProcess):
                         param_file_path = perform_substitutions(
                             context, normalize_to_list_of_substitutions(params))
                 if not os.path.isfile(param_file_path):
-                    _logger.warn(
-                        'Parameter file path is not a file: {}'.format(param_file_path))
+                    self.__logger.warning(
+                        __name__,
+                        'Parameter file path is not a file: {}'.format(param_file_path),
+                    )
                     # Don't skip adding the file to the parameter list since space has been
                     # reserved for it in the ros_specific_arguments.
                 self.__expanded_parameter_files.append(param_file_path)


### PR DESCRIPTION
Mostly find/replacing instances of Python's `logging` module with `LaunchLogger`. The key parts are:

execute_process.py, a logger is configured based on the supplied `output` arg:

https://github.com/ros2/launch/blob/d83812b3245d6eee701468ea4e7312f3a7b1d60c/launch/launch/actions/execute_process.py#L484-L485

launch_service.py, the callback is registered for the `OnProcessIO` event:

https://github.com/ros2/launch/blob/d83812b3245d6eee701468ea4e7312f3a7b1d60c/launch/launch/launch_service.py#L106-L111

---

Here's an example launch file where the talker node outputs to 'screen' and the listener node outputs to 'log' (might be nice to add an OpaqueFunction or something outputing plain stdout/stderr to 'both' for completeness):

```python
"""Launch a talker and a listener."""

import os
import sys

from launch import LaunchDescription
from launch import LaunchIntrospector
from launch import LaunchService

from launch_ros import get_default_launch_description
import launch_ros.actions


def generate_launch_description():
    ld = LaunchDescription([
        launch_ros.actions.Node(
            package='demo_nodes_cpp', node_executable='talker', output='screen',
            remappings=[('chatter', 'my_chatter')]),
        launch_ros.actions.Node(
            package='demo_nodes_cpp', node_executable='listener', output='log',
            remappings=[('chatter', 'my_chatter')]),
        ])

    print('Starting introspection of launch description...\n')

    print(LaunchIntrospector().format_launch_description(ld))

    return ld
```

Screen output:

```sh
Starting introspection of launch description...

<launch.launch_description.LaunchDescription object at 0x7fd7e8847c50>
├── ExecuteProcess(cmd=[ExecInPkg(pkg='demo_nodes_cpp', exec='talker'), LocalVar('remapping 1')], cwd=None, env=None, shell=False)
└── ExecuteProcess(cmd=[ExecInPkg(pkg='demo_nodes_cpp', exec='listener'), LocalVar('remapping 1')], cwd=None, env=None, shell=False)
1539131114.2102978 [INFO] [talker-1] process started with pid [23422]
1539131115.2265387 [INFO] [talker-1] [INFO] [talker]: Publishing: 'Hello World: 1'
1539131116.2265813 [INFO] [talker-1] [INFO] [talker]: Publishing: 'Hello World: 2'
1539131117.2271516 [INFO] [talker-1] [INFO] [talker]: Publishing: 'Hello World: 3'
1539131118.2269557 [INFO] [talker-1] [INFO] [talker]: Publishing: 'Hello World: 4'
1539131119.2268794 [INFO] [talker-1] [INFO] [talker]: Publishing: 'Hello World: 5'
^Cuser interrupted with ctrl-c (SIGINT)
1539131120.2120588 [INFO] [talker-1] signal_handler(2)
1539131120.2136695 [INFO] [talker-1] process has finished cleanly [pid 23422]
```

Log contents (located in `~/.ros/log`):

```sh
1539131114.210665 [INFO] [listener-2] process started with pid [23423]
1539131115.2269616 [INFO] [listener-2] [INFO] [listener]: I heard: [Hello World: 1]
1539131116.227143 [INFO] [listener-2] [INFO] [listener]: I heard: [Hello World: 2]
1539131117.2280726 [INFO] [listener-2] [INFO] [listener]: I heard: [Hello World: 3]
1539131118.2277687 [INFO] [listener-2] [INFO] [listener]: I heard: [Hello World: 4]
1539131119.2276838 [INFO] [listener-2] [INFO] [listener]: I heard: [Hello World: 5]
1539131120.213369 [INFO] [listener-2] signal_handler(2)
1539131120.213953 [INFO] [listener-2] process has finished cleanly [pid 23423]
```