### PR TITLE
Fix test failures

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -23,7 +23,7 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Text  # noqa: F401
-from typing import Tuple
+from typing import Tuple  # noqa: F401
 
 from launch import Substitution
 from launch.action import Action

--- a/launch_testing/launch_testing/legacy/__init__.py
+++ b/launch_testing/launch_testing/legacy/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from importlib.machinery import SourceFileLoader
 import io
 import os


### PR DESCRIPTION
Seeing two local test failures when I run pytest locally:

```
> pytest launch/test
...
...
...
======================================== FAILURES =========================================
_____________________________________ test_copyright ______________________________________

    @pytest.mark.copyright
    @pytest.mark.linter
    def test_copyright():
        rc = main(argv=['.', 'test'])
>       assert rc == 0, 'Found errors'
E       AssertionError: Found errors
E       assert 1 == 0

launch/test/test_copyright.py:23: AssertionError
---------------------------------- Captured stderr call -----------------------------------
launch_testing/launch_testing/legacy/__init__.py: could not find copyright notice
1 errors, checked 188 files
_______________________________________ test_flake8 _______________________________________

    @pytest.mark.flake8
    @pytest.mark.linter
    def test_flake8():
        rc = main(argv=[])
>       assert rc == 0, 'Found errors'
E       AssertionError: Found errors
E       assert 1 == 0

launch/test/test_flake8.py:23: AssertionError
---------------------------------- Captured stdout call -----------------------------------

./launch_ros/launch_ros/actions/node.py:26:1: F401 'typing.Tuple' imported but unused
from typing import Tuple
^

1     F401 'typing.Tuple' imported but unused

191 files checked
1 errors
```
### Changes
 - launch_testing/launch/launch_testing/legacy/__init__.py missing copyright
 - launch_ros/launch_ros/actions/node flake8 error