### PR TITLE
Plumb rclpy.init context to get_default_launch_description

### DIFF
--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -122,10 +122,10 @@ def get_default_launch_description(*, prefix_output_with_name=False, rclpy_conte
     :param: prefix_output_with_name if True, each line of output is prefixed
         with the name of the process as `[process_name] `, else it is printed
         unmodified
-
-    :param: rclpy_context Provide a context other than the default rclpy context to pass down
-    to rclpy.init.  The context is expected to have already been initialized by the caller using
-    rclpy.init
+    :param: rclpy_context Provide a context other than the default rclpy context
+        to pass down to rclpy.init.
+        The context is expected to have already been initialized by the caller
+        using rclpy.init().
     """
     default_ros_launch_description = launch.LaunchDescription([
         # ROS initialization (create node and other stuff).

--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -96,7 +96,9 @@ class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
 
     def _function(self, context: launch.LaunchContext):
         try:
-            rclpy.init(args=context.argv, context=self.__rclpy_context)
+            if self.__rclpy_context is None:
+                # Initialize the default global context
+                rclpy.init(args=context.argv)
         except RuntimeError as exc:
             if 'rcl_init called while already initialized' in str(exc):
                 pass
@@ -121,8 +123,9 @@ def get_default_launch_description(*, prefix_output_with_name=False, rclpy_conte
         with the name of the process as `[process_name] `, else it is printed
         unmodified
 
-    :param: rclpy_context Provide a context other than the default rclpy context pass down
-    to rclpy.init
+    :param: rclpy_context Provide a context other than the default rclpy context to pass down
+    to rclpy.init.  The context is expected to have already been initialized by the caller using
+    rclpy.init
     """
     default_ros_launch_description = launch.LaunchDescription([
         # ROS initialization (create node and other stuff).

--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -27,6 +27,7 @@ import launch.actions
 import launch.events
 
 import rclpy
+from rclpy.executors import SingleThreadedExecutor
 
 _logger = logging.getLogger('launch_ros')
 _process_log_files = {}  # type: Dict[Text, TextIO]
@@ -68,10 +69,11 @@ def _on_process_output(event: launch.Event, *, file_name: Text, prefix_output: b
 class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
     """Does ROS specific launch startup."""
 
-    def __init__(self):
+    def __init__(self, rclpy_context=None):
         """Constructor."""
         super().__init__(function=self._function)
         self.__shutting_down = False
+        self.__rclpy_context = rclpy_context
 
     def _shutdown(self, event: launch.Event, context: launch.LaunchContext):
         self.__shutting_down = True
@@ -79,7 +81,7 @@ class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
         self.__launch_ros_node.destroy_node()
 
     def _run(self):
-        executor = rclpy.get_global_executor()
+        executor = SingleThreadedExecutor(context=self.__rclpy_context)
         try:
             executor.add_node(self.__launch_ros_node)
             while not self.__shutting_down:
@@ -94,12 +96,12 @@ class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
 
     def _function(self, context: launch.LaunchContext):
         try:
-            rclpy.init(args=context.argv)
+            rclpy.init(args=context.argv, context=self.__rclpy_context)
         except RuntimeError as exc:
             if 'rcl_init called while already initialized' in str(exc):
                 pass
             raise
-        self.__launch_ros_node = rclpy.create_node('launch_ros')
+        self.__launch_ros_node = rclpy.create_node('launch_ros', context=self.__rclpy_context)
         context.extend_globals({
             'ros_startup_action': self,
             'launch_ros_node': self.__launch_ros_node
@@ -111,17 +113,20 @@ class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
         self.__rclpy_spin_thread.start()
 
 
-def get_default_launch_description(*, prefix_output_with_name=False):
+def get_default_launch_description(*, prefix_output_with_name=False, rclpy_context=None):
     """
     Return a LaunchDescription to be included before user descriptions.
 
     :param: prefix_output_with_name if True, each line of output is prefixed
         with the name of the process as `[process_name] `, else it is printed
         unmodified
+
+    :param: rclpy_context Provide a context other than the default rclpy context pass down
+    to rclpy.init
     """
     default_ros_launch_description = launch.LaunchDescription([
         # ROS initialization (create node and other stuff).
-        ROSSpecificLaunchStartup(),
+        ROSSpecificLaunchStartup(rclpy_context=rclpy_context),
         # Handle process starts.
         launch.actions.RegisterEventHandler(launch.EventHandler(
             matcher=lambda event: isinstance(event, launch.events.process.ProcessStarted),


### PR DESCRIPTION
From https://github.com/ros2/launch/issues/189

This lets you pass a launch context to get_default_launch_description into get_default_launch_description and plumbs it all the way down to the ROSSpecificLaunchStartup launch action.

I couldn't find where rclpy.shutdown is called, so I didn't hook that up anywhere.

I also had to change `rclpy.get_global_executor` to constructing my own SingleThreadedExecutor because the executor needs to be built with the same context as the node.

#### This Incomplete!
This is about 50% of what's needed for issue 189.  The other half is to make ros2 launch actually use this plumbing.  A question for @wjwwood - is it necessary to shut-down the context when we're done, or is it sufficient to just [pass a context here?](https://github.com/ros2/launch/blob/632ef1f3eca7dbc54fbed85ab65a5efc512d83ed/ros2launch/ros2launch/api/api.py#L140-L141)