### PR TITLE
Support required nodes

### DIFF
--- a/launch/launch/actions/__init__.py
+++ b/launch/launch/actions/__init__.py
@@ -25,6 +25,7 @@ from .pop_launch_configurations import PopLaunchConfigurations
 from .push_launch_configurations import PushLaunchConfigurations
 from .register_event_handler import RegisterEventHandler
 from .set_launch_configuration import SetLaunchConfiguration
+from .shutdown_action import Shutdown
 from .timer_action import TimerAction
 from .unregister_event_handler import UnregisterEventHandler
 from .unset_launch_configuration import UnsetLaunchConfiguration
@@ -41,6 +42,7 @@ __all__ = [
     'PushLaunchConfigurations',
     'RegisterEventHandler',
     'SetLaunchConfiguration',
+    'Shutdown',
     'TimerAction',
     'UnregisterEventHandler',
     'UnsetLaunchConfiguration',

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -89,9 +89,10 @@ class ExecuteProcess(Action):
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Optional[Text] = None,
         log_cmd: bool = False,
-        on_exit: Optional[Union[SomeActionsType,
-                          Callable[
-                              [ProcessExited, LaunchContext], Optional[SomeActionsType]]]] = None,
+        on_exit: Optional[Union[
+            SomeActionsType,
+            Callable[[ProcessExited, LaunchContext], Optional[SomeActionsType]]
+        ]] = None,
         **kwargs
     ) -> None:
         """

--- a/launch/launch/actions/shutdown_action.py
+++ b/launch/launch/actions/shutdown_action.py
@@ -15,6 +15,7 @@
 """Module for the Shutdown action."""
 
 import logging
+from typing import Text
 
 from .emit_event import EmitEvent
 from ..events import Shutdown as ShutdownEvent
@@ -27,8 +28,8 @@ _logger = logging.getLogger(name='launch')
 class Shutdown(EmitEvent):
     """Action that shuts down a launched system by emitting Shutdown when executed."""
 
-    def __init__(self, **kwargs):
-        super().__init__(event=ShutdownEvent(), **kwargs)
+    def __init__(self, *, reason: Text = 'reason not given', **kwargs):
+        super().__init__(event=ShutdownEvent(reason=reason), **kwargs)
 
     def execute(self, context: LaunchContext):
         """Execute the action."""

--- a/launch/launch/actions/shutdown_action.py
+++ b/launch/launch/actions/shutdown_action.py
@@ -16,7 +16,7 @@
 
 import logging
 
-from ..action import Action
+from .emit_event import EmitEvent
 from ..events import Shutdown as ShutdownEvent
 from ..events.process import ProcessExited
 from ..launch_context import LaunchContext
@@ -24,8 +24,11 @@ from ..launch_context import LaunchContext
 _logger = logging.getLogger(name='launch')
 
 
-class Shutdown(Action):
+class Shutdown(EmitEvent):
     """Action that shuts down a launched system by emitting Shutdown when executed."""
+
+    def __init__(self, **kwargs):
+        super().__init__(event=ShutdownEvent(), **kwargs)
 
     def execute(self, context: LaunchContext):
         """Execute the action."""
@@ -38,4 +41,4 @@ class Shutdown(Action):
             _logger.info('process[{}] was required: shutting down launched system'.format(
                 event.process_name))
 
-        context.emit_event_sync(ShutdownEvent())
+        super().execute(context)

--- a/launch/launch/actions/shutdown_action.py
+++ b/launch/launch/actions/shutdown_action.py
@@ -1,0 +1,41 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the Shutdown action."""
+
+import logging
+
+from ..action import Action
+from ..events import Shutdown as ShutdownEvent
+from ..events.process import ProcessExited
+from ..launch_context import LaunchContext
+
+_logger = logging.getLogger(name='launch')
+
+
+class Shutdown(Action):
+    """Action that shuts down a launched system by emitting Shutdown when executed."""
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        try:
+            event = context.locals.event
+        except AttributeError:
+            event = None
+
+        if isinstance(event, ProcessExited):
+            _logger.info('process[{}] was required: shutting down launched system'.format(
+                event.process_name))
+
+        context.emit_event_sync(ShutdownEvent())

--- a/launch/test/launch/actions/test_shutdown_action.py
+++ b/launch/test/launch/actions/test_shutdown_action.py
@@ -44,3 +44,14 @@ def test_shutdown_execute_conditional():
     assert context._event_queue.qsize() == 1
     event = context._event_queue.get_nowait()
     assert isinstance(event, ShutdownEvent)
+
+
+def test_shutdown_reason():
+    """Test the execute (or visit) of a Shutdown class that has a reason."""
+    action = Shutdown(reason='test reason')
+    context = LaunchContext()
+    assert action.visit(context) is None
+    assert context._event_queue.qsize() == 1
+    event = context._event_queue.get_nowait()
+    assert isinstance(event, ShutdownEvent)
+    assert event.reason == 'test reason'

--- a/launch/test/launch/actions/test_shutdown_action.py
+++ b/launch/test/launch/actions/test_shutdown_action.py
@@ -1,0 +1,46 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Shutdown action class."""
+
+from launch import LaunchContext
+from launch.actions import Shutdown
+from launch.conditions import IfCondition
+from launch.events import Shutdown as ShutdownEvent
+
+
+def test_shutdown_execute():
+    """Test the execute (or visit) of the Shutdown class."""
+    action = Shutdown()
+    context = LaunchContext()
+    assert context._event_queue.qsize() == 0
+    assert action.visit(context) is None
+    assert context._event_queue.qsize() == 1
+    event = context._event_queue.get_nowait()
+    assert isinstance(event, ShutdownEvent)
+
+
+def test_shutdown_execute_conditional():
+    """Test the conditional execution (or visit) of the Shutdown class."""
+    true_action = Shutdown(condition=IfCondition('True'))
+    false_action = Shutdown(condition=IfCondition('False'))
+    context = LaunchContext()
+
+    assert context._event_queue.qsize() == 0
+    assert false_action.visit(context) is None
+    assert context._event_queue.qsize() == 0
+    assert true_action.visit(context) is None
+    assert context._event_queue.qsize() == 1
+    event = context._event_queue.get_nowait()
+    assert isinstance(event, ShutdownEvent)


### PR DESCRIPTION
Currently, the only way to specify that a given node is required for a given `LaunchDescription` is to register an `OnProcessExit` handler for the exit event of the required node that then emits a `Shutdown` event. Instead of requiring this boilerplate for a common use-case, This PR resolves #174 by adding an `on_exit` parameter to `ExecuteProcess` that can take actions, and adding a new action called `Shutdown` that immediately causes the launched system to shut down. This allows for the concept of a required node to be expressed simply with:

    launch_ros.actions.Node(
        # ...
        on_exit=Shutdown()
    )