### PR TITLE
Ensure that shutdown event is handled correctly

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -208,7 +208,9 @@ class LaunchService:
             # Check if we're idle, i.e. no on-going entities (actions) or events in the queue
             is_idle = self._is_idle()  # self._entity_future_pairs is pruned here
             if not self.__shutting_down and self.__shutdown_when_idle and is_idle:
-                self._shutdown(reason='idle', due_to_sigint=False)
+                coroutine = self._shutdown(reason='idle', due_to_sigint=False)
+                await coroutine
+                continue
 
             if self.__loop_from_run_thread is None:
                 raise RuntimeError('__loop_from_run_thread unexpectedly None')
@@ -297,7 +299,8 @@ class LaunchService:
                 base_msg = 'user interrupted with ctrl-c (SIGINT)'
                 if not sigint_received:
                     _logger.warn(base_msg)
-                    self._shutdown(reason='ctrl-c (SIGINT)', due_to_sigint=True)
+                    ret = self._shutdown(reason='ctrl-c (SIGINT)', due_to_sigint=True)
+                    assert(ret is None)
                     sigint_received = True
                 else:
                     _logger.warn('{} again, ignoring...'.format(base_msg))
@@ -347,7 +350,8 @@ class LaunchService:
                     _logger.debug(traceback.format_exc())
                     _logger.error(msg)
                     self.__return_code = 1
-                    self._shutdown(reason=msg, due_to_sigint=False)
+                    ret = self._shutdown(reason=msg, due_to_sigint=False)
+                    assert(ret is None)
                     # restart run loop to let it shutdown properly
                     run_loop_task = self.__loop_from_run_thread.create_task(self.__run_loop())
         finally:
@@ -373,6 +377,7 @@ class LaunchService:
 
     def _shutdown(self, *, reason, due_to_sigint):
         # Assumption is that this method is only called when running.
+        retval = None
         if not self.__shutting_down:
             shutdown_event = Shutdown(reason=reason, due_to_sigint=due_to_sigint)
             asyncio_event_loop = None
@@ -384,12 +389,13 @@ class LaunchService:
                 pass
             if self.__loop_from_run_thread == asyncio_event_loop:
                 # If in the thread of the loop.
-                self.__loop_from_run_thread.create_task(self.__context.emit_event(shutdown_event))
+                retval = self.__context.emit_event(shutdown_event)
             else:
                 # Otherwise in a different thread, so use the thread-safe method.
                 self.emit_event(shutdown_event)
         self.__shutting_down = True
         self.__context._set_is_shutdown(True)
+        return retval
 
     def shutdown(self) -> None:
         """
@@ -403,4 +409,5 @@ class LaunchService:
         """
         with self.__loop_from_run_thread_lock:
             if self.__loop_from_run_thread is not None:
-                self._shutdown(reason='LaunchService.shutdown() called', due_to_sigint=False)
+                ret = self._shutdown(reason='LaunchService.shutdown() called', due_to_sigint=False)
+                assert(ret is None)

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -57,7 +57,7 @@ class TestNode(unittest.TestCase):
     def test_launch_invalid_node(self):
         """Test launching an invalid node."""
         node_action = launch_ros.actions.Node(
-            package='nonexistent_package', node_executable='node', output='screen'),
+            package='nonexistent_package', node_executable='node', output='screen')
         self._assert_launch_errors([node_action])
 
     def test_launch_node(self):


### PR DESCRIPTION
There is a potential race condition in bewteen when the shutdown event
is emitted and the rest of the shutdown handling code.  This introduces
an additional await to ensure that the event is emitted before
proceeding.