### PR TITLE
Fix event loop closed bug

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -359,6 +359,9 @@ class ExecuteProcess(Action):
             self.__sigterm_timer.cancel()
         if self.__sigkill_timer is not None:
             self.__sigkill_timer.cancel()
+        # Close subprocess transport if any.
+        if self._subprocess_transport is not None:
+            self._subprocess_transport.close()
         # Signal that we're done to the launch system.
         self.__completed_future.set_result(None)
 


### PR DESCRIPTION
Fixes #185. Apparently, `atexit` registered functions get run before the python's gc runs objects destructors and thus asyncio loops were being closed before `ExecuteProcess` related awaitables were terminated.

~This PR also fixes an issue introduced by #167 on Python 3.5 (in Xenial).~