### PR TITLE
Remove whitespace in keyword arg

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -80,9 +80,9 @@ class ExecuteProcess(Action):
         env: Optional[Dict[SomeSubstitutionsType, SomeSubstitutionsType]] = None,
         shell: bool = False,
         sigterm_timeout: SomeSubstitutionsType = LaunchConfiguration(
-            'sigterm_timeout', default = 5),
+            'sigterm_timeout', default=5),
         sigkill_timeout: SomeSubstitutionsType = LaunchConfiguration(
-            'sigkill_timeout', default = 5),
+            'sigkill_timeout', default=5),
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Optional[Text] = None,
         log_cmd: bool = False,


### PR DESCRIPTION
Failures in [nightly_linux-aarch64_debug #713](https://ci.ros2.org/job/nightly_linux-aarch64_debug/713), [nightly_linux-aarch64_extra_rmw_release #245](https://ci.ros2.org/job/nightly_linux-aarch64_extra_rmw_release/245), [nightly_linux-aarch64_release #673](https://ci.ros2.org/job/nightly_linux-aarch64_release/673), [nightly_linux_debug #1088](https://ci.ros2.org/job/nightly_linux_debug/1088), [nightly_linux_extra_rmw_release #241](https://ci.ros2.org/job/nightly_linux_extra_rmw_release/241), [nightly_linux_release #1069](https://ci.ros2.org/job/nightly_linux_release/1069), [nightly_osx_debug #1143](https://ci.ros2.org/job/nightly_osx_debug/1143), [nightly_osx_extra_rmw_release #279](https://ci.ros2.org/job/nightly_osx_extra_rmw_release/279), [nightly_osx_release #1151](https://ci.ros2.org/job/nightly_osx_release/1151), [nightly_win_deb #1143](https://ci.ros2.org/job/nightly_win_deb/1143), [nightly_win_extra_rmw_rel #248](https://ci.ros2.org/job/nightly_win_extra_rmw_rel/248), [nightly_win_rel #1082](https://ci.ros2.org/job/nightly_win_rel/1082), [nightly_xenial_linux-aarch64_release #243](https://ci.ros2.org/job/nightly_xenial_linux-aarch64_release/243), [nightly_xenial_linux_release #234](https://ci.ros2.org/job/nightly_xenial_linux_release/234)

Connects to ros2/ros2cli#192