### PR TITLE
rename transitions as lifecycle_msgs changed

### DIFF
--- a/launch_ros/launch_ros/events/lifecycle/change_state.py
+++ b/launch_ros/launch_ros/events/lifecycle/change_state.py
@@ -36,7 +36,15 @@ class ChangeState(Event):
         (lifecycle_msgs.msg.Transition.TRANSITION_CLEANUP, 'TRANSITION_CLEANUP'),
         (lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE, 'TRANSITION_ACTIVATE'),
         (lifecycle_msgs.msg.Transition.TRANSITION_DEACTIVATE, 'TRANSITION_DEACTIVATE'),
-        (lifecycle_msgs.msg.Transition.TRANSITION_SHUTDOWN, 'TRANSITION_SHUTDOWN'),
+        (
+            lifecycle_msgs.msg.Transition.TRANSITION_UNCONFIGURED_SHUTDOWN,
+            'TRANSITION_UNCONFIGURED_SHUTDOWN',
+        ),
+        (
+            lifecycle_msgs.msg.Transition.TRANSITION_INACTIVE_SHUTDOWN,
+            'TRANSITION_INACTIVE_SHUTDOWN',
+        ),
+        (lifecycle_msgs.msg.Transition.TRANSITION_ACTIVE_SHUTDOWN, 'TRANSITION_ACTIVE_SHUTDOWN'),
         (lifecycle_msgs.msg.Transition.TRANSITION_DESTROY, 'TRANSITION_DESTROY'),
     ])
     valid_states = collections.OrderedDict([


### PR DESCRIPTION
TRANSITION_SHUTDOWN is delated in lifecycle_msgs/msg/Transition.msg

Align with the code changes from https://github.com/ros2/rcl_interfaces/commit/852a37ba3ae0f7e58f4314fa432a8ea7f0cbf639

Signed-off-by: Chris Ye <chris.ye@intel.com>

To fix https://github.com/ros2/launch/issues/152