### PR TITLE
Support required nodes

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -451,7 +451,7 @@ class ExecuteProcess(Action):
         await context.emit_event(ProcessExited(returncode=returncode, **process_event_args))
         if self.__required:
             _logger.info('process[{}] was required: shutting down launched system'.format(name))
-            await context.emit_event(Shutdown(reason="Required process {!r} exited".format(name)))
+            await context.emit_event(Shutdown(reason='Required process {!r} exited'.format(name)))
         self.__cleanup()
 
     def execute(self, context: LaunchContext) -> Optional[List['Action']]:


### PR DESCRIPTION
Currently, the only way to specify that a given node is required for a given `LaunchDescription` is to register an `OnProcessExit` handler for the exit event of the required node that then emits a `Shutdown` event. This use-case is pretty common. This PR resolves #174 by adding some syntactic sugar to make it a bit easier and reduce boilerplate.