### PR TITLE
Fixes timer global init of event handler

### DIFF
--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -135,7 +135,7 @@ class TimerAction(Action):
             return None
 
         # Once per context, install the general purpose OnTimerEvent event handler.
-        if not hasattr(context, "_TimerAction__event_handler_has_been_installed"):
+        if not hasattr(context, '_TimerAction__event_handler_has_been_installed'):
             from ..actions import OpaqueFunction
             context.register_event_handler(EventHandler(
                 matcher=lambda event: is_a_subclass(event, TimerEvent),
@@ -145,7 +145,7 @@ class TimerAction(Action):
                     )
                 ),
             ))
-            setattr(context, "_TimerAction__event_handler_has_been_installed", True)
+            setattr(context, '_TimerAction__event_handler_has_been_installed', True)
 
         # Capture the current context locals so the yielded actions can make use of them too.
         self.__context_locals = dict(context.get_locals_as_dict())  # Capture a copy

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -41,7 +41,6 @@ from ..utilities import is_a_subclass
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
 
-_event_handler_has_been_installed = False
 _logger = logging.getLogger('launch.timer_action')
 
 
@@ -136,8 +135,7 @@ class TimerAction(Action):
             return None
 
         # Once globally, install the general purpose OnTimerEvent event handler.
-        global _event_handler_has_been_installed
-        if not _event_handler_has_been_installed:
+        if not hasattr(context, "_TimerAction__event_handler_has_been_installed"):
             from ..actions import OpaqueFunction
             context.register_event_handler(EventHandler(
                 matcher=lambda event: is_a_subclass(event, TimerEvent),
@@ -147,7 +145,7 @@ class TimerAction(Action):
                     )
                 ),
             ))
-            _event_handler_has_been_installed = True
+            setattr(context, "_TimerAction__event_handler_has_been_installed", True)
 
         # Capture the current context locals so the yielded actions can make use of them too.
         self.__context_locals = dict(context.get_locals_as_dict())  # Capture a copy

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -134,7 +134,7 @@ class TimerAction(Action):
             self.__completed_future.set_result(None)
             return None
 
-        # Once globally, install the general purpose OnTimerEvent event handler.
+        # Once per context, install the general purpose OnTimerEvent event handler.
         if not hasattr(context, "_TimerAction__event_handler_has_been_installed"):
             from ..actions import OpaqueFunction
             context.register_event_handler(EventHandler(

--- a/launch/test/launch/test_timer_action.py
+++ b/launch/test/launch/test_timer_action.py
@@ -37,4 +37,5 @@ def test_multiple_launch_with_timers():
 
     ls = launch.LaunchService()
     ls.include_launch_description(generate_launch_description())
-    assert 0 == ls.run(shutdown_when_idle=False)  # Hangs forever before BUG183 is fixed
+    # Next line hangs forever before https://github.com/ros2/launch/issues/183 was fixed.
+    assert 0 == ls.run(shutdown_when_idle=False)

--- a/launch/test/launch/test_timer_action.py
+++ b/launch/test/launch/test_timer_action.py
@@ -1,0 +1,40 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import launch
+import launch.actions
+
+def test_multiple_launch_with_timers():
+    # Regression test for https://github.com/ros2/launch/issues/183
+    # Unfortunately, when things aren't working this test just hangs on the second call to
+    # ls.run
+
+    def generate_launch_description():
+        return launch.LaunchDescription([
+            launch.actions.TimerAction(
+                period="1",
+                actions=[
+                    launch.actions.Shutdown(reason="Timer expired")
+                ]
+            )
+        ])
+
+    ls = launch.LaunchService()
+    ls.include_launch_description(generate_launch_description())
+    assert 0 == ls.run(shutdown_when_idle=False)  # Always works
+
+    ls = launch.LaunchService()
+    ls.include_launch_description(generate_launch_description())
+    assert 0 == ls.run(shutdown_when_idle=False)  # Hangs forever before BUG183 is fixed

--- a/launch/test/launch/test_timer_action.py
+++ b/launch/test/launch/test_timer_action.py
@@ -16,6 +16,7 @@
 import launch
 import launch.actions
 
+
 def test_multiple_launch_with_timers():
     # Regression test for https://github.com/ros2/launch/issues/183
     # Unfortunately, when things aren't working this test just hangs on the second call to
@@ -24,9 +25,9 @@ def test_multiple_launch_with_timers():
     def generate_launch_description():
         return launch.LaunchDescription([
             launch.actions.TimerAction(
-                period="1",
+                period='1',
                 actions=[
-                    launch.actions.Shutdown(reason="Timer expired")
+                    launch.actions.Shutdown(reason='Timer expired')
                 ]
             )
         ])


### PR DESCRIPTION
Fixes https://github.com/ros2/launch/issues/183

 - Use an attribute on the context to see if we need to install the timer
   callback event handler
 - Add a regression test that fails (hangs, actually) before the fix was applied

I manually verified that a launch description containing multiple timers would only register the TimerEvent handler once.