### PR TITLE
always use shell to avoid inconsistency of time being a shell command or executable

### DIFF
--- a/launch/examples/launch_counters.py
+++ b/launch/examples/launch_counters.py
@@ -71,7 +71,7 @@ def main(argv=sys.argv[1:]):
         whoami_cmd = [launch.substitutions.FindExecutable(name='whoami')]
     whoami_action = launch.actions.ExecuteProcess(
         cmd=whoami_cmd,
-        shell=(platform.system() == 'Windows')
+        shell=True
     )
     ld.add_action(whoami_action)
     # Make event handler that uses the output.


### PR DESCRIPTION
fixes #149 