### PR TITLE
Refactor arg print functions

### DIFF
--- a/ros2launch/ros2launch/api/__init__.py
+++ b/ros2launch/ros2launch/api/__init__.py
@@ -20,6 +20,7 @@ from .api import launch_a_python_launch_file
 from .api import LaunchFileNameCompleter
 from .api import MultipleLaunchFilesError
 from .api import print_a_python_launch_file
+from .api import print_arguments_of_launch_description
 from .api import print_arguments_of_python_launch_file
 
 __all__ = [
@@ -29,5 +30,6 @@ __all__ = [
     'launch_a_python_launch_file',
     'MultipleLaunchFilesError',
     'print_a_python_launch_file',
+    'print_arguments_of_launch_description',
     'print_arguments_of_python_launch_file',
 ]

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -88,9 +88,8 @@ def print_a_python_launch_file(*, python_launch_file_path):
     print(launch.LaunchIntrospector().format_launch_description(launch_description))
 
 
-def print_arguments_of_python_launch_file(*, python_launch_file_path):
-    """Print the arguments of a Python launch file to the console."""
-    launch_description = get_launch_description_from_python_launch_file(python_launch_file_path)
+def print_arguments_of_launch_description(*, launch_description):
+    """Print the arguments of a LaunchDescription to the console."""
     print("Arguments (pass arguments as '<name>:=<value>'):")
     launch_arguments = launch_description.get_launch_arguments()
     any_conditional_arguments = False
@@ -113,6 +112,12 @@ def print_arguments_of_python_launch_file(*, python_launch_file_path):
             print('\n* argument(s) which are only used if specific conditions occur')
     else:
         print('\n  No arguments.')
+
+
+def print_arguments_of_python_launch_file(*, python_launch_file_path):
+    """Print the arguments of a Python launch file to the console."""
+    launch_description = get_launch_description_from_python_launch_file(python_launch_file_path)
+    print_arguments_of_launch_description(launch_description)
 
 
 def parse_launch_arguments(launch_arguments: List[Text]) -> List[Tuple[Text, Text]]:


### PR DESCRIPTION
Make it easier to print args if you already have a LaunchDescription object and don't need to parse a file

I'm working on a tool that uses arguments in the same way as the ros2 launch CLI tool but I only have LaunchDescription objects, not python launch files.  This PR makes it easy to print the same message as ros2 launch <file> --show-args, but starting with a LaunchDescription object instead of python file