### PR TITLE
fix deprecation warning related to collections.abc

### DIFF
--- a/launch/launch/actions/opaque_function.py
+++ b/launch/launch/actions/opaque_function.py
@@ -14,7 +14,7 @@
 
 """Module for the OpaqueFunction action."""
 
-import collections
+import collections.abc
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -58,7 +58,8 @@ class OpaqueFunction(Action):
             raise TypeError("OpaqueFunction expected a callable for 'function', got '{}'".format(
                 type(function)
             ))
-        ensure_argument_type(args, (collections.Iterable, type(None)), 'args', 'OpaqueFunction')
+        ensure_argument_type(
+            args, (collections.abc.Iterable, type(None)), 'args', 'OpaqueFunction')
         ensure_argument_type(kwargs, (dict, type(None)), 'kwargs', 'OpaqueFunction')
         self.__function = function
         self.__args = []  # type: Iterable

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -15,7 +15,7 @@
 """Module for the TimerAction action."""
 
 import asyncio
-import collections
+import collections.abc
 import logging
 from typing import Any  # noqa: F401
 from typing import cast
@@ -63,7 +63,7 @@ class TimerAction(Action):
         super().__init__(**kwargs)
         period_types = list(SomeSubstitutionsType_types_tuple) + [float]
         ensure_argument_type(period, period_types, 'period', 'TimerAction')
-        ensure_argument_type(actions, collections.Iterable, 'actions', 'TimerAction')
+        ensure_argument_type(actions, collections.abc.Iterable, 'actions', 'TimerAction')
         if isinstance(period, float):
             self.__period = normalize_to_list_of_substitutions([str(period)])
         else:

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -14,9 +14,10 @@
 
 """Module for OnProcessExit class."""
 
-import collections
+import collections.abc
 from typing import Callable
 from typing import cast
+from typing import List  # noqa
 from typing import Optional
 from typing import overload
 from typing import Text
@@ -92,7 +93,7 @@ class OnProcessExit(EventHandler):
             pass
         else:
             # Otherwise, setup self.__actions_on_exit
-            if isinstance(on_exit, collections.Iterable):
+            if isinstance(on_exit, collections.abc.Iterable):
                 for entity in on_exit:
                     if not isinstance(entity, LaunchDescriptionEntity):
                         raise ValueError(

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -16,7 +16,7 @@
 
 import asyncio
 import atexit
-import collections
+import collections.abc
 import logging
 import signal
 import threading
@@ -186,7 +186,8 @@ class LaunchService:
                     "processing event: '{}' ✓ '{}'".format(event, event_handler))
                 self.__context._push_locals()
                 entities = event_handler.handle(event, self.__context)
-                entities = entities if isinstance(entities, collections.Iterable) else (entities,)
+                entities = \
+                    entities if isinstance(entities, collections.abc.Iterable) else (entities,)
                 for entity in [e for e in entities if e is not None]:
                     from .utilities import is_a_subclass
                     if not is_a_subclass(entity, LaunchDescriptionEntity):

--- a/launch/launch/some_actions_type.py
+++ b/launch/launch/some_actions_type.py
@@ -14,7 +14,7 @@
 
 """Module for SomeActionsType type."""
 
-import collections
+import collections.abc
 from typing import Iterable
 from typing import Union
 
@@ -28,5 +28,5 @@ SomeActionsType = Union[
 
 SomeActionsType_types_tuple = (
     LaunchDescriptionEntity,
-    collections.Iterable,
+    collections.abc.Iterable,
 )

--- a/launch/launch/some_substitutions_type.py
+++ b/launch/launch/some_substitutions_type.py
@@ -14,7 +14,7 @@
 
 """Module for SomeSubstitutionsType type."""
 
-import collections
+import collections.abc
 from typing import Iterable
 from typing import Text
 from typing import Union
@@ -30,5 +30,5 @@ SomeSubstitutionsType = Union[
 SomeSubstitutionsType_types_tuple = (
     str,
     Substitution,
-    collections.Iterable,
+    collections.abc.Iterable,
 )

--- a/launch/launch/substitutions/launch_configuration.py
+++ b/launch/launch/substitutions/launch_configuration.py
@@ -14,7 +14,7 @@
 
 """Module for the LaunchConfiguration substitution."""
 
-import collections
+import collections.abc
 from typing import Any
 from typing import Iterable
 from typing import List
@@ -51,7 +51,7 @@ class LaunchConfiguration(Substitution):
             # convert any items in default that are not a Substitution or str to a str
             str_normalized_default = []  # type: List[Union[Text, Substitution]]
             definitely_iterable_default = ((),)  # type: Iterable[Any]
-            if isinstance(default, collections.Iterable):
+            if isinstance(default, collections.abc.Iterable):
                 definitely_iterable_default = default
             else:
                 definitely_iterable_default = (default,)

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -14,7 +14,7 @@
 
 """Module for the PythonExpression substitution."""
 
-import collections
+import collections.abc
 from typing import List
 from typing import Text
 
@@ -38,7 +38,7 @@ class PythonExpression(Substitution):
 
         ensure_argument_type(
             expression,
-            (str, Substitution, collections.Iterable),
+            (str, Substitution, collections.abc.Iterable),
             'expression',
             'PythonExpression')
 

--- a/launch/launch/utilities/ensure_argument_type_impl.py
+++ b/launch/launch/utilities/ensure_argument_type_impl.py
@@ -14,7 +14,7 @@
 
 """Module for the ensure_argument_type() utility function."""
 
-import collections
+import collections.abc
 import inspect
 from typing import Any
 from typing import Iterable
@@ -36,11 +36,11 @@ def ensure_argument_type(
     The caller is included in the error message if given and not None.
     """
     error_msg_template = "{}xpected '{}' to be one of [{}], but got '{}' of type '{}'"
-    if not isinstance(types, collections.Iterable) and not isinstance(types, type):
+    if not isinstance(types, collections.abc.Iterable) and not isinstance(types, type):
         raise TypeError(error_msg_template.format(
             "'ensure_argument_type()' e",
             'types',
-            'type, collections.Iterable of type',
+            'type, collections.abc.Iterable of type',
             types,
             type(types),
         ))
@@ -68,7 +68,7 @@ def ensure_argument_type(
             result |= issubclass(argument.__class__, type_var)
         return result
 
-    list_of_types = types if isinstance(types, collections.Iterable) else [types]
+    list_of_types = types if isinstance(types, collections.abc.Iterable) else [types]
     if not any(check_argument(argument, type_var) for type_var in list_of_types):
         raise TypeError(error_msg_template.format(
             'E' if caller is None else "'{}' e".format(caller),

--- a/launch/test/launch/test_launch_description.py
+++ b/launch/test/launch/test_launch_description.py
@@ -14,7 +14,7 @@
 
 """Tests for the LaunchDescription class."""
 
-import collections
+import collections.abc
 import logging
 import os
 
@@ -103,6 +103,6 @@ def test_launch_description_visit():
         ...
 
     result = ld.visit(MockLaunchContext())
-    assert isinstance(result, collections.Iterable)
+    assert isinstance(result, collections.abc.Iterable)
     for entity in result:
         assert isinstance(entity, LaunchDescriptionEntity)


### PR DESCRIPTION
I found this while investigating unrelated changes in this job (https://ci.ros2.org/job/ci_windows/5784/consoleFull):

```
00:05:11 175: ============================== warnings summary ===============================
00:05:11 175: C:\J\workspace\ci_windows\ws\install\Lib\site-packages\launch\some_actions_type.py:31
00:05:11 175:   C:\J\workspace\ci_windows\ws\install\Lib\site-packages\launch\some_actions_type.py:31: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
00:05:11 175:     collections.Iterable,
00:05:11 175: 
00:05:11 175: -- Docs: https://docs.pytest.org/en/latest/warnings.html
00:05:11 175:  generated xml file: C:\J\workspace\ci_windows\ws\build\test_communication\test_results\test_communication\test_publisher_subscriber__DynamicArrayPrimitivesNested__rclpy__rmw_fastrtps_cpp__rmw_connext_cpp.xunit.xml 
00:05:11 175: ==================== 1 failed, 1 warnings in 11.83 seconds ====================
```

It seems that pytest reports this as a warning, but it's unclear to me if this alone would cause the tests to fail or not, and if not whether or not our jenkins plugins will report them somehow and if it will cause a retry when that's being used.

We should be careful to see if this breaks Xenial which has an older Python.