### PR TITLE
launch: ensure event handlers add event to context locals

### DIFF
--- a/launch/launch/event_handler.py
+++ b/launch/launch/event_handler.py
@@ -36,9 +36,6 @@ class EventHandler:
     via the context's locals, e.g. `context.locals.event`
     As another example, getting the name of the event as a Substitution:
     `launch.substitutions.LocalSubstitution('event.name')`.
-
-    Child classes should implement the _handle(event: Event, context: 'LaunchContext')
-    function instead of overriding the handle() function.
     """
 
     def __init__(
@@ -111,8 +108,4 @@ class EventHandler:
         context.extend_locals({'event': event})
         if self.handle_once:
             context.unregister_event_handler(self)
-
-        try:
-            return self._handle(event, context)
-        except AttributeError:
-            return self.entities
+        return self.entities

--- a/launch/launch/event_handler.py
+++ b/launch/launch/event_handler.py
@@ -36,6 +36,9 @@ class EventHandler:
     via the context's locals, e.g. `context.locals.event`
     As another example, getting the name of the event as a Substitution:
     `launch.substitutions.LocalSubstitution('event.name')`.
+
+    Child classes should implement the _handle(event: Event, context: 'LaunchContext')
+    function instead of overriding the handle() function.
     """
 
     def __init__(
@@ -108,4 +111,8 @@ class EventHandler:
         context.extend_locals({'event': event})
         if self.handle_once:
             context.unregister_event_handler(self)
-        return self.__entities
+
+        try:
+            return self._handle(event, context)
+        except AttributeError:
+            return self.entities

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -23,7 +23,7 @@ from typing import Text
 from typing import Union
 
 from ..event import Event
-from ..event_handler import EventHandler
+from ..event_handler import BaseEventHandler
 from ..events.process import ProcessExited
 from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
@@ -35,7 +35,7 @@ if False:
     from ..actions import ExecuteProcess  # noqa
 
 
-class OnProcessExit(EventHandler):
+class OnProcessExit(BaseEventHandler):
     """
     Convenience class for handling a process exited event.
 
@@ -64,7 +64,6 @@ class OnProcessExit(EventHandler):
                     )
                 )
             ),
-            entities=None,
             **kwargs,
         )
         self.__target_action = target_action

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -54,7 +54,7 @@ class OnProcessExit(EventHandler):
         """Constructor."""
         from ..actions import ExecuteProcess  # noqa
         if not isinstance(target_action, (ExecuteProcess, type(None))):
-            raise RuntimeError("OnProcessExit requires an 'ExecuteProcess' action as the target")
+            raise TypeError("OnProcessExit requires an 'ExecuteProcess' action as the target")
         super().__init__(
             matcher=(
                 lambda event: (
@@ -88,7 +88,7 @@ class OnProcessExit(EventHandler):
             else:
                 self.__actions_on_exit = [on_exit]
 
-    def handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+    def _handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         """Handle the given event."""
         if self.__actions_on_exit:
             return self.__actions_on_exit

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -88,8 +88,10 @@ class OnProcessExit(EventHandler):
             else:
                 self.__actions_on_exit = [on_exit]
 
-    def _handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+    def handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         """Handle the given event."""
+        super().handle(event, context)
+
         if self.__actions_on_exit:
             return self.__actions_on_exit
         return self.__on_exit(cast(ProcessExited, event), context)

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -47,7 +47,7 @@ class OnProcessIO(EventHandler):
         """Constructor."""
         from ..actions import ExecuteProcess  # noqa
         if not isinstance(target_action, (ExecuteProcess, type(None))):
-            raise RuntimeError("OnProcessIO requires an 'ExecuteProcess' action as the target")
+            raise TypeError("OnProcessIO requires an 'ExecuteProcess' action as the target")
         super().__init__(matcher=self._matcher, entities=None, **kwargs)
         self.__target_action = target_action
         self.__on_stdin = on_stdin
@@ -64,7 +64,7 @@ class OnProcessIO(EventHandler):
             )
         )
 
-    def handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+    def _handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         """Handle the given event."""
         event = cast(ProcessIO, event)
         if event.from_stdout and self.__on_stdout is not None:

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -20,7 +20,7 @@ from typing import Optional
 from typing import Text
 
 from ..event import Event
-from ..event_handler import EventHandler
+from ..event_handler import BaseEventHandler
 from ..events.process import ProcessIO
 from ..launch_context import LaunchContext
 from ..some_actions_type import SomeActionsType
@@ -30,7 +30,7 @@ if False:
     from ..actions import ExecuteProcess  # noqa
 
 
-class OnProcessIO(EventHandler):
+class OnProcessIO(BaseEventHandler):
     """Convenience class for handling I/O from processes via events."""
 
     # TODO(wjwwood): make the __init__ more flexible like OnProcessExit, so
@@ -48,7 +48,7 @@ class OnProcessIO(EventHandler):
         from ..actions import ExecuteProcess  # noqa
         if not isinstance(target_action, (ExecuteProcess, type(None))):
             raise TypeError("OnProcessIO requires an 'ExecuteProcess' action as the target")
-        super().__init__(matcher=self._matcher, entities=None, **kwargs)
+        super().__init__(matcher=self._matcher, **kwargs)
         self.__target_action = target_action
         self.__on_stdin = on_stdin
         self.__on_stdout = on_stdout

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -64,8 +64,10 @@ class OnProcessIO(EventHandler):
             )
         )
 
-    def _handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+    def handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         """Handle the given event."""
+        super().handle(event, context)
+
         event = cast(ProcessIO, event)
         if event.from_stdout and self.__on_stdout is not None:
             return self.__on_stdout(event)

--- a/launch/launch/event_handlers/on_process_start.py
+++ b/launch/launch/event_handlers/on_process_start.py
@@ -23,7 +23,7 @@ from typing import Text
 from typing import Union
 
 from ..event import Event
-from ..event_handler import EventHandler
+from ..event_handler import BaseEventHandler
 from ..events.process import ProcessStarted
 from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
@@ -35,7 +35,7 @@ if False:
     from ..actions import ExecuteProcess  # noqa
 
 
-class OnProcessStart(EventHandler):
+class OnProcessStart(BaseEventHandler):
     """
     Convenience class for handling a process started event.
 
@@ -64,7 +64,6 @@ class OnProcessStart(EventHandler):
                     )
                 )
             ),
-            entities=None,
             **kwargs,
         )
         self.__target_action = target_action

--- a/launch/launch/event_handlers/on_process_start.py
+++ b/launch/launch/event_handlers/on_process_start.py
@@ -85,7 +85,7 @@ class OnProcessStart(EventHandler):
         else:
             raise TypeError('on_start with type {} not allowed'.format(repr(on_start)))
 
-    def handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+    def _handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         """Handle the given event."""
         if self.__actions_on_start:
             return self.__actions_on_start

--- a/launch/launch/event_handlers/on_process_start.py
+++ b/launch/launch/event_handlers/on_process_start.py
@@ -85,8 +85,10 @@ class OnProcessStart(EventHandler):
         else:
             raise TypeError('on_start with type {} not allowed'.format(repr(on_start)))
 
-    def _handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+    def handle(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
         """Handle the given event."""
+        super().handle(event, context)
+
         if self.__actions_on_start:
             return self.__actions_on_start
         return self.__on_start(cast(ProcessStarted, event), context)

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -21,7 +21,7 @@ from typing import overload
 from typing import Text
 
 from ..event import Event
-from ..event_handler import EventHandler
+from ..event_handler import BaseEventHandler
 from ..events import Shutdown
 from ..some_actions_type import SomeActionsType
 from ..utilities import is_a_subclass
@@ -31,7 +31,7 @@ if False:
     from ..launch_context import LaunchContext  # noqa
 
 
-class OnShutdown(EventHandler):
+class OnShutdown(BaseEventHandler):
     """Convenience class for handling the launch shutdown event."""
 
     @overload
@@ -53,7 +53,6 @@ class OnShutdown(EventHandler):
         """Constructor."""
         super().__init__(
             matcher=lambda event: is_a_subclass(event, Shutdown),
-            entities=None,  # noop
             **kwargs,
         )
         # TODO(wjwwood) check that it is not only callable, but also a callable that matches

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -62,9 +62,8 @@ class OnShutdown(EventHandler):
         if not callable(on_shutdown):
             self.__on_shutdown = (lambda event, context: on_shutdown)
 
-    def handle(self, event: Event, context: 'LaunchContext') -> Optional[SomeActionsType]:
+    def _handle(self, event: Event, context: 'LaunchContext') -> Optional[SomeActionsType]:
         """Handle the given event."""
-        context.extend_locals({'event': event})
         return self.__on_shutdown(cast(Shutdown, event), context)
 
     @property

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -62,8 +62,9 @@ class OnShutdown(EventHandler):
         if not callable(on_shutdown):
             self.__on_shutdown = (lambda event, context: on_shutdown)
 
-    def _handle(self, event: Event, context: 'LaunchContext') -> Optional[SomeActionsType]:
+    def handle(self, event: Event, context: 'LaunchContext') -> Optional[SomeActionsType]:
         """Handle the given event."""
+        super().handle(event, context)
         return self.__on_shutdown(cast(Shutdown, event), context)
 
     @property

--- a/launch/test/launch/test_on_include_launch_description.py
+++ b/launch/test/launch/test_on_include_launch_description.py
@@ -1,0 +1,56 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OnIncludeLaunchDescription event handler."""
+
+from unittest.mock import Mock
+
+from launch import LaunchContext
+from launch import LaunchDescription
+from launch.action import Action
+from launch.event_handlers.on_include_launch_description import OnIncludeLaunchDescription
+from launch.events import IncludeLaunchDescription
+from launch.events.process import ProcessStarted
+
+phony_process_started = ProcessStarted(
+    action=Mock(spec=Action), name='PhonyProcessStarted', cmd=['ls'], cwd=None, env=None, pid=1)
+phony_include_launch_description = IncludeLaunchDescription(
+    launch_description=Mock(spec=LaunchDescription))
+phony_context = Mock(spec=LaunchContext)
+
+
+def test_matches_include_launch_description():
+    handler = OnIncludeLaunchDescription()
+    assert handler.matches(phony_include_launch_description)
+    assert not handler.matches(phony_process_started)
+
+
+def test_event_added_to_context():
+    context = Mock(spec=LaunchContext)
+    extend_locals_mock = context.extend_locals
+    unregister_event_handler_mock = context.unregister_event_handler
+
+    handler = OnIncludeLaunchDescription()
+    handler.handle(phony_include_launch_description, context)
+    extend_locals_mock.assert_called_once_with({'event': phony_include_launch_description})
+    unregister_event_handler_mock.assert_not_called()
+
+
+def test_handle_once():
+    context = Mock(spec=LaunchContext)
+    unregister_event_handler_mock = context.unregister_event_handler
+
+    handler = OnIncludeLaunchDescription(handle_once=True)
+    handler.handle(phony_include_launch_description, context)
+    unregister_event_handler_mock.assert_called_once_with(handler)

--- a/launch/test/launch/test_on_process_exit.py
+++ b/launch/test/launch/test_on_process_exit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the OnProcessStart event handler."""
+"""Tests for the OnProcessExit event handler."""
 
 from unittest.mock import Mock
 from unittest.mock import NonCallableMock
@@ -20,7 +20,7 @@ from unittest.mock import NonCallableMock
 from launch import LaunchContext
 from launch.action import Action
 from launch.actions.execute_process import ExecuteProcess
-from launch.event_handlers.on_process_start import OnProcessStart
+from launch.event_handlers.on_process_exit import OnProcessExit
 from launch.events.process import ProcessExited
 from launch.events.process import ProcessStarted
 
@@ -37,52 +37,53 @@ phony_context = Mock(spec=LaunchContext)
 
 def test_non_execute_process_target():
     with pytest.raises(TypeError):
-        OnProcessStart(
+        OnProcessExit(
             target_action=Mock(),
-            on_start=NonCallableMock(spec=Action))
+            on_exit=NonCallableMock(spec=Action))
 
 
-def test_non_action_on_start():
+def test_non_action_on_exit():
     with pytest.raises(TypeError):
-        OnProcessStart(
+        OnProcessExit(
             target_action=Mock(spec=ExecuteProcess),
             on_start=NonCallableMock())
 
 
-def test_matches_process_started():
-    handler = OnProcessStart(on_start=Mock())
-    assert handler.matches(phony_process_started)
-    assert not handler.matches(phony_process_exited)
+def test_matches_process_exited():
+    handler = OnProcessExit(on_exit=Mock())
+    assert handler.matches(phony_process_exited)
+    assert not handler.matches(phony_process_started)
 
 
 def test_matches_single_process():
     target_action = Mock(spec=ExecuteProcess)
-    handler = OnProcessStart(
+    handler = OnProcessExit(
         target_action=target_action,
-        on_start=Mock())
-    assert handler.matches(ProcessStarted(
-        action=target_action, name='foo', cmd=['ls'], cwd=None, env=None, pid=3))
+        on_exit=Mock())
+    assert handler.matches(ProcessExited(
+        action=target_action, name='foo', cmd=['ls'], cwd=None, env=None, pid=3,
+        returncode=0))
     assert not handler.matches(phony_process_started)
     assert not handler.matches(phony_process_exited)
 
 
 def test_handle_callable():
     mock_callable = Mock()
-    handler = OnProcessStart(on_start=mock_callable)
-    handler.handle(phony_process_started, phony_context)
-    mock_callable.assert_called_once_with(phony_process_started, phony_context)
+    handler = OnProcessExit(on_exit=mock_callable)
+    handler.handle(phony_process_exited, phony_context)
+    mock_callable.assert_called_once_with(phony_process_exited, phony_context)
 
 
 def test_handle_action():
     mock_action = NonCallableMock(spec=Action)
-    handler = OnProcessStart(on_start=mock_action)
-    assert [mock_action] == handler.handle(phony_process_started, phony_context)
+    handler = OnProcessExit(on_exit=mock_action)
+    assert [mock_action] == handler.handle(phony_process_exited, phony_context)
 
 
 def test_handle_list_of_actions():
     mock_actions = [NonCallableMock(spec=Action), NonCallableMock(spec=Action)]
-    handler = OnProcessStart(on_start=mock_actions)
-    assert mock_actions == handler.handle(phony_process_started, phony_context)
+    handler = OnProcessExit(on_exit=mock_actions)
+    assert mock_actions == handler.handle(phony_process_exited, phony_context)
 
 
 def test_event_added_to_context():
@@ -90,9 +91,9 @@ def test_event_added_to_context():
     extend_locals_mock = context.extend_locals
     unregister_event_handler_mock = context.unregister_event_handler
 
-    handler = OnProcessStart(on_start=Mock())
-    handler.handle(phony_process_started, context)
-    extend_locals_mock.assert_called_once_with({'event': phony_process_started})
+    handler = OnProcessExit(on_exit=Mock())
+    handler.handle(phony_process_exited, context)
+    extend_locals_mock.assert_called_once_with({'event': phony_process_exited})
     unregister_event_handler_mock.assert_not_called()
 
 
@@ -100,6 +101,6 @@ def test_handle_once():
     context = Mock(spec=LaunchContext)
     unregister_event_handler_mock = context.unregister_event_handler
 
-    handler = OnProcessStart(on_start=Mock(), handle_once=True)
-    handler.handle(phony_process_started, context)
+    handler = OnProcessExit(on_exit=Mock(), handle_once=True)
+    handler.handle(phony_process_exited, context)
     unregister_event_handler_mock.assert_called_once_with(handler)

--- a/launch/test/launch/test_on_process_io.py
+++ b/launch/test/launch/test_on_process_io.py
@@ -1,0 +1,130 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OnProcessIO event handler."""
+
+from unittest.mock import Mock
+
+from launch import LaunchContext
+from launch.action import Action
+from launch.actions.execute_process import ExecuteProcess
+from launch.event_handlers.on_process_io import OnProcessIO
+from launch.events.process import ProcessIO
+from launch.events.process import ProcessStarted
+
+import pytest
+
+
+phony_process_started = ProcessStarted(
+    action=Mock(spec=Action), name='PhonyProcessStarted', cmd=['ls'], cwd=None, env=None, pid=1)
+phony_process_io = ProcessIO(
+    action=Mock(spec=Action), name='PhonyProcessIO', cmd=['ls'], cwd=None, env=None, pid=1,
+    text=b'phony io', fd=0)
+phony_context = Mock(spec=LaunchContext)
+
+
+def test_non_execute_target():
+    with pytest.raises(TypeError):
+        OnProcessIO(target_action=Mock())
+
+
+def test_matches_process_io():
+    handler = OnProcessIO()
+    assert handler.matches(phony_process_io)
+    assert not handler.matches(phony_process_started)
+
+
+def test_matches_single_process_output():
+    target_action = Mock(spec=ExecuteProcess)
+    handler = OnProcessIO(
+        target_action=target_action)
+    assert handler.matches(ProcessIO(
+        action=target_action, name='foo', cmd=['ls'], cwd=None, env=None, pid=3,
+        text=b'phony io', fd=0))
+    assert not handler.matches(phony_process_started)
+    assert not handler.matches(phony_process_io)
+
+
+def test_handle_callable_stdin():
+    mock_stdin_callable = Mock()
+    mock_stdout_callable = Mock()
+    mock_stderr_callable = Mock()
+    handler = OnProcessIO(
+        on_stdin=mock_stdin_callable,
+        on_stdout=mock_stdout_callable,
+        on_stderr=mock_stderr_callable)
+
+    event = ProcessIO(
+        action=Mock(spec=Action), name='stdin', cmd=['ls'], cwd=None, env=None, pid=1,
+        text=b'stdin', fd=0)
+    handler.handle(event, phony_context)
+    mock_stdin_callable.assert_called_once_with(event)
+    mock_stdout_callable.assert_not_called()
+    mock_stderr_callable.assert_not_called()
+
+
+def test_handle_callable_stdout():
+    mock_stdin_callable = Mock()
+    mock_stdout_callable = Mock()
+    mock_stderr_callable = Mock()
+    handler = OnProcessIO(
+        on_stdin=mock_stdin_callable,
+        on_stdout=mock_stdout_callable,
+        on_stderr=mock_stderr_callable)
+
+    event = ProcessIO(
+        action=Mock(spec=Action), name='stdout', cmd=['ls'], cwd=None, env=None, pid=1,
+        text=b'stdout', fd=1)
+    handler.handle(event, phony_context)
+    mock_stdout_callable.assert_called_once_with(event)
+    mock_stdin_callable.assert_not_called()
+    mock_stderr_callable.assert_not_called()
+
+
+def test_handle_callable_stderr():
+    mock_stdin_callable = Mock()
+    mock_stdout_callable = Mock()
+    mock_stderr_callable = Mock()
+    handler = OnProcessIO(
+        on_stdin=mock_stdin_callable,
+        on_stdout=mock_stdout_callable,
+        on_stderr=mock_stderr_callable)
+
+    event = ProcessIO(
+        action=Mock(spec=Action), name='stderr', cmd=['ls'], cwd=None, env=None, pid=1,
+        text=b'stderr', fd=2)
+    handler.handle(event, phony_context)
+    mock_stderr_callable.assert_called_once_with(event)
+    mock_stdin_callable.assert_not_called()
+    mock_stdout_callable.assert_not_called()
+
+
+def test_event_added_to_context():
+    context = Mock(spec=LaunchContext)
+    extend_locals_mock = context.extend_locals
+    unregister_event_handler_mock = context.unregister_event_handler
+
+    handler = OnProcessIO()
+    handler.handle(phony_process_io, context)
+    extend_locals_mock.assert_called_once_with({'event': phony_process_io})
+    unregister_event_handler_mock.assert_not_called()
+
+
+def test_handle_once():
+    context = Mock(spec=LaunchContext)
+    unregister_event_handler_mock = context.unregister_event_handler
+
+    handler = OnProcessIO(handle_once=True)
+    handler.handle(phony_process_io, context)
+    unregister_event_handler_mock.assert_called_once_with(handler)

--- a/launch/test/launch/test_on_shutdown.py
+++ b/launch/test/launch/test_on_shutdown.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OnShutdown event handler."""
+
+from unittest.mock import Mock
+from unittest.mock import NonCallableMock
+
+from launch import LaunchContext
+from launch.action import Action
+from launch.event_handlers.on_shutdown import OnShutdown
+from launch.events import Shutdown
+from launch.events.process import ProcessStarted
+
+phony_process_started = ProcessStarted(
+    action=Mock(spec=Action), name='PhonyProcessStarted', cmd=['ls'], cwd=None, env=None, pid=1)
+phony_shutdown = Shutdown()
+phony_context = Mock(spec=LaunchContext)
+
+
+def test_matches_shutdown():
+    handler = OnShutdown(on_shutdown=Mock())
+    assert handler.matches(phony_shutdown)
+    assert not handler.matches(phony_process_started)
+
+
+def test_handle_callable():
+    mock_callable = Mock()
+    handler = OnShutdown(on_shutdown=mock_callable)
+    handler.handle(phony_shutdown, phony_context)
+    mock_callable.assert_called_once_with(phony_shutdown, phony_context)
+
+
+def test_handle_action():
+    mock_action = NonCallableMock(spec=Action)
+    handler = OnShutdown(on_shutdown=mock_action)
+    assert mock_action == handler.handle(phony_shutdown, phony_context)
+
+
+def test_event_added_to_context():
+    context = Mock(spec=LaunchContext)
+    extend_locals_mock = context.extend_locals
+    unregister_event_handler_mock = context.unregister_event_handler
+
+    handler = OnShutdown(on_shutdown=Mock())
+    handler.handle(phony_shutdown, context)
+    extend_locals_mock.assert_called_once_with({'event': phony_shutdown})
+    unregister_event_handler_mock.assert_not_called()
+
+
+def test_handle_once():
+    context = Mock(spec=LaunchContext)
+    unregister_event_handler_mock = context.unregister_event_handler
+
+    handler = OnShutdown(on_shutdown=Mock(), handle_once=True)
+    handler.handle(phony_shutdown, context)
+    unregister_event_handler_mock.assert_called_once_with(handler)


### PR DESCRIPTION
There is some inconsistency in what event handlers add to the context's `locals`. Some add the event, others don't, and [the documentation for `EventHandler`](https://github.com/ros2/launch/blob/master/launch/launch/event_handler.py#L35) implies that they all should (this was reaffirmed during a conversation with @wjwwood in IRC).

First of all, this PR adds tests for all event handlers (only `OnProcessStart` had any) in order to ensure behavior is not changed. In the process, a few inconsistencies were found regarding exception types which were resolved.

Finally, a small backward-compatible `EventHandler` API modification was made to ensure all event handlers properly added the event to the context's locals as well as properly handled `handle_once=True` (few did).