### PR TITLE
Timers will cancel on shutdown

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -308,27 +308,35 @@ class ExecuteProcess(Action):
             ('float(', *self.__sigterm_timeout, ') + float(', *self.__sigkill_timeout, ')')
         )]
         # Setup a timer to send us a SIGTERM if we don't shutdown quickly.
-        self.__sigterm_timer = TimerAction(period=sigterm_timeout, actions=[
-            OpaqueFunction(
-                function=printer,
-                args=(base_msg.format('{}', '{}', 'SIGINT', 'SIGTERM'), sigterm_timeout)
-            ),
-            EmitEvent(event=SignalProcess(
-                signal_number=signal.SIGTERM,
-                process_matcher=matches_action(self)
-            )),
-        ])
+        self.__sigterm_timer = TimerAction(
+            period=sigterm_timeout,
+            actions=[
+                OpaqueFunction(
+                    function=printer,
+                    args=(base_msg.format('{}', '{}', 'SIGINT', 'SIGTERM'), sigterm_timeout)
+                ),
+                EmitEvent(event=SignalProcess(
+                    signal_number=signal.SIGTERM,
+                    process_matcher=matches_action(self)
+                )),
+            ],
+            cancel_on_shutdown=False,
+        )
         # Setup a timer to send us a SIGKILL if we don't shutdown after SIGTERM.
-        self.__sigkill_timer = TimerAction(period=sigkill_timeout, actions=[
-            OpaqueFunction(
-                function=printer,
-                args=(base_msg.format('{}', '{}', 'SIGTERM', 'SIGKILL'), sigkill_timeout)
-            ),
-            EmitEvent(event=SignalProcess(
-                signal_number='SIGKILL',
-                process_matcher=matches_action(self)
-            ))
-        ])
+        self.__sigkill_timer = TimerAction(
+            period=sigkill_timeout,
+            actions=[
+                OpaqueFunction(
+                    function=printer,
+                    args=(base_msg.format('{}', '{}', 'SIGTERM', 'SIGKILL'), sigkill_timeout)
+                ),
+                EmitEvent(event=SignalProcess(
+                    signal_number='SIGKILL',
+                    process_matcher=matches_action(self)
+                ))
+            ],
+            cancel_on_shutdown=False,
+        )
         return [
             cast(Action, self.__sigterm_timer),
             cast(Action, self.__sigkill_timer),

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -27,6 +27,7 @@ from typing import Text
 from typing import Tuple
 from typing import Union
 
+from .opaque_function import OpaqueFunction
 from ..action import Action
 from ..event_handler import EventHandler
 from ..events import Shutdown
@@ -41,7 +42,6 @@ from ..utilities import ensure_argument_type
 from ..utilities import is_a_subclass
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
-from .opaque_function import OpaqueFunction
 
 _logger = logging.getLogger('launch.timer_action')
 

--- a/launch/test/launch/test_timer_action.py
+++ b/launch/test/launch/test_timer_action.py
@@ -137,7 +137,7 @@ def test_timer_can_block_preemption():
         ),
 
         launch.actions.TimerAction(
-            period="2",
+            period='2',
             actions=[
                 launch.actions.Shutdown(reason='slow shutdown')
             ],

--- a/launch/test/launch/test_timer_action.py
+++ b/launch/test/launch/test_timer_action.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 
+"""Tests for the TimerAction Action."""
+import sys
+
 import launch
 import launch.actions
+import launch.event_handlers
 
 
 def test_multiple_launch_with_timers():
@@ -24,6 +28,11 @@ def test_multiple_launch_with_timers():
 
     def generate_launch_description():
         return launch.LaunchDescription([
+
+            launch.actions.ExecuteProcess(
+                cmd=[sys.executable, '-c', 'while True: pass'],
+            ),
+
             launch.actions.TimerAction(
                 period='1',
                 actions=[
@@ -34,9 +43,113 @@ def test_multiple_launch_with_timers():
 
     ls = launch.LaunchService()
     ls.include_launch_description(generate_launch_description())
-    assert 0 == ls.run(shutdown_when_idle=False)  # Always works
+    assert 0 == ls.run()  # Always works
 
     ls = launch.LaunchService()
     ls.include_launch_description(generate_launch_description())
     # Next line hangs forever before https://github.com/ros2/launch/issues/183 was fixed.
-    assert 0 == ls.run(shutdown_when_idle=False)
+    assert 0 == ls.run()
+
+
+def _shutdown_listener_factory(reasons_arr):
+    return launch.actions.RegisterEventHandler(
+        launch.event_handlers.OnShutdown(
+            on_shutdown=lambda event, context: reasons_arr.append(event)
+        )
+    )
+
+
+def test_timer_action_sanity_check():
+    """Test that timer actions work (sanity check)."""
+    # This test is structured like test_shutdown_preempts_timers and
+    # test_timer_can_block_preemption as a sanity check that the shutdown listener
+    # and other launch related infrastructure works as expected
+    shutdown_reasons = []
+
+    ld = launch.LaunchDescription([
+        launch.actions.ExecuteProcess(
+            cmd=[sys.executable, '-c', 'while True: pass'],
+        ),
+
+        launch.actions.TimerAction(
+            period='1',
+            actions=[
+                launch.actions.Shutdown(reason='One second timeout')
+            ]
+        ),
+
+        _shutdown_listener_factory(shutdown_reasons),
+    ])
+
+    ls = launch.LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+    assert shutdown_reasons[0].reason == 'One second timeout'
+
+
+def test_shutdown_preempts_timers():
+    shutdown_reasons = []
+
+    ld = launch.LaunchDescription([
+
+        launch.actions.ExecuteProcess(
+            cmd=[sys.executable, '-c', 'while True: pass'],
+        ),
+
+        launch.actions.TimerAction(
+            period='1',
+            actions=[
+                launch.actions.Shutdown(reason='fast shutdown')
+            ]
+        ),
+
+        launch.actions.TimerAction(
+            period='2',
+            actions=[
+                launch.actions.Shutdown(reason='slow shutdown')
+            ]
+        ),
+
+        _shutdown_listener_factory(shutdown_reasons),
+    ])
+
+    ls = launch.LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+    assert len(shutdown_reasons) == 1
+    assert shutdown_reasons[0].reason == 'fast shutdown'
+
+
+def test_timer_can_block_preemption():
+    shutdown_reasons = []
+
+    ld = launch.LaunchDescription([
+
+        launch.actions.ExecuteProcess(
+            cmd=[sys.executable, '-c', 'while True: pass'],
+        ),
+
+        launch.actions.TimerAction(
+            period='1',
+            actions=[
+                launch.actions.Shutdown(reason='fast shutdown')
+            ]
+        ),
+
+        launch.actions.TimerAction(
+            period="2",
+            actions=[
+                launch.actions.Shutdown(reason='slow shutdown')
+            ],
+            cancel_on_shutdown=False  # Preempted in test_shutdown_preempts_timers, but not here
+        ),
+
+        _shutdown_listener_factory(shutdown_reasons),
+    ])
+
+    ls = launch.LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+    assert len(shutdown_reasons) == 2  # Should see 'shutdown' event twice because
+    assert shutdown_reasons[0].reason == 'fast shutdown'
+    assert shutdown_reasons[1].reason == 'slow shutdown'


### PR DESCRIPTION
 - By default, a shutdown event will cancel a TimerAction
 - The timers used to send SIGKILL and SIGTERM to processes don't cancel on shutdown

From issue https://github.com/ros2/launch/issues/180

The only TimerActions I found in launch are the sigterm timer and sigkill timer in launch/actions/execute_process.py.  I've set these up to not cancel on shutdown

@wjwwood I'm a little concerned about the thread safety note [here](https://github.com/ros2/launch/blob/master/launch/launch/actions/timer_action.py#L103-L111).  I didn't deep dive the thread model for event EventHandler actions.  Do I need to be more cautious about calling self.cancel from an OpaqueFunction in TimerAction.execute?

#### Todo:
- [x] Make sure this works for ctrl+c, otherwise it's weird