### PR TITLE
Migrates legacy launch API tests

### DIFF
--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -60,17 +60,15 @@ class Action(LaunchDescriptionEntity):
                 return cast(Optional[List[LaunchDescriptionEntity]], self.execute(context))
             finally:
                 from .events import ExecutionComplete  # noqa
-                future = self.get_asyncio_future()
-                if future is not None:
-                    future.add_done_callback(
-                        lambda _: context.emit_event_sync(
-                            ExecutionComplete(action=self)
+                event = ExecutionComplete(action=self)
+                if context.would_handle_event(event):
+                    future = self.get_asyncio_future()
+                    if future is not None:
+                        future.add_done_callback(
+                            lambda _: context.emit_event_sync(event)
                         )
-                    )
-                else:
-                    context.emit_event_sync(
-                        ExecutionComplete(action=self)
-                    )
+                    else:
+                        context.emit_event_sync(event)
         return None
 
     def execute(self, context: LaunchContext) -> Optional[List['Action']]:

--- a/launch/launch/actions/__init__.py
+++ b/launch/launch/actions/__init__.py
@@ -20,6 +20,7 @@ from .execute_process import ExecuteProcess
 from .group_action import GroupAction
 from .include_launch_description import IncludeLaunchDescription
 from .log_info import LogInfo
+from .opaque_coroutine import OpaqueCoroutine
 from .opaque_function import OpaqueFunction
 from .pop_launch_configurations import PopLaunchConfigurations
 from .push_launch_configurations import PushLaunchConfigurations
@@ -36,6 +37,7 @@ __all__ = [
     'GroupAction',
     'IncludeLaunchDescription',
     'LogInfo',
+    'OpaqueCoroutine',
     'OpaqueFunction',
     'PopLaunchConfigurations',
     'PushLaunchConfigurations',

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -80,9 +80,9 @@ class ExecuteProcess(Action):
         env: Optional[Dict[SomeSubstitutionsType, SomeSubstitutionsType]] = None,
         shell: bool = False,
         sigterm_timeout: SomeSubstitutionsType = LaunchConfiguration(
-            'sigterm_timeout', default = 5),
+            'sigterm_timeout', default=5),
         sigkill_timeout: SomeSubstitutionsType = LaunchConfiguration(
-            'sigkill_timeout', default = 5),
+            'sigkill_timeout', default=5),
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Optional[Text] = None,
         log_cmd: bool = False,

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -41,8 +41,8 @@ from ..action import Action
 from ..event import Event
 from ..event_handler import EventHandler
 from ..event_handlers import OnShutdown
-from ..events import Shutdown
 from ..events import matches_action
+from ..events import Shutdown
 from ..events.process import ProcessExited
 from ..events.process import ProcessStarted
 from ..events.process import ProcessStderr

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -68,6 +68,14 @@ _global_process_counter_lock = threading.Lock()
 _global_process_counter = 0  # in Python3, this number is unbounded (no rollover)
 
 
+def _is_process_running(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
 class ExecuteProcess(Action):
     """Action that begins executing a process and sets up event handlers for the process."""
 
@@ -246,7 +254,10 @@ class ExecuteProcess(Action):
             raise RuntimeError('Signal event received before execution.')
         if self._subprocess_transport is None:
             raise RuntimeError('Signal event received before subprocess transport available.')
-        if self._subprocess_protocol.complete.done():
+        # if self._subprocess_protocol.complete.done():
+        # disable above's check as this handler may get called *after* the process has
+        # terminated but *before* the asyncio future has been resolved.
+        if not _is_process_running(self._subprocess_transport.get_pid()):
             # the process is done or is cleaning up, no need to signal
             _logger.debug("signal '{}' not set to '{}' because it is already closing".format(
                 typed_event.signal_name, self.process_details['name']

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -42,7 +42,7 @@ from ..event import Event
 from ..event_handler import EventHandler
 from ..event_handlers import OnShutdown
 from ..events import Shutdown
-from ..events.process import matches_action
+from ..events import matches_action
 from ..events.process import ProcessExited
 from ..events.process import ProcessStarted
 from ..events.process import ProcessStderr

--- a/launch/launch/actions/opaque_coroutine.py
+++ b/launch/launch/actions/opaque_coroutine.py
@@ -41,11 +41,23 @@ class OpaqueCoroutine(Action):
     .. code-block:: python
 
         async def coroutine(
-            context: LaunchContext,  # iff ignore_context is False
+            context: LaunchContext,
             *args,
             **kwargs
         ):
             ...
+
+    if ignore_context is False on construction (currently the default), or
+
+    .. code-block:: python
+
+        async def coroutine(
+            *args,
+            **kwargs
+        ):
+            ...
+
+    if ignore_context is True on construction.
     """
 
     def __init__(
@@ -60,7 +72,7 @@ class OpaqueCoroutine(Action):
         super().__init__(**left_over_kwargs)
         if not asyncio.iscoroutinefunction(coroutine):
             raise TypeError(
-                "OpaqueCoroutine expected a couroutine for 'couroutine', got '{}'".format(
+                "OpaqueCoroutine expected a coroutine for 'coroutine', got '{}'".format(
                     type(coroutine)
                 )
             )

--- a/launch/launch/actions/opaque_coroutine.py
+++ b/launch/launch/actions/opaque_coroutine.py
@@ -1,0 +1,89 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the OpaqueCoroutine action."""
+
+import asyncio
+import collections.abc
+from typing import Any
+from typing import Coroutine
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Text
+
+from ..action import Action
+from ..launch_context import LaunchContext
+from ..utilities import ensure_argument_type
+
+
+class OpaqueCoroutine(Action):
+    """
+    Action that adds a Python coroutine to the launch run loop.
+
+    The signature of a coroutine should be:
+
+    .. code-block:: python
+
+        async def coroutine(
+            context: LaunchContext,  # iff ignore_context is False
+            *args,
+            **kwargs
+        ):
+            ...
+    """
+
+    def __init__(
+        self, *,
+        coroutine: Coroutine,
+        args: Optional[Iterable[Any]] = None,
+        kwargs: Optional[Dict[Text, Any]] = None,
+        ignore_context: bool = False,
+        **left_over_kwargs
+    ) -> None:
+        """Constructor."""
+        super().__init__(**left_over_kwargs)
+        if not asyncio.iscoroutinefunction(coroutine):
+            raise TypeError("OpaqueCoroutine expected a couroutine function for 'couroutine', got '{}'".format(
+                type(function)
+            ))
+        ensure_argument_type(
+            args, (collections.abc.Iterable, type(None)), 'args', 'OpaqueCoroutine'
+        )
+        ensure_argument_type(kwargs, (dict, type(None)), 'kwargs', 'OpaqueCoroutine')
+        ensure_argument_type(ignore_context, bool, 'ignore_context', 'OpaqueCoroutine')
+        self.__coroutine = coroutine
+        self.__args = []  # type: Iterable
+        if args is not None:
+            self.__args = args
+        self.__kwargs = {}  # type: Dict[Text, Any]
+        if kwargs is not None:
+            self.__kwargs = kwargs
+        self.__ignore_context = ignore_context  # type: bool
+        self.__future = None  # type: Optional[asyncio.Future]
+
+    def execute(self, context: LaunchContext) -> Optional[List[Action]]:
+        """Execute the action."""
+        args = self.__args
+        if not self.__ignore_context:
+            args = [context, *self.__args]
+        self.__future = context.asyncio_loop.create_task(
+            self.__coroutine(*args, **self.__kwargs)
+        )
+        return None
+
+    def get_asyncio_future(self) -> Optional[asyncio.Future]:
+        """Return an asyncio Future, used to let the launch system know when we're done."""
+        return self.__future

--- a/launch/launch/event_handlers/__init__.py
+++ b/launch/launch/event_handlers/__init__.py
@@ -15,6 +15,7 @@
 """Package for event_handlers."""
 
 from .event_named import event_named
+from .on_execution_complete import OnExecutionComplete
 from .on_include_launch_description import OnIncludeLaunchDescription
 from .on_process_exit import OnProcessExit
 from .on_process_io import OnProcessIO
@@ -22,6 +23,7 @@ from .on_shutdown import OnShutdown
 
 __all__ = [
     'event_named',
+    'OnExecutionComplete',
     'OnIncludeLaunchDescription',
     'OnProcessExit',
     'OnProcessIO',

--- a/launch/launch/event_handlers/on_execution_complete.py
+++ b/launch/launch/event_handlers/on_execution_complete.py
@@ -21,8 +21,8 @@ from typing import overload
 from typing import Text
 
 from ..event import Event
-from ..events import ExecutionComplete
 from ..event_handler import EventHandler
+from ..events import ExecutionComplete
 from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType

--- a/launch/launch/event_handlers/on_execution_complete.py
+++ b/launch/launch/event_handlers/on_execution_complete.py
@@ -61,7 +61,7 @@ class OnExecutionComplete(EventHandler):
         """Constructor."""
         from ..action import Action  # noqa
         if not isinstance(target_action, (Action, type(None))):
-            raise RuntimeError("OnExecutionComplete requires an 'Action' as the target")
+            raise ValueError("OnExecutionComplete requires an 'Action' as the target")
         super().__init__(
             matcher=(
                 lambda event: (

--- a/launch/launch/event_handlers/on_execution_complete.py
+++ b/launch/launch/event_handlers/on_execution_complete.py
@@ -110,7 +110,7 @@ class OnExecutionComplete(EventHandler):
         #                    via the 'entities' property.
         if self.__actions_on_completion:
             return '<actions>'
-        return '{}'.format(self.__on_exit)
+        return '{}'.format(self.__on_completion)
 
     @property
     def matcher_description(self) -> Text:

--- a/launch/launch/event_handlers/on_execution_complete.py
+++ b/launch/launch/event_handlers/on_execution_complete.py
@@ -1,0 +1,122 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections.abc
+from typing import Callable
+from typing import cast
+from typing import List  # noqa
+from typing import Optional
+from typing import overload
+from typing import Text
+
+from ..event import Event
+from ..events import ExecutionComplete
+from ..event_handler import EventHandler
+from ..launch_context import LaunchContext
+from ..launch_description_entity import LaunchDescriptionEntity
+from ..some_actions_type import SomeActionsType
+
+
+class OnExecutionComplete(EventHandler):
+    """
+    Convenience class for handling an action completion event.
+
+    It may be configured to only handle the completion of a specific action,
+    or to handle them all.
+    """
+
+    @overload
+    def __init__(
+        self, *,
+        target_action: Optional['Action'] = None,
+        on_completion: SomeActionsType,
+        **kwargs
+    ) -> None:
+        """Overload which takes just actions."""
+        ...
+
+    @overload  # noqa: F811
+    def __init__(
+        self,
+        *,
+        target_action: Optional['Action'] = None,
+        on_completion: Callable[[int], Optional[SomeActionsType]],
+        **kwargs
+    ) -> None:
+        """Overload which takes a callable to handle completion."""
+        ...
+
+    def __init__(self, *, target_action=None, on_completion, **kwargs) -> None:  # noqa: F811
+        """Constructor."""
+        from ..action import Action  # noqa
+        if not isinstance(target_action, (Action, type(None))):
+            raise RuntimeError("OnExecutionComplete requires an 'Action' as the target")
+        super().__init__(
+            matcher=(
+                lambda event: (
+                    isinstance(event, ExecutionComplete) and (
+                        target_action is None or
+                        event.action == target_action
+                    )
+                )
+            ),
+            entities=None,
+            **kwargs,
+        )
+        self.__target_action = target_action
+        # TODO(wjwwood) check that it is not only callable, but also a callable that matches
+        # the correct signature for a handler in this case
+        self.__on_completion = on_completion
+        self.__actions_on_completion = []  # type: List[LaunchDescriptionEntity]
+        if callable(on_completion):
+            # Then on_completion is a function or lambda, so we can just call it, but
+            # we don't put anything in self.__actions_on_completion because we cannot
+            # know what the function will return.
+            pass
+        else:
+            # Otherwise, setup self.__actions_on_completion
+            if isinstance(on_completion, collections.abc.Iterable):
+                for entity in on_completion:
+                    if not isinstance(entity, LaunchDescriptionEntity):
+                        raise ValueError(
+                            "expected all items in 'on_completion' iterable to be of type "
+                            "'LaunchDescriptionEntity' but got '{}'".format(type(entity)))
+                self.__actions_on_completion = list(on_completion)
+            else:
+                self.__actions_on_completion = [on_completion]
+            # Then return it from a lambda and use that as the self.__on_completion callback.
+            self.__on_completion = lambda event, context: self.__actions_on_completion
+
+    def handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+        """Handle the given event."""
+        return self.__on_completion(cast(ExecutionComplete, event), context)
+
+    @property
+    def handler_description(self) -> Text:
+        """Return the string description of the handler."""
+        # TODO(jacobperron): revisit how to describe known actions that are passed in.
+        #                    It would be nice if the parent class could output their description
+        #                    via the 'entities' property.
+        if self.__actions_on_completion:
+            return '<actions>'
+        return '{}'.format(self.__on_exit)
+
+    @property
+    def matcher_description(self) -> Text:
+        """Return the string description of the matcher."""
+        if self.__target_action is None:
+            return 'event == ExecutionComplete'
+        return 'event == ExecutionComplete and event.action == Action({})'.format(
+            hex(id(self.__target_action))
+        )

--- a/launch/launch/events/__init__.py
+++ b/launch/launch/events/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Open Source Robotics Foundation, Inc.
+# Copyright 2018 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/launch/events/execution_complete.py
+++ b/launch/launch/events/execution_complete.py
@@ -14,6 +14,7 @@
 
 """Module for ExecutionComplete event."""
 
+from ..action import Action
 from ..event import Event
 
 

--- a/launch/launch/events/execution_complete.py
+++ b/launch/launch/events/execution_complete.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Package for events."""
+"""Module for ExecutionComplete event."""
 
-from . import process
-from .execution_complete import ExecutionComplete
-from .include_launch_description import IncludeLaunchDescription
-from .matchers import matches_action
-from .shutdown import Shutdown
-from .timer_event import TimerEvent
+from ..event import Event
 
-__all__ = [
-    'matches_action',
-    'process',
-    'ExecutionComplete',
-    'IncludeLaunchDescription',
-    'Shutdown',
-    'TimerEvent',
-]
+
+class ExecutionComplete(Event):
+    """Event that is emitted on action execution completion."""
+
+    name = 'launch.events.ExecutionComplete'
+
+    def __init__(self, *, action: 'Action') -> None:
+        """Constructor."""
+        self.__action = action
+
+    @property
+    def action(self):
+        """Getter for action."""
+        return self.__action

--- a/launch/launch/events/matchers.py
+++ b/launch/launch/events/matchers.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Open Source Robotics Foundation, Inc.
+# Copyright 2018 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Package for events."""
+"""Module for standard "matchers", which are used with Events."""
 
-from . import process
-from .execution_complete import ExecutionComplete
-from .include_launch_description import IncludeLaunchDescription
-from .matchers import matches_action
-from .shutdown import Shutdown
-from .timer_event import TimerEvent
+from typing import Callable
 
-__all__ = [
-    'matches_action',
-    'process',
-    'ExecutionComplete',
-    'IncludeLaunchDescription',
-    'Shutdown',
-    'TimerEvent',
-]
+from ..action import Action
+
+
+def matches_action(target_action: 'Action') -> Callable[['Action'], bool]:
+    """Return a matcher which matches based on an exact given ExecuteProcess action."""
+    return lambda action: action == target_action

--- a/launch/launch/events/process/__init__.py
+++ b/launch/launch/events/process/__init__.py
@@ -16,7 +16,6 @@
 
 from .process_exited import ProcessExited
 from .process_io import ProcessIO
-from .process_matchers import matches_action
 from .process_matchers import matches_executable
 from .process_matchers import matches_name
 from .process_matchers import matches_pid
@@ -30,7 +29,6 @@ from .shutdown_process import ShutdownProcess
 from .signal_process import SignalProcess
 
 __all__ = [
-    'matches_action',
     'matches_executable',
     'matches_name',
     'matches_pid',

--- a/launch/launch/events/process/process_matchers.py
+++ b/launch/launch/events/process/process_matchers.py
@@ -22,11 +22,6 @@ if False:
     from ...actions import ExecuteProcess  # noqa
 
 
-def matches_action(execute_process_action: 'ExecuteProcess') -> Callable[['ExecuteProcess'], bool]:
-    """Return a matcher which matches based on an exact given ExecuteProcess action."""
-    return lambda action: action == execute_process_action
-
-
 def matches_pid(pid: int) -> Callable[['ExecuteProcess'], bool]:
     """Return a matcher which matches based on the pid of the process."""
     def matcher(action: 'ExecuteProcess') -> bool:

--- a/launch/launch/events/process/process_targeted_event.py
+++ b/launch/launch/events/process/process_targeted_event.py
@@ -34,7 +34,7 @@ class ProcessTargetedEvent(Event):
 
         Some standard matchers are also available, like:
 
-        - :func:`launch.events.process.matches_action()`
+        - :func:`launch.events.matches_action()`
         - :func:`launch.events.process.matches_pid()`
         - :func:`launch.events.process.matches_name()`
         - :func:`launch.events.process.matches_executable()`

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -156,6 +156,10 @@ class LaunchContext:
         """Getter for launch_configurations dictionary."""
         return self.__launch_configurations
 
+    def would_handle_event(self, event: Event) -> bool:
+        """Check whether an event would be handled or not."""
+        return any(handler.matches(event) for handler in self._event_handlers)
+
     def register_event_handler(self, event_handler: EventHandler) -> None:
         """Register a event handler."""
         self._event_handlers.appendleft(event_handler)

--- a/launch/launch/launch_introspector.py
+++ b/launch/launch/launch_introspector.py
@@ -110,7 +110,7 @@ def format_action(action: Action) -> List[Text]:
             ),
             typed_action.env if typed_action.env is None else '{' + ', '.join(
                 ['{}: {}'.format(format_substitutions(k), format_substitutions(v))
-                 for k, v in typed_action.env.items()]) + '}',
+                 for k, v in typed_action.env]) + '}',
             typed_action.shell,
         )
         return [msg]

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -375,6 +375,7 @@ class LaunchService:
 
     def __on_shutdown(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         self.__shutting_down = True
+        self.__context._set_is_shutdown(True)
         return None
 
     def _shutdown(self, *, reason, due_to_sigint, force_sync=False):

--- a/launch/test/launch/event_handlers/test_on_execution_complete.py
+++ b/launch/test/launch/event_handlers/test_on_execution_complete.py
@@ -1,0 +1,60 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OnExecutionComplete class."""
+
+from launch.actions import LogInfo
+from launch.event_handlers import OnExecutionComplete
+from launch.events import ExecutionComplete
+
+
+import pytest
+
+
+def test_bad_construction():
+    """Test bad construction parameters."""
+    with pytest.raises(ValueError):
+        OnExecutionComplete(
+            target_action='not-an-action',
+            on_completion=lambda *args: None
+        )
+
+    with pytest.raises(ValueError):
+        OnExecutionComplete(
+            target_action=LogInfo(msg='some message'),
+            on_completion='not-a-callable-nor-an-action-iterable'
+        )
+
+
+def test_single_action_is_matched():
+    """Test that only the target action execution complete event is matched."""
+    an_action = LogInfo(msg='some message')
+    event_handler = OnExecutionComplete(
+        target_action=an_action,
+        on_completion=lambda *args: None
+    )
+    other_action = LogInfo(msg='other message')
+    assert event_handler.matches(ExecutionComplete(action=an_action))
+    assert not event_handler.matches(ExecutionComplete(action=other_action))
+
+
+def test_all_actions_are_matched():
+    """Test that all execution complete events are matched."""
+    an_action = LogInfo(msg='some message')
+    other_action = LogInfo(msg='other message')
+    event_handler = OnExecutionComplete(
+        on_completion=lambda *args: None
+    )
+    assert event_handler.matches(ExecutionComplete(action=an_action))
+    assert event_handler.matches(ExecutionComplete(action=other_action))

--- a/launch/test/launch/test_action.py
+++ b/launch/test/launch/test_action.py
@@ -16,6 +16,7 @@
 
 from launch import Action
 from launch import Condition
+from launch import LaunchContext
 
 
 def test_action_constructors():
@@ -26,7 +27,7 @@ def test_action_constructors():
 
 def test_action_methods():
     """Test the methods of the Action class."""
-    class MockLaunchContext:
+    class MockLaunchContext(LaunchContext):
         ...
 
     action = Action()

--- a/launch/test/launch/test_launch_service.py
+++ b/launch/test/launch/test_launch_service.py
@@ -19,6 +19,7 @@ import threading
 
 from launch import LaunchDescription
 from launch import LaunchService
+from launch.events import ExecutionComplete
 from launch.utilities import install_signal_handlers
 
 # Install the signal handlers here, in the hope that this is executed in the
@@ -55,7 +56,7 @@ def test_launch_service_emit_event():
     handled_events = queue.Queue()
     ld = LaunchDescription([
         RegisterEventHandler(EventHandler(
-            matcher=lambda event: True,
+            matcher=lambda event: not isinstance(event, ExecutionComplete),
             entities=OpaqueFunction(
                 function=lambda context: handled_events.put(context.locals.event),
             ),

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -31,23 +31,41 @@ class LaunchTestService():
         self.__tests = OrderedDict()
         self.__processes_rc = OrderedDict()
 
-    def _arm(self, test_name):
+    def _arm(
+        self,
+        test_name
+    ):
+        """Prepare for test execution."""
         assert test_name not in self.__tests
         self.__tests[test_name] = 'armed'
 
-    def _fail(self, test_name, reason):
+    def _fail(
+        self,
+        test_name,
+        reason
+    ):
+        """Mark test as a failure and shutdown, dropping the tests that are still ongoing."""
         self.__tests[test_name] = 'failed'
         for test_name in self.__tests:
             if self.__tests[test_name] == 'armed':
                 self.__tests[test_name] = 'dropped'
         return EmitEvent(event=Shutdown(reason=reason))
 
-    def _succeed(self, test_name):
+    def _succeed(
+        self,
+        test_name
+    ):
+        """Mark test as a success and shutdown if all other tests have succeeded too."""
         self.__tests[test_name] = 'succeeded'
         if all(status == 'succeeded' for status in self.__tests.values()):
             return EmitEvent(event=Shutdown(reason='all tests finished'))
 
-    def add_fixture_action(self, launch_description, action, required=False):
+    def add_fixture_action(
+        self,
+        launch_description,
+        action,
+        required=False
+    ):
         """
         Add action used as testing fixture.
 
@@ -70,14 +88,17 @@ class LaunchTestService():
             )
         return action
 
-    def add_test_action(self, launch_description, action):
+    def add_test_action(
+        self,
+        launch_description,
+        action
+    ):
         """
         Add action used for testing.
 
         If either all test actions have completed or a process action has
         exited with a non-zero return code, a shutdown event is emitted.
         """
-        launch_description.add_action(action)
         test_name = 'test_{}'.format(id(action))
         if isinstance(action, ExecuteProcess):
             def on_test_process_exit(event, context):
@@ -104,12 +125,19 @@ class LaunchTestService():
                     )
                 ))
             )
+        launch_description.add_action(action)
         self._arm(test_name)
         return action
 
-    def add_output_test(self, launch_description, action, output_file,
-                        filtered_prefixes=None, filtered_patterns=None,
-                        filtered_rmw_implementation=None):
+    def add_output_test(
+        self,
+        launch_description,
+        action,
+        output_file,
+        filtered_prefixes=None,
+        filtered_patterns=None,
+        filtered_rmw_implementation=None
+    ):
         """
         Test an action process' output against text or regular expressions.
 
@@ -164,7 +192,12 @@ class LaunchTestService():
 
         return action
 
-    def run(self, launch_service, *args, **kwargs):
+    def run(
+        self,
+        launch_service,
+        *args,
+        **kwargs
+    ):
         """
         Invoke the `run` method of the launch service.
 

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -127,15 +127,17 @@ class LaunchTestService():
         """
         assert isinstance(action, ExecuteProcess)
         test_name = 'test_{}_output'.format(id(action))
-
         output, collate_output, match_output, match_patterns = create_output_check(
             output_file, filtered_prefixes, filtered_patterns, filtered_rmw_implementation
         )
+        assert any(match_patterns)
 
-        def on_process_exit(event):
+        def on_process_exit(event, context):
             nonlocal match_patterns
             if any(match_patterns):
-                return self._fail(test_name)
+                process_name = event.action.process_details['name']
+                reason = 'not all {} output matched!'.format(process_name)
+                return self._fail(test_name, reason)
 
         def on_process_stdout(event):
             nonlocal output

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -68,7 +68,6 @@ class LaunchTestService():
         launch_description,
         action,
         exit_allowed=[0],
-        ignore_returncode=False
     ):
         """
         Add action used as testing fixture.
@@ -82,10 +81,9 @@ class LaunchTestService():
                 allowed_to_exit = exit_allowed
                 if isinstance(exit_allowed, list):
                     allowed_to_exit = event.returncode in exit_allowed
-                if not allowed_to_exit:
-                    if not ignore_returncode:
-                        rc = event.returncode if event.returncode else 1
-                        self.__processes_rc[process_name] = rc
+                if not context.is_shutdown and not allowed_to_exit:
+                    rc = event.returncode if event.returncode else 1
+                    self.__processes_rc[process_name] = rc
                     return EmitEvent(event=Shutdown(
                         reason='{} fixture process died!'.format(process_name)
                     ))

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -152,9 +152,10 @@ class LaunchTestService():
         :param launch_description: test launch description that owns the given action.
         :param action: launch action to test whose output is to be tested.
         :param output_test: test tuple as returned by launch_testing.output.create_* functions.
-        :param test_suffix: an optional test suffix to disambiguate multiple test instances, defaults
-        to 'output'.
-        :param output_filter: an optional function to filter out i.e. ignore output lines for the test.
+        :param test_suffix: an optional test suffix to disambiguate multiple test instances,
+        defaults to 'output'.
+        :param output_filter: an optional function to filter out i.e. ignore output lines for
+        the test.
         :param side_effect: an optional side effect of a passing test, currently only 'shutdown'
         is supported.
         """

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2018-2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ from collections import OrderedDict
 from launch.actions import EmitEvent
 from launch.actions import ExecuteProcess
 from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnExecutionComplete
 from launch.event_handlers import OnProcessExit
 from launch.event_handlers import OnProcessIO
-from launch.event_handlers import OnExecutionComplete
 from launch.events import Shutdown
 
 from .output import create_output_check
@@ -37,6 +37,9 @@ class LaunchTestService():
 
     def _fail(self, test_name, reason):
         self.__tests[test_name] = 'failed'
+        for test_name in self.__tests:
+            if self.__tests[test_name] == 'armed':
+                self.__tests[test_name] = 'dropped'
         return EmitEvent(event=Shutdown(reason=reason))
 
     def _succeed(self, test_name):
@@ -44,22 +47,22 @@ class LaunchTestService():
         if all(status == 'succeeded' for status in self.__tests.values()):
             return EmitEvent(event=Shutdown(reason='all tests finished'))
 
-    def add_fixture_action(self, launch_description, action):
+    def add_fixture_action(self, launch_description, action, required=False):
         """
         Add action used as testing fixture.
 
         If a process action and it exits, a shutdown event is emitted.
         """
-
         launch_description.add_action(action)
-        fixture_name = 'fixture_{}'.format(id(action))
         if isinstance(action, ExecuteProcess):
             def on_fixture_process_exit(event, context):
                 process_name = event.action.process_details['name']
-                self.__processes_rc[process_name] = event.returncode
-                return EmitEvent(event=Shutdown(
-                    reason='{} fixture process died!'.format(process_name)
-                ))
+                if required or event.returncode != 0:
+                    rc = event.returncode if event.returncode else 1
+                    self.__processes_rc[process_name] = rc
+                    return EmitEvent(event=Shutdown(
+                        reason='{} fixture process died!'.format(process_name)
+                    ))
             launch_description.add_action(
                 RegisterEventHandler(OnProcessExit(
                     target_action=action, on_exit=on_fixture_process_exit
@@ -108,19 +111,19 @@ class LaunchTestService():
                         filtered_prefixes=None, filtered_patterns=None,
                         filtered_rmw_implementation=None):
         """
-        Tests an action process' output against text or regular expressions.
+        Test an action process' output against text or regular expressions.
 
         :param launch_description: test launch description that owns the given action.
         :param action: launch action to test whose output is to be tested.
         :param output_file: basename (i.e. w/o extension) of either a .txt file containing the
         lines to be matched or a .regex file containing patterns to be searched for.
-        :param filtered_prefixes: A list of byte strings representing prefixes that will cause output
-        lines to be ignored if they start with one of the prefixes. By default lines starting with
-        the process ID (`b'pid'`) and return code (`b'rc'`) will be ignored.
-        :param filtered_patterns: A list of byte strings representing regexes that will cause output
-        lines to be ignored if they match one of the regexes.
-        :param filtered_rmw_implementation: RMW implementation for which the output will be ignored
-        in addition to the `filtered_prefixes`/`filtered_patterns`.
+        :param filtered_prefixes: A list of byte strings representing prefixes that will cause
+        output lines to be ignored if they start with one of the prefixes. By default lines
+        starting with the process ID (`b'pid'`) and return code (`b'rc'`) will be ignored.
+        :param filtered_patterns: A list of byte strings representing regexes that will cause
+        output lines to be ignored if they match one of the regexes.
+        :param filtered_rmw_implementation: RMW implementation for which the output will be
+        ignored in addition to the `filtered_prefixes`/`filtered_patterns`.
         """
         assert isinstance(action, ExecuteProcess)
         test_name = 'test_{}_output'.format(id(action))
@@ -128,6 +131,11 @@ class LaunchTestService():
         output, collate_output, match_output, match_patterns = create_output_check(
             output_file, filtered_prefixes, filtered_patterns, filtered_rmw_implementation
         )
+
+        def on_process_exit(event):
+            nonlocal match_patterns
+            if any(match_patterns):
+                return self._fail(test_name)
 
         def on_process_stdout(event):
             nonlocal output
@@ -141,11 +149,17 @@ class LaunchTestService():
                 return self._succeed(test_name)
 
         launch_description.add_action(
+            RegisterEventHandler(OnProcessExit(
+                target_action=action, on_exit=on_process_exit
+            ))
+        )
+        launch_description.add_action(
             RegisterEventHandler(OnProcessIO(
                 target_action=action, on_stdout=on_process_stdout
             ))
         )
         self._arm(test_name)
+
         return action
 
     def run(self, launch_service, *args, **kwargs):
@@ -158,5 +172,6 @@ class LaunchTestService():
         """
         rc = launch_service.run(*args, **kwargs)
         if rc == 0:
-            rc = next((rc for rc in self.__processes_rc.values() if rc), rc)
+            default_rc = 1 if 'failed' in self.__tests.values() else 0
+            rc = next((rc for rc in self.__processes_rc.values() if rc != 0), default_rc)
         return rc

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -151,7 +151,7 @@ class LaunchTestService():
                         return self._drop(test_name)
                     exc = future.exception()
                     if exc is not None:
-                         return self._fail(test_name, str(exc))
+                        return self._fail(test_name, str(exc))
                 return self._succeed(test_name)
 
             launch_description.add_action(
@@ -221,6 +221,7 @@ class LaunchTestService():
             nonlocal output
             nonlocal match_patterns
             output = collate_output(output, output_filter(event.text))
+            print(output.getvalue())
             match_patterns = [
                 pattern for pattern in match_patterns
                 if not match_output(output, pattern)

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Open Source Robotics Foundation, Inc.
+# Copyright 2018 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch_testing/launch_testing/output.py
+++ b/launch_testing/launch_testing/output.py
@@ -1,0 +1,105 @@
+import io
+import os
+import re
+
+import ament_index_python
+
+
+def get_default_filtered_prefixes():
+    return [
+        b'pid', b'rc',
+    ]
+
+
+def get_default_filtered_patterns():
+    return []
+
+
+def get_rmw_output_filter(rmw_implementation, filter_type):
+    supported_filter_types = ['prefixes', 'patterns']
+    if filter_type not in supported_filter_types:
+        raise TypeError(
+            'Unsupported filter_type "{0}". Supported types: {1}'
+            .format(filter_type, supported_filter_types))
+    resource_name = 'rmw_output_' + filter_type
+    prefix_with_resource = ament_index_python.has_resource(
+        resource_name, rmw_implementation)
+    if not prefix_with_resource:
+        return []
+
+    # Treat each line of the resource as an independent filter.
+    rmw_output_filter, _ = ament_index_python.get_resource(resource_name, rmw_implementation)
+    return [str.encode(l) for l in rmw_output_filter.splitlines()]
+
+
+def get_expected_output(output_file):
+    literal_file = output_file + '.txt'
+    if os.path.isfile(literal_file):
+        with open(literal_file, 'rb') as f:
+            return f.read().splitlines()
+    regex_file = output_file + '.regex'
+    if os.path.isfile(regex_file):
+        with open(regex_file, 'rb') as f:
+            return f.read().splitlines()
+
+
+def create_output_lines_filter(filtered_prefixes, filtered_patterns,
+                               filtered_rmw_implementation):
+    filtered_prefixes = filtered_prefixes or get_default_filtered_prefixes()
+    filtered_patterns = filtered_patterns or get_default_filtered_patterns()
+    if filtered_rmw_implementation:
+        filtered_prefixes.extend(get_rmw_output_filter(
+            filtered_rmw_implementation, 'prefixes'
+        ))
+        filtered_patterns.extend(get_rmw_output_filter(
+            filtered_rmw_implementation, 'patterns'
+        ))
+    filtered_patterns = map(re.compile, filtered_patterns)
+
+    def _filter(output):
+        for line in output.splitlines():
+            # Filter out stdout that comes from underlying DDS implementation
+            # Note: we do not currently support matching filters across multiple stdout lines.
+            if any(line.startswith(prefix) for prefix in filtered_prefixes):
+                continue
+            if any(pattern.match(line) for pattern in filtered_patterns):
+                continue
+            yield line
+    return _filter
+
+
+def create_output_check(output_file, filtered_prefixes, filtered_patterns,
+                        filtered_rmw_implementation=None):
+    filter_output_lines = create_output_lines_filter(
+        filtered_prefixes, filtered_patterns, filtered_rmw_implementation
+    )
+
+    literal_file = output_file + '.txt'
+    if os.path.isfile(literal_file):
+        def _collate(output, addendum):
+            output.extend(filter_output_lines(addendum))
+            return output
+
+        def _match(output, pattern):
+            return pattern in output
+
+        with open(literal_file, 'rb') as f:
+            expected_output = f.read().splitlines()
+        return [], _collate, _match, expected_output
+
+    regex_file = output_file + '.regex'
+    if os.path.isfile(regex_file):
+        def _collate(output, addendum):
+            output.write(b'\n'.join(
+                filter_output_lines(addendum)
+            ))
+            return output
+
+        def _match(output, pattern):
+            return bool(pattern.search(output))
+
+        with open(regex_file, 'rb') as f:
+            patterns = map(re.compile, f.read().splitlines())
+        return io.BytesIO(), _collate, _match, patterns
+
+    raise RuntimeError('could not find output check file: {}'.format(output_file))

--- a/launch_testing/launch_testing/output.py
+++ b/launch_testing/launch_testing/output.py
@@ -58,6 +58,7 @@ def create_output_lines_filter(
             filtered_rmw_implementation, 'patterns'
         ))
     filtered_patterns = map(re.compile, filtered_patterns)
+    encoded_line_sep = os.linesep.encode('ascii')
 
     def _filter(output):
         filtered_output = []
@@ -69,23 +70,22 @@ def create_output_lines_filter(
             if any(pattern.match(line) for pattern in filtered_patterns):
                 continue
             filtered_output.append(line)
-        if output.endswith(b'\n'):
-            filtered_output.append(b'\n')
-        return b'\n'.join(filtered_output)
+        if output.endswith(encoded_line_sep):
+            filtered_output.append(encoded_line_sep)
+        return encoded_line_sep.join(filtered_output)
     return _filter
 
 
 def create_output_lines_test(expected_lines):
     """Create output test given a list of expected lines."""
     def _collate(output, addendum):
-        output.extend(addendum.splitlines())
+        output.write(addendum)
         return output
 
     def _match(output, pattern):
-        print(output, pattern, pattern in output)
-        return any(pattern in line for line in output)
+        return any(pattern in line for line in output.getvalue().splitlines())
 
-    return [], _collate, _match, expected_lines
+    return io.BytesIO(), _collate, _match, expected_lines
 
 
 def create_output_regex_test(expected_patterns):

--- a/launch_testing/launch_testing/output.py
+++ b/launch_testing/launch_testing/output.py
@@ -69,7 +69,7 @@ def create_output_lines_filter(filtered_prefixes, filtered_patterns,
 
 
 def create_output_check(output_file, filtered_prefixes, filtered_patterns,
-                        filtered_rmw_implementation=None):
+                        filtered_rmw_implementation):
     filter_output_lines = create_output_lines_filter(
         filtered_prefixes, filtered_patterns, filtered_rmw_implementation
     )
@@ -99,7 +99,7 @@ def create_output_check(output_file, filtered_prefixes, filtered_patterns,
             return pattern.search(output.getvalue()) is not None
 
         with open(regex_file, 'rb') as f:
-            patterns = map(re.compile, f.read().splitlines())
+            patterns = [re.compile(regex) for regex in f.read().splitlines()]
         return io.BytesIO(), _collate, _match, patterns
 
     raise RuntimeError('could not find output check file: {}'.format(output_file))

--- a/launch_testing/launch_testing/output.py
+++ b/launch_testing/launch_testing/output.py
@@ -96,7 +96,7 @@ def create_output_check(output_file, filtered_prefixes, filtered_patterns,
             return output
 
         def _match(output, pattern):
-            return bool(pattern.search(output))
+            return pattern.search(output.getvalue()) is not None
 
         with open(regex_file, 'rb') as f:
             patterns = map(re.compile, f.read().splitlines())

--- a/launch_testing/launch_testing/output.py
+++ b/launch_testing/launch_testing/output.py
@@ -91,7 +91,7 @@ def create_output_lines_test(expected_lines):
 def create_output_regex_test(expected_patterns):
     """Create output test given a list of expected matching regular expressions."""
     def _collate(output, addendum):
-        output.write(addendum)
+        output.write(b'\n'.join(addendum.splitlines()))
         return output
 
     def _match(output, pattern):

--- a/launch_testing/launch_testing/output.py
+++ b/launch_testing/launch_testing/output.py
@@ -76,9 +76,7 @@ def create_output_lines_filter(
 
 
 def create_output_lines_test(expected_lines):
-    """
-    Create output test given a list of expected lines.
-    """
+    """Create output test given a list of expected lines."""
     def _collate(output, addendum):
         output.extend(addendum.splitlines())
         return output
@@ -91,10 +89,7 @@ def create_output_lines_test(expected_lines):
 
 
 def create_output_regex_test(expected_patterns):
-    """
-    Create output test given a list of expected matching regular
-    expressions.
-    """
+    """Create output test given a list of expected matching regular expressions."""
     def _collate(output, addendum):
         output.write(addendum)
         return output

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -22,6 +22,7 @@ from launch.actions import ExecuteProcess
 from launch_testing import LaunchTestService
 from launch_testing.output import create_output_test_from_file
 
+
 def test_matching():
     # This temporary directory and files contained in it
     # will be deleted when the process ends.

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -40,7 +40,7 @@ def test_matching():
     ld = LaunchDescription()
     launch_test = LaunchTestService()
     action = launch_test.add_fixture_action(
-        ld, ExecuteProcess(cmd=executable_command)
+        ld, ExecuteProcess(cmd=executable_command, output='screen')
     )
     launch_test.add_output_test(ld, action, output_file)
 

--- a/launch_testing/test/test_matching.py
+++ b/launch_testing/test/test_matching.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
 from launch_testing import LaunchTestService
-
+from launch_testing.output import create_output_test_from_file
 
 def test_matching():
     # This temporary directory and files contained in it
@@ -42,7 +42,9 @@ def test_matching():
     action = launch_test.add_fixture_action(
         ld, ExecuteProcess(cmd=executable_command, output='screen')
     )
-    launch_test.add_output_test(ld, action, output_file)
+    launch_test.add_output_test(
+        ld, action, create_output_test_from_file(output_file)
+    )
 
     launch_service = LaunchService()
     launch_service.include_launch_description(ld)


### PR DESCRIPTION
Connected to #159. This pull request adds the bare minimum functionality to migrate all tests in ROS 2 core packages that make use of the legacy launch API. May eventually face deprecation depending on the path taken after #165. 

Some `launch.legacy` tests still remain to be ported, unclear if these should in the first place as such additions may as well fall under the improving test coverage for `launch` umbrella.