### PR TITLE
Add normalize_parameters and evaluate_paramters

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -149,7 +149,7 @@ class Node(ExecuteProcess):
                     'ros_specific_arguments[{}]'.format(ros_args_index),
                     description='parameter {}'.format(i))]
                 ros_args_index += 1
-            parameters = normalize_parameters(parameters)
+            normalized_params = normalize_parameters(parameters)
         if remappings is not None:
             i = 0
             for remapping in normalize_remap_rules(remappings):
@@ -164,7 +164,7 @@ class Node(ExecuteProcess):
         self.__node_executable = node_executable
         self.__node_name = node_name
         self.__node_namespace = node_namespace
-        self.__parameters = [] if parameters is None else parameters
+        self.__parameters = [] if parameters is None else normalized_params
         self.__remappings = [] if remappings is None else remappings
         self.__arguments = arguments
 

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -14,6 +14,7 @@
 
 """Module for the Node action."""
 
+from collections.abc import Mapping
 import logging
 import os
 import pathlib
@@ -25,12 +26,10 @@ from typing import Optional
 from typing import Text  # noqa: F401
 from typing import Tuple
 
-from launch import Substitution
 from launch.action import Action
 from launch.actions import ExecuteProcess
 from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
-from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
 from launch.substitutions import LocalSubstitution
 from launch.utilities import ensure_argument_type
 from launch.utilities import normalize_to_list_of_substitutions
@@ -38,6 +37,8 @@ from launch.utilities import perform_substitutions
 
 from launch_ros.remap_rule_type import SomeRemapRules
 from launch_ros.substitutions import ExecutableInPackage
+from launch_ros.utilities import evaluate_parameters
+from launch_ros.utilities import normalize_parameters
 from launch_ros.utilities import normalize_remap_rules
 
 from rclpy.validate_namespace import validate_namespace
@@ -136,11 +137,9 @@ class Node(ExecuteProcess):
             ensure_argument_type(parameters, (list), 'parameters', 'Node')
             # All elements in the list are paths to files with parameters (or substitutions that
             # evaluate to paths), or dictionaries of parameters (fields can be substitutions).
-            parameter_types = list(SomeSubstitutionsType_types_tuple) + [pathlib.Path, dict]
             i = 0
             for param in parameters:
-                ensure_argument_type(param, parameter_types, 'parameters[{}]'.format(i), 'Node')
-                if isinstance(param, dict) and node_name is None:
+                if isinstance(param, Mapping) and node_name is None:
                     raise RuntimeError(
                         'If a dictionary of parameters is specified, the node name must also be '
                         'specified. See https://github.com/ros2/launch/issues/139')
@@ -149,6 +148,7 @@ class Node(ExecuteProcess):
                     'ros_specific_arguments[{}]'.format(ros_args_index),
                     description='parameter {}'.format(i))]
                 ros_args_index += 1
+            parameters = normalize_parameters(parameters)
         if remappings is not None:
             i = 0
             for remapping in normalize_remap_rules(remappings):
@@ -182,65 +182,11 @@ class Node(ExecuteProcess):
             raise RuntimeError("cannot access 'node_name' before executing action")
         return self.__final_node_name
 
-    def _create_params_file_from_dict(self, context, params):
+    def _create_params_file_from_dict(self, params):
         with NamedTemporaryFile(mode='w', prefix='launch_params_', delete=False) as h:
             param_file_path = h.name
             # TODO(dhood): clean up generated parameter files.
-
-            def perform_substitution_if_applicable(context, var):
-                if isinstance(var, (int, float, str)):
-                    # No substitution necessary.
-                    return var
-                if isinstance(var, Substitution):
-                    return perform_substitutions(context, normalize_to_list_of_substitutions(var))
-                if isinstance(var, tuple):
-                    try:
-                        return perform_substitutions(
-                            context, normalize_to_list_of_substitutions(var))
-                    except TypeError:
-                        raise TypeError(
-                            'Invalid element received in parameters dictionary '
-                            '(not all tuple elements are Substitutions): {}'.format(var))
-                else:
-                    raise TypeError(
-                        'Unsupported type received in parameters dictionary: {}'
-                        .format(type(var)))
-
-            def expand_dict(input_dict):
-                expanded_dict = {}
-                for k, v in input_dict.items():
-                    # Key (parameter/group name) can only be a string/Substitutions that evaluates
-                    # to a string.
-                    expanded_key = perform_substitutions(
-                        context, normalize_to_list_of_substitutions(k))
-                    if isinstance(v, dict):
-                        # Expand the nested dict.
-                        expanded_value = expand_dict(v)
-                    elif isinstance(v, list):
-                        # Expand each element.
-                        expanded_value = []
-                        for e in v:
-                            if isinstance(e, list):
-                                raise TypeError(
-                                    'Nested lists are not supported for parameters: {} found in {}'
-                                    .format(e, v))
-                            expanded_value.append(perform_substitution_if_applicable(context, e))
-                    # Tuples are treated as Substitution(s) to be concatenated.
-                    elif isinstance(v, tuple):
-                        for e in v:
-                            ensure_argument_type(
-                                e, SomeSubstitutionsType_types_tuple,
-                                'parameter dictionary tuple entry', 'Node')
-                        expanded_value = perform_substitutions(
-                            context, normalize_to_list_of_substitutions(v))
-                    else:
-                        expanded_value = perform_substitution_if_applicable(context, v)
-                    expanded_dict[expanded_key] = expanded_value
-                return expanded_dict
-
-            expanded_dict = expand_dict(params)
-            param_dict = {
-                self.__expanded_node_name: {'ros__parameters': expanded_dict}}
+            param_dict = {self.__expanded_node_name: {'ros__parameters': params}}
             if self.__expanded_node_namespace:
                 param_dict = {self.__expanded_node_namespace: param_dict}
             yaml.dump(param_dict, h, default_flow_style=False)
@@ -281,15 +227,14 @@ class Node(ExecuteProcess):
         # expand parameters too
         if self.__parameters is not None:
             self.__expanded_parameter_files = []
-            for params in self.__parameters:
+            evaluated_parameters = evaluate_parameters(context, self.__parameters)
+            for params in evaluated_parameters:
                 if isinstance(params, dict):
-                    param_file_path = self._create_params_file_from_dict(context, params)
+                    param_file_path = self._create_params_file_from_dict(params)
+                elif isinstance(params, pathlib.Path):
+                    param_file_path = str(params)
                 else:
-                    if isinstance(params, pathlib.Path):
-                        param_file_path = str(params)
-                    else:
-                        param_file_path = perform_substitutions(
-                            context, normalize_to_list_of_substitutions(params))
+                    raise RuntimeError('invalid normalized parameters {}'.format(repr(params)))
                 if not os.path.isfile(param_file_path):
                     _logger.warn(
                         'Parameter file path is not a file: {}'.format(param_file_path))

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -35,8 +35,8 @@ from launch.utilities import ensure_argument_type
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 
-from launch_ros.remap_rule_type import SomeRemapRules
 from launch_ros.parameters_type import SomeParameters
+from launch_ros.remap_rule_type import SomeRemapRules
 from launch_ros.substitutions import ExecutableInPackage
 from launch_ros.utilities import evaluate_parameters
 from launch_ros.utilities import normalize_parameters

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -36,6 +36,7 @@ from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 
 from launch_ros.remap_rule_type import SomeRemapRules
+from launch_ros.parameters_type import SomeParameters
 from launch_ros.substitutions import ExecutableInPackage
 from launch_ros.utilities import evaluate_parameters
 from launch_ros.utilities import normalize_parameters
@@ -58,7 +59,7 @@ class Node(ExecuteProcess):
         node_executable: SomeSubstitutionsType,
         node_name: Optional[SomeSubstitutionsType] = None,
         node_namespace: Optional[SomeSubstitutionsType] = None,
-        parameters: Optional[List[SomeSubstitutionsType]] = None,
+        parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         **kwargs

--- a/launch_ros/launch_ros/parameters_type.py
+++ b/launch_ros/launch_ros/parameters_type.py
@@ -1,0 +1,60 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for ROS parameter types."""
+
+import pathlib
+
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Mapping
+from typing import Union
+
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitution import Substitution
+
+
+# Parameter value types used below
+_SingleValueType = Union[str, int, float, bool]
+_MultiValueType = Union[
+    Iterable[str], Iterable[int], Iterable[float], Iterable[bool], bytes]
+
+SomeParameterFile = Union[SomeSubstitutionsType, pathlib.Path]
+SomeParameterName = Iterable[Substitution]
+SomeParameterValue = Union[SomeSubstitutionsType, _SingleValueType, _MultiValueType]
+
+# TODO(sloretz) Recursive type when mypy supports them python/mypy#731
+_SomeParametersDict = Mapping[SomeParameterName, Any]
+SomeParametersDict = Mapping[SomeParameterName, Union[SomeParameterValue, _SomeParametersDict]]
+
+# Paths to yaml files with parameters, or dictionaries of parameters, or pairs of
+# parameter names and values
+SomeParameters = Iterable[Union[SomeParameterFile, Mapping[SomeParameterName, SomeParameterValue]]]
+
+ParameterFile = Iterable[Substitution]
+ParameterValue = Union[Iterable[Substitution],
+                       Iterable[Iterable[Substitution]],
+                       _SingleValueType,
+                       _MultiValueType]
+
+# Normalized (flattened to avoid having a recursive type) parameter dict
+ParametersDict = Mapping[SomeParameterName, SomeParameterValue]
+
+# Normalized parameters
+Parameters = Iterable[Union[ParameterFile, ParametersDict]]
+
+EvaluatedParameterValue = Union[_SingleValueType, _MultiValueType]
+# Evaluated parameters: filenames or dictionary after substitutions have been evaluated
+EvaluatedParameters = Iterable[Union[pathlib.Path, Dict[str, EvaluatedParameterValue]]]

--- a/launch_ros/launch_ros/parameters_type.py
+++ b/launch_ros/launch_ros/parameters_type.py
@@ -33,7 +33,10 @@ _MultiValueType = Union[
 
 SomeParameterFile = Union[SomeSubstitutionsType, pathlib.Path]
 SomeParameterName = Sequence[Union[Substitution, str]]
-SomeParameterValue = Union[SomeSubstitutionsType, _SingleValueType, _MultiValueType]
+SomeParameterValue = Union[SomeSubstitutionsType,
+                           Sequence[SomeSubstitutionsType],
+                           _SingleValueType,
+                           _MultiValueType]
 
 # TODO(sloretz) Recursive type when mypy supports them python/mypy#731
 _SomeParametersDict = Mapping[SomeParameterName, Any]

--- a/launch_ros/launch_ros/parameters_type.py
+++ b/launch_ros/launch_ros/parameters_type.py
@@ -32,7 +32,7 @@ _MultiValueType = Union[
     Sequence[str], Sequence[int], Sequence[float], Sequence[bool], bytes]
 
 SomeParameterFile = Union[SomeSubstitutionsType, pathlib.Path]
-SomeParameterName = Sequence[Substitution]
+SomeParameterName = Sequence[Union[Substitution, str]]
 SomeParameterValue = Union[SomeSubstitutionsType, _SingleValueType, _MultiValueType]
 
 # TODO(sloretz) Recursive type when mypy supports them python/mypy#731
@@ -44,13 +44,14 @@ SomeParametersDict = Mapping[SomeParameterName, Union[SomeParameterValue, _SomeP
 SomeParameters = Sequence[Union[SomeParameterFile, Mapping[SomeParameterName, SomeParameterValue]]]
 
 ParameterFile = Sequence[Substitution]
+ParameterName = Sequence[Substitution]
 ParameterValue = Union[Sequence[Substitution],
                        Sequence[Sequence[Substitution]],
                        _SingleValueType,
                        _MultiValueType]
 
 # Normalized (flattened to avoid having a recursive type) parameter dict
-ParametersDict = Mapping[SomeParameterName, SomeParameterValue]
+ParametersDict = Dict[ParameterName, ParameterValue]
 
 # Normalized parameters
 Parameters = Sequence[Union[ParameterFile, ParametersDict]]

--- a/launch_ros/launch_ros/parameters_type.py
+++ b/launch_ros/launch_ros/parameters_type.py
@@ -18,8 +18,8 @@ import pathlib
 
 from typing import Any
 from typing import Dict
-from typing import Iterable
 from typing import Mapping
+from typing import Sequence
 from typing import Union
 
 from launch.some_substitutions_type import SomeSubstitutionsType
@@ -29,10 +29,10 @@ from launch.substitution import Substitution
 # Parameter value types used below
 _SingleValueType = Union[str, int, float, bool]
 _MultiValueType = Union[
-    Iterable[str], Iterable[int], Iterable[float], Iterable[bool], bytes]
+    Sequence[str], Sequence[int], Sequence[float], Sequence[bool], bytes]
 
 SomeParameterFile = Union[SomeSubstitutionsType, pathlib.Path]
-SomeParameterName = Iterable[Substitution]
+SomeParameterName = Sequence[Substitution]
 SomeParameterValue = Union[SomeSubstitutionsType, _SingleValueType, _MultiValueType]
 
 # TODO(sloretz) Recursive type when mypy supports them python/mypy#731
@@ -41,11 +41,11 @@ SomeParametersDict = Mapping[SomeParameterName, Union[SomeParameterValue, _SomeP
 
 # Paths to yaml files with parameters, or dictionaries of parameters, or pairs of
 # parameter names and values
-SomeParameters = Iterable[Union[SomeParameterFile, Mapping[SomeParameterName, SomeParameterValue]]]
+SomeParameters = Sequence[Union[SomeParameterFile, Mapping[SomeParameterName, SomeParameterValue]]]
 
-ParameterFile = Iterable[Substitution]
-ParameterValue = Union[Iterable[Substitution],
-                       Iterable[Iterable[Substitution]],
+ParameterFile = Sequence[Substitution]
+ParameterValue = Union[Sequence[Substitution],
+                       Sequence[Sequence[Substitution]],
                        _SingleValueType,
                        _MultiValueType]
 
@@ -53,8 +53,8 @@ ParameterValue = Union[Iterable[Substitution],
 ParametersDict = Mapping[SomeParameterName, SomeParameterValue]
 
 # Normalized parameters
-Parameters = Iterable[Union[ParameterFile, ParametersDict]]
+Parameters = Sequence[Union[ParameterFile, ParametersDict]]
 
 EvaluatedParameterValue = Union[_SingleValueType, _MultiValueType]
 # Evaluated parameters: filenames or dictionary after substitutions have been evaluated
-EvaluatedParameters = Iterable[Union[pathlib.Path, Dict[str, EvaluatedParameterValue]]]
+EvaluatedParameters = Sequence[Union[pathlib.Path, Dict[str, EvaluatedParameterValue]]]

--- a/launch_ros/launch_ros/utilities/__init__.py
+++ b/launch_ros/launch_ros/utilities/__init__.py
@@ -18,11 +18,15 @@ Module for descriptions of launchable entities.
 Descriptions are not executable and are immutable so they can be reused by launch entities.
 """
 
+from .evaluate_parameters import evaluate_parameters
+from .normalize_parameters import normalize_parameters
 from .normalize_remap_rule import normalize_remap_rule
 from .normalize_remap_rule import normalize_remap_rules
 
 
 __all__ = [
+    'evaluate_parameters',
+    'normalize_parameters',
     'normalize_remap_rule',
     'normalize_remap_rules',
 ]

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -1,0 +1,80 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module with utility for evaluating parametesr in a launch context."""
+
+
+from collections.abc import Mapping
+from collections.abc import Sequence
+import pathlib
+from typing import Dict
+from typing import List
+from typing import Union
+
+from launch.launch_context import LaunchContext
+from launch.substitution import Substitution
+from launch.utilities import ensure_argument_type
+from launch.utilities import perform_substitutions
+
+from ..parameters_type import EvaluatedParameters
+from ..parameters_type import EvaluatedParameterValue  # noqa
+from ..parameters_type import Parameters
+
+
+def evaluate_parameters(context: LaunchContext, parameters: Parameters) -> EvaluatedParameters:
+    """
+    Evaluate substitutions to produce paths and name/value pairs.
+
+    The parameters must have been normalized with normalize_parameters() prior to calling this.
+
+    :param parameters: normalized parameters
+    :returns: values after evaluating lists of substitutions
+    """
+    output_params = []  # type: List[Union[pathlib.Path, Dict[str, EvaluatedParameterValue]]]
+    for param in parameters:
+        # If it's a list of substitutions then evaluate them to a string and return a pathlib.Path
+        if isinstance(param, tuple) and len(param) and isinstance(param[0], Substitution):
+            # Evaluate a list of Substitution to a file path
+            output_params.append(pathlib.Path(perform_substitutions(context, list(param))))
+        elif isinstance(param, Mapping):
+            # It's a list of name/value pairs
+            output_dict = {}  # type: Dict[str, EvaluatedParameterValue]
+            for name, value in param.items():
+                if not isinstance(name, tuple):
+                    raise TypeError('Expecting tuple of substitutions got {}'.format(repr(name)))
+                name = perform_substitutions(context, list(name))
+
+                if isinstance(value, tuple) and len(value):
+                    if isinstance(value[0], Substitution):
+                        # Value is a list of substitutions, so perform them to make a string
+                        value = perform_substitutions(context, list(value))
+                    elif isinstance(value[0], Sequence):
+                        # Value is an array of a list of substitutions
+                        output_subvalue = []  # List[str]
+                        for subvalue in value:
+                            output_subvalue.append(perform_substitutions(context, list(subvalue)))
+                        value = tuple(output_subvalue)
+                    else:
+                        # Value is an array of the same type, so nothing to evaluate.
+                        output_value = []
+                        target_type = type(value[0])
+                        for i, subvalue in enumerate(value):
+                            output_value.append(target_type(subvalue))
+                        value = tuple(output_value)
+                else:
+                    # Value is a singular type, so nothing to evaluate
+                    ensure_argument_type(value, (float, int, str, bool, bytes), 'value')
+                output_dict[name] = value
+            output_params.append(output_dict)
+    return tuple(output_params)

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -55,7 +55,7 @@ def evaluate_parameters(context: LaunchContext, parameters: Parameters) -> Evalu
                 if not isinstance(name, tuple):
                     raise TypeError('Expecting tuple of substitutions got {}'.format(repr(name)))
                 evaluated_name = perform_substitutions(context, list(name))  # type: str
-                evaluated_value = ''  # type: EvaluatedParameterValue
+                evaluated_value = None  # type: EvaluatedParameterValue
 
                 if isinstance(value, tuple) and len(value):
                     if isinstance(value[0], Substitution):
@@ -66,7 +66,7 @@ def evaluate_parameters(context: LaunchContext, parameters: Parameters) -> Evalu
                         output_subvalue = []  # List[str]
                         for subvalue in value:
                             output_subvalue.append(perform_substitutions(context, list(subvalue)))
-                        evalutated_value = tuple(output_subvalue)
+                        evaluated_value = tuple(output_subvalue)
                     else:
                         # Value is an array of the same type, so nothing to evaluate.
                         output_value = []
@@ -78,6 +78,8 @@ def evaluate_parameters(context: LaunchContext, parameters: Parameters) -> Evalu
                     # Value is a singular type, so nothing to evaluate
                     ensure_argument_type(value, (float, int, str, bool, bytes), 'value')
                     evaluated_value = cast(Union[float, int, str, bool, bytes], value)
+                if evaluated_value is None:
+                    raise TypeError('given unnormalized parameters %r, %r' % (name, value))
                 output_dict[evaluated_name] = evaluated_value
             output_params.append(output_dict)
     return tuple(output_params)

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -21,6 +21,7 @@ import pathlib
 from typing import cast
 from typing import Dict
 from typing import List
+from typing import Optional  # noqa
 from typing import Union
 
 from launch.launch_context import LaunchContext
@@ -55,7 +56,7 @@ def evaluate_parameters(context: LaunchContext, parameters: Parameters) -> Evalu
                 if not isinstance(name, tuple):
                     raise TypeError('Expecting tuple of substitutions got {}'.format(repr(name)))
                 evaluated_name = perform_substitutions(context, list(name))  # type: str
-                evaluated_value = None  # type: EvaluatedParameterValue
+                evaluated_value = None  # type: Optional[EvaluatedParameterValue]
 
                 if isinstance(value, tuple) and len(value):
                     if isinstance(value[0], Substitution):

--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -33,7 +33,6 @@ from launch.utilities import ensure_argument_type
 from launch.utilities import normalize_to_list_of_substitutions
 
 from ..parameters_type import ParameterFile
-from ..parameters_type import ParameterName
 from ..parameters_type import Parameters
 from ..parameters_type import ParametersDict
 from ..parameters_type import ParameterValue
@@ -84,11 +83,11 @@ def _normalize_parameter_array_value(value: SomeParameterValue) -> ParameterValu
             return tuple(normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, value)))
 
         if target_type == float:
-            return tuple([float(s) for s in value])
+            return tuple(float(s) for s in value)
         elif target_type == int:
-            return tuple([int(s) for s in value])
+            return tuple(int(s) for s in value)
         elif target_type == bool:
-            return tuple([bool(s) for s in value])
+            return tuple(bool(s) for s in value)
         else:
             output_value = []  # type: List[Tuple[Substitution, ...]]
             for subvalue in value:

--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -110,7 +110,7 @@ def normalize_parameter_dict(
     The parameters are passed as a dictionary that specifies parameter rules.
     Keys of the dictionary can be strings, a Substitution, or an iterable of Substitution.
     A normalized key will be a tuple of substitutions.
-    Values in the dictionary can be strings, integers, floats, substututions, lists of
+    Values in the dictionary can be strings, integers, floats, substitutions, lists of
     the previous types, or another dictionary with the same properties.
 
     Normalized values that were lists will have all subvalues converted to the same type.

--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -1,0 +1,184 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module with utility for normalizing parameters to a node."""
+
+from collections.abc import Iterable
+from collections.abc import Mapping
+from collections.abc import Sequence
+import pathlib
+from typing import cast
+from typing import List  # noqa
+from typing import Tuple # noqa
+from typing import Union  # noqa
+
+from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
+from launch.substitution import Substitution
+from launch.substitutions import TextSubstitution
+from launch.utilities import ensure_argument_type
+from launch.utilities import normalize_to_list_of_substitutions
+
+from ..parameters_type import Parameters
+from ..parameters_type import ParametersDict
+from ..parameters_type import ParameterValue
+from ..parameters_type import SomeParameters
+from ..parameters_type import SomeParametersDict
+from ..parameters_type import SomeParameterValue
+
+
+def _normalize_parameter_array_value(value: SomeParameterValue) -> ParameterValue:
+    """Normalize substitutions while preserving the type if it's not a substitution."""
+    if isinstance(value, Sequence):
+        # a list of values of the same type
+        # Figure out what type the list should be
+        target_type = None
+        for subvalue in value:
+            allowed_subtypes = (float, int, str, bool) + SomeSubstitutionsType_types_tuple
+            ensure_argument_type(subvalue, allowed_subtypes, 'subvalue')
+
+            if isinstance(subvalue, Substitution):
+                subtype = Substitution
+            else:
+                subtype = type(subvalue)
+
+            if target_type is None:
+                target_type = subtype
+
+            if subtype == float and target_type == int:
+                # If any value is a float, convert all integers to floats
+                target_type = float
+            elif subtype == int and target_type == float:
+                # If any value is a float, convert all integers to floats
+                pass
+            elif subtype == str and target_type == Substitution:
+                # If any value is a single substitution then result is a single string
+                target_type = Substitution
+            elif subtype == str and target_type == Substitution:
+                # If any value is a single substitution then result is a single string
+                target_type = Substitution
+            elif subtype != target_type:
+                # If types don't match, assume list of strings
+                target_type = str
+
+        if target_type is None:
+            # No clue what an empty list's type should be
+            return []
+        elif target_type == Substitution:
+            # Keep the list of substitutions together to form a single string
+            return tuple(normalize_to_list_of_substitutions(value))
+
+        output_value = []  # type: List[Union[Tuple[Substitution, ...], float, int, str, bool]]
+        for subvalue in value:
+            # Make all values in a list the same type
+            if target_type == float:
+                # cast to make mypy happy
+                output_value.append(float(cast(float, subvalue)))
+            elif target_type == int:
+                # cast to make mypy happy
+                output_value.append(int(cast(int, subvalue)))
+            elif target_type == bool:
+                # cast to make mypy happy
+                output_value.append(bool(cast(bool, subvalue)))
+            else:
+                if not isinstance(subvalue, Iterable) and not isinstance(subvalue, Substitution):
+                    # Convert simple types to strings
+                    subvalue = str(subvalue)
+                # Make everything a substitution
+                output_value.append(tuple(normalize_to_list_of_substitutions(subvalue)))
+        return tuple(output_value)
+    else:
+        raise TypeError('Value {} must be a sequence'.format(repr(value)))
+
+
+def normalize_parameter_dict(parameters: SomeParametersDict, *, _prefix=None) -> ParametersDict:
+    """
+    Normalize types used to store parameters in a dictionary.
+
+    The parameters are passed as a dictionary that specifies parameter rules.
+    Keys of the dictionary can be strings, a Substitution, or an iterable of Substitution.
+    A normalized keys will be a tuple of substitutions.
+    Values in the dictionary can be strings, integers, floats, substututions, lists of
+    the previous types, or another dictionary with the same properties.
+
+    Normalized values that were lists will have all subvalues converted to the same type.
+    If all subvalues are int or float, then the normalized subvalues will all be float.
+    If the subvalues otherwise do not all have the same type, then the normalized subvalues
+    will be lists of Substitution that will result in string parameters.
+
+    Values that are a list of strings will become a list of strings when normalized and evaluated.
+    Values that are a list of :class:`Substitution` will become a single string.
+    To make a list of strings from substitutions, each item in the list must be a list or tuple.
+
+    Normalized values that contained nested dictionaries will be collapsed into a single
+    layer with parameter names concatenated with the parameter namespace separator ".".
+
+    :param parameters: Parameters to be normalized
+    :param _prefix: internal parameter used for flatening recursive dictionaries
+    :return: Normalized parameters
+    """
+    if not isinstance(parameters, Mapping):
+        raise TypeError('expected dict')
+
+    normalized = {}  # ParametersDict
+    for name, value in parameters.items():
+        # First make name a list of substitutions
+        name = normalize_to_list_of_substitutions(name)
+        if _prefix:
+            # Prefix name if there is a recursive dictionary
+            name = _prefix + [TextSubstitution(text='.')] + name
+
+        # Normalize the value next
+        if isinstance(value, Mapping):
+            # Flatten recursive dictionaries
+            sub_dict = normalize_parameter_dict(value, _prefix=name)
+            normalized.update(sub_dict)
+        elif isinstance(value, str) or isinstance(value, Substitution):
+            normalized[tuple(name)] = tuple(normalize_to_list_of_substitutions(value))
+        elif isinstance(value, float) or isinstance(value, bool) or isinstance(value, int):
+            # Keep some types as is
+            normalized[tuple(name)] = value
+        elif isinstance(value, bytes):
+            # Keep bytes as is
+            normalized[tuple(name)] = value
+        elif isinstance(value, Sequence):
+            # try to make the parameter types uniform
+            normalized[tuple(name)] = _normalize_parameter_array_value(value)
+        else:
+            raise TypeError('Unexpected type for parameter value {}'.format(repr(value)))
+    return normalized
+
+
+def normalize_parameters(parameters: SomeParameters) -> Parameters:
+    """
+    Normalize the types used to store parameters to substitution types.
+
+    The passed parameters must be an iterable where each element is
+    a path to a yaml file or a dict.
+    The normalized parameters will have all paths converted to a list of :class:`Substitution`,
+    and dictionaries normalized using :meth:`normalize_parameter_dict`.
+    """
+    if isinstance(parameters, str) or not isinstance(parameters, Sequence):
+        raise TypeError('Expecting list of parameters, got {}'.format(parameters))
+
+    normalized_params = []  # type: Parameters
+    for param in parameters:
+        if isinstance(param, Mapping):
+            normalized_params.append(normalize_parameter_dict(param))
+        else:
+            # It's a path, normalize to a list of substitutions
+            if isinstance(param, pathlib.Path):
+                param = str(param)
+            ensure_argument_type(param, SomeSubstitutionsType_types_tuple, 'parameters')
+            normalized_params.append(tuple(normalize_to_list_of_substitutions(param)))
+    return tuple(normalized_params)

--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -109,7 +109,7 @@ def normalize_parameter_dict(
 
     The parameters are passed as a dictionary that specifies parameter rules.
     Keys of the dictionary can be strings, a Substitution, or an iterable of Substitution.
-    A normalized keys will be a tuple of substitutions.
+    A normalized key will be a tuple of substitutions.
     Values in the dictionary can be strings, integers, floats, substututions, lists of
     the previous types, or another dictionary with the same properties.
 

--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -68,11 +68,13 @@ def _normalize_parameter_array_value(value: SomeParameterValue) -> ParameterValu
             raise RuntimeError('Failed to handle type {}'.format(repr(subvalue)))
 
     if {int} == has_types:
-        # all integers
-        return tuple(int(e) for e in value)
+        # everything is an integer
+        make_mypy_happy_int = cast(List[int], value)
+        return tuple(int(e) for e in make_mypy_happy_int)
     elif has_types in ({float}, {int, float}):
         # all were floats or ints, so return floats
-        return tuple(float(e) for e in value)
+        make_mypy_happy_float = cast(List[Union[int, float]], value)
+        return tuple(float(e) for e in make_mypy_happy_float)
     elif Substitution in has_types and has_types.issubset({str, Substitution, tuple}):
         # make a list of substitutions forming a single string
         return tuple(normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, value)))

--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -68,7 +68,7 @@ def _normalize_parameter_array_value(value: SomeParameterValue) -> ParameterValu
             elif subtype == str and target_type == Substitution:
                 # If any value is a single substitution then result is a single string
                 target_type = Substitution
-            elif subtype == str and target_type == Substitution:
+            elif subtype == Substitution and target_type == str:
                 # If any value is a single substitution then result is a single string
                 target_type = Substitution
             elif subtype != target_type:

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -167,12 +167,8 @@ class TestNode(unittest.TestCase):
                         'ros__parameters': {
                             'param1': 'param1_value',
                             'param2': 'param2_value',
-                            'param_group1': {
-                                'list_params': [1.2, 3.4],
-                                'param_group2': {
-                                    'param2_values': ['param2_value'],
-                                }
-                            }
+                            'param_group1.list_params': (1.2, 3.4),
+                            'param_group1.param_group2.param2_values': ('param2_value',),
                         }
                     }
                 }
@@ -199,14 +195,15 @@ class TestNode(unittest.TestCase):
         """Test launching a node with invalid parameter dicts."""
         # Substitutions aren't expanded until the node action is executed, at which time a type
         # error should be raised and cause the launch to fail.
+        # However, the types are checked in Node.__init__()
         # For each type of invalid parameter, check that they are detected at both the top-level
         # and at a nested level in the dictionary.
 
         # Key must be a string/Substitution evaluating to a string.
-        self._assert_launch_errors(actions=[
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{5: 'asdf'}])
-        ])
-        self._assert_launch_errors(actions=[
+
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{
                 'param_group': {
                     'param_subgroup': {
@@ -214,13 +211,12 @@ class TestNode(unittest.TestCase):
                     },
                 },
             }])
-        ])
 
         # Nested lists are not supported.
-        self._assert_launch_errors(actions=[
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{'param': [1, 2, [3, 4]]}])
-        ])
-        self._assert_launch_errors(actions=[
+
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{
                 'param_group': {
                     'param_subgroup': {
@@ -228,27 +224,12 @@ class TestNode(unittest.TestCase):
                     },
                 },
             }])
-        ])
-
-        # Tuples are only supported for Substitutions.
-        self._assert_launch_errors(actions=[
-            self._create_node(parameters=[{'param': (1, 2)}])
-        ])
-        self._assert_launch_errors(actions=[
-            self._create_node(parameters=[{
-                'param_group': {
-                    'param_subgroup': {
-                        'param': (1, 2),
-                    },
-                },
-            }])
-        ])
 
         # Other types are not supported.
-        self._assert_launch_errors(actions=[
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{'param': {1, 2}}])
-        ])
-        self._assert_launch_errors(actions=[
+
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{
                 'param_group': {
                     'param_subgroup': {
@@ -256,11 +237,11 @@ class TestNode(unittest.TestCase):
                     },
                 },
             }])
-        ])
-        self._assert_launch_errors(actions=[
+
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{'param': self}])
-        ])
-        self._assert_launch_errors(actions=[
+
+        with self.assertRaises(TypeError):
             self._create_node(parameters=[{
                 'param_group': {
                     'param_subgroup': {
@@ -268,4 +249,3 @@ class TestNode(unittest.TestCase):
                     },
                 },
             }])
-        ])

--- a/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
+++ b/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
@@ -1,0 +1,173 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the normalizing parameters utility."""
+
+import pathlib
+
+from launch import LaunchContext
+from launch.substitutions import TextSubstitution
+from launch_ros.utilities import evaluate_parameters
+from launch_ros.utilities import normalize_parameters
+import pytest
+
+
+def test_not_a_list():
+    with pytest.raises(TypeError):
+        normalize_parameters({'foo': 'bar'})
+    with pytest.raises(TypeError):
+        normalize_parameters('foobar')
+
+
+def test_single_str_path():
+    norm = normalize_parameters(['/foo/bar'])
+    expected = (pathlib.Path('/foo/bar'),)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_single_pathlib_path():
+    norm = normalize_parameters([pathlib.Path('/foo/bar')])
+    expected = (pathlib.Path('/foo/bar'),)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_multiple_paths():
+    norm = normalize_parameters([pathlib.Path('/foo/bar'), '/bar/baz'])
+    expected = (pathlib.Path('/foo/bar'), pathlib.Path('/bar/baz'))
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_path_with_substitutions():
+    orig = [(TextSubstitution(text='/foo'), TextSubstitution(text='/bar'))]
+    norm = normalize_parameters(orig)
+    expected = (pathlib.Path('/foo/bar'),)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_single_dictionary():
+    orig = [{'foo': 1, 'bar': 2.0}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'bar': 2.0},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_multiple_dictionaries():
+    orig = [{'foo': 1, 'bar': 2.0}, {'baz': 'asdf'}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'bar': 2.0}, {'baz': 'asdf'})
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_substitution():
+    orig = [{TextSubstitution(text='bar'): TextSubstitution(text='baz')}]
+    norm = normalize_parameters(orig)
+    expected = ({'bar': 'baz'},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_substitution_list_name():
+    orig = [{(TextSubstitution(text='bar'), TextSubstitution(text='foo')): 1}]
+    norm = normalize_parameters(orig)
+    expected = ({'barfoo': 1},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_substitution_list_value():
+    orig = [{'foo': [TextSubstitution(text='fiz'), TextSubstitution(text='buz')]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 'fizbuz'},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'foo': [[TextSubstitution(text='fiz')], [TextSubstitution(text='buz')]]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': ('fiz', 'buz')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_mixed_substitutions_and_strings():
+    orig = [{'foo': [TextSubstitution(text='fiz'), 'bar']}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 'fizbar'},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'foo': [[TextSubstitution(text='fiz')], 'bar']}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': ('fiz', 'bar')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_str():
+    orig = [{'foo': 'bar', 'fiz': ['b', 'u', 'z']}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 'bar', 'fiz': ('b', 'u', 'z')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_bool():
+    orig = [{'foo': False, 'fiz': [True, False, True]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': False, 'fiz': (True, False, True)},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_float():
+    orig = [{'foo': 1.2, 'fiz': [2.3, 3.4, 4.5]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1.2, 'fiz': (2.3, 3.4, 4.5)},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_int():
+    orig = [{'foo': 1, 'fiz': [2, 3, 4]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': (2, 3, 4)},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_int_and_float():
+    orig = [{'foo': 1, 'fiz': [2, 3.1, 4]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': (2.0, 3.1, 4.0)},)
+    evaluated = evaluate_parameters(LaunchContext(), norm)
+    assert evaluated == expected
+    # pytest doesn't check int vs float type
+    assert tuple(map(type, evaluated[0]['fiz'])) == (float, float, float)
+
+
+def test_dictionary_with_bytes():
+    orig = [{'foo': 1, 'fiz': bytes([0xff, 0x5c, 0xaa])}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': bytes([0xff, 0x5c, 0xaa])},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_dictionary_with_dissimilar_array():
+    orig = [{'foo': 1, 'fiz': [True, 2.0, 3]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': ('True', '2.0', '3')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_nested_dictionaries():
+    orig = [{'foo': {'bar': 'baz'}, 'fiz': {'buz': 3}}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo.bar': 'baz', 'fiz.buz': 3},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_mixed_path_dicts():
+    orig = ['/foo/bar', {'fiz': {'buz': 3}}, pathlib.Path('/tmp/baz')]
+    norm = normalize_parameters(orig)
+    expected = (pathlib.Path('/foo/bar'), {'fiz.buz': 3}, pathlib.Path('/tmp/baz'))
+    assert evaluate_parameters(LaunchContext(), norm) == expected

--- a/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
+++ b/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
@@ -144,6 +144,14 @@ def test_dictionary_with_int_and_float():
     # pytest doesn't check int vs float type
     assert tuple(map(type, evaluated[0]['fiz'])) == (float, float, float)
 
+    orig = [{'foo': 1, 'fiz': [2.0, 3, 4]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': (2.0, 3.0, 4.0)},)
+    evaluated = evaluate_parameters(LaunchContext(), norm)
+    assert evaluated == expected
+    # pytest doesn't check int vs float type
+    assert tuple(map(type, evaluated[0]['fiz'])) == (float, float, float)
+
 
 def test_dictionary_with_bytes():
     orig = [{'foo': 1, 'fiz': bytes([0xff, 0x5c, 0xaa])}]

--- a/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
+++ b/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
@@ -106,6 +106,16 @@ def test_dictionary_with_mixed_substitutions_and_strings():
     expected = ({'foo': ('fiz', 'bar')},)
     assert evaluate_parameters(LaunchContext(), norm) == expected
 
+    orig = [{'foo': ['bar', TextSubstitution(text='fiz')]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 'barfiz'},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'foo': ['bar', [TextSubstitution(text='fiz')]]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': ('bar', 'fiz')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
 
 def test_dictionary_with_str():
     orig = [{'foo': 'bar', 'fiz': ['b', 'u', 'z']}]

--- a/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
+++ b/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
@@ -176,6 +176,26 @@ def test_dictionary_with_dissimilar_array():
     expected = ({'foo': 1, 'fiz': ('True', '2.0', '3')},)
     assert evaluate_parameters(LaunchContext(), norm) == expected
 
+    orig = [{'foo': 1, 'fiz': [True, 1, TextSubstitution(text='foo')]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': ('True', '1', 'foo')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'foo': 1, 'fiz': [TextSubstitution(text='foo'), True, 1]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': ('foo', 'True', '1')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'foo': 1, 'fiz': [True, 1, [TextSubstitution(text='foo')]]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': ('True', '1', 'foo')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'foo': 1, 'fiz': [[TextSubstitution(text='foo')], True, 1]}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': 1, 'fiz': ('foo', 'True', '1')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
 
 def test_nested_dictionaries():
     orig = [{'foo': {'bar': 'baz'}, 'fiz': {'buz': 3}}]


### PR DESCRIPTION
Probably complete, but in progress while I self review. I wrote this a while ago and am just now coming back to it.

Like #173 but for parameters. This refactors the type checking and evaluation of parameters in `Node` into new functions `normalize_parameters()` and `evaluate_parameters()`. The reason is to make this logic reusable for composable nodes #160.

I made some changes along the way

* parameter dictionaries are flattened to one level with names containing `.`
  * Reason: python type hints can't yet do recursive types
  * `rcl_yaml_param_parser` supports this just fine.
* Lists of parameters may be any `Sequence`, not just `List`
  * Reason: I wanted to use make evaluated parameters `normalize_parameters()` immutable, meaning `tuple` is used for the list of parameters. I didn't succeed since they still use dictionaries, but this is a little closer.
* Parameter types are checked in `Node.__init__()` instead of when the action is executed
  * Reason: Not really intentional; it just made sense to call `normalize_parameters()` there
  * Of course substitutions are still evaluatated when the action is executed
* Types of lists output by `evaluated_parameters()` are made uniform
  * Reason: Composable nodes will need to know the list type so it can be passed in a ros service.
  * if a list contains int and float, the list type is float
  * if a list contains dissimilar types, the list type is `str`