### PR TITLE
signit executes the shutdown event synchronously

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -299,7 +299,7 @@ class LaunchService:
                 base_msg = 'user interrupted with ctrl-c (SIGINT)'
                 if not sigint_received:
                     _logger.warn(base_msg)
-                    ret = self._shutdown(reason='ctrl-c (SIGINT)', due_to_sigint=True)
+                    ret = self._shutdown(reason='ctrl-c (SIGINT)', due_to_sigint=True, force_sync=True)
                     assert ret is None, ret
                     sigint_received = True
                 else:


### PR DESCRIPTION
Recently my launch scripts have been hanging on signint (control-c).
After a little digging it seems to exist since https://github.com/ros2/launch/pull/154 .

Having the signint-triggered shutdown event execute synchronously fixes the hanging.
This makes sense to me, although I admit my understanding of Python's async is rather limited. 