### PR TITLE
Fix lint warnings from invalid escape sequences

### DIFF
--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -32,7 +32,7 @@ def test_matching():
     output_file = tempdir + os.sep + 'testfile'
     full_output_file = output_file + '.regex'
     with open(full_output_file, 'w+') as f:
-        f.write('this is line \d\nthis is line [a-z]')
+        f.write(r'this is line \d\nthis is line [a-z]')
 
     name = 'test_executable_0'
 


### PR DESCRIPTION
Use raw strings for regex patterns to avoid warnings.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5348)](http://ci.ros2.org/job/ci_linux/5348/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2078)](http://ci.ros2.org/job/ci_linux-aarch64/2078/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4441)](http://ci.ros2.org/job/ci_osx/4441/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5311)](http://ci.ros2.org/job/ci_windows/5311/)