### PR TITLE
update logger.warn (deprecated) to logger.warning

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -263,7 +263,7 @@ class ExecuteProcess(Action):
             return None
         if platform.system() == 'Windows' and typed_event.signal_name == 'SIGINT':
             # TODO(wjwwood): remove this when/if SIGINT is fixed on Windows
-            _logger.warn(
+            _logger.warning(
                 "'SIGINT' sent to process[{}] not supported on Windows, escalating to 'SIGTERM'"
                 .format(self.process_details['name']))
             typed_event = SignalProcess(
@@ -288,7 +288,7 @@ class ExecuteProcess(Action):
         event: Event,
         context: LaunchContext
     ) -> Optional[LaunchDescription]:
-        _logger.warn("in ExecuteProcess('{}').__on_process_stdin_event()".format(id(self)))
+        _logger.warning("in ExecuteProcess('{}').__on_process_stdin_event()".format(id(self)))
         cast(ProcessStdin, event)
         return None
 

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -299,13 +299,13 @@ class LaunchService:
                 nonlocal sigint_received
                 base_msg = 'user interrupted with ctrl-c (SIGINT)'
                 if not sigint_received:
-                    _logger.warn(base_msg)
+                    _logger.warning(base_msg)
                     ret = self._shutdown(
                         reason='ctrl-c (SIGINT)', due_to_sigint=True, force_sync=True)
                     assert ret is None, ret
                     sigint_received = True
                 else:
-                    _logger.warn('{} again, ignoring...'.format(base_msg))
+                    _logger.warning('{} again, ignoring...'.format(base_msg))
 
                 signal.signal(signal.SIGINT, prev_handler)
 

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -78,7 +78,7 @@ class LifecycleNode(Node):
     def _call_change_state(self, request, context: launch.LaunchContext):
         while not self.__rclpy_change_state_client.wait_for_service(timeout_sec=1.0):
             if context.is_shutdown:
-                _logger.warn("Abandoning wait for the '{}' service, due to shutdown.".format(
+                _logger.warning("Abandoning wait for the '{}' service, due to shutdown.".format(
                     self.__rclpy_change_state_client.srv_name))
                 return
         response = self.__rclpy_change_state_client.call(request)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -237,7 +237,7 @@ class Node(ExecuteProcess):
                 else:
                     raise RuntimeError('invalid normalized parameters {}'.format(repr(params)))
                 if not os.path.isfile(param_file_path):
-                    _logger.warn(
+                    _logger.warning(
                         'Parameter file path is not a file: {}'.format(param_file_path))
                     # Don't skip adding the file to the parameter list since space has been
                     # reserved for it in the ros_specific_arguments.

--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -37,7 +37,8 @@ def _on_process_started(context: launch.LaunchContext):
     typed_event = cast(launch.events.process.ProcessStarted, context.locals.event)
     if typed_event.execute_process_action.output == 'log':
         # TODO(wjwwood): implement file logging
-        _logger.warn("process '{}' asked for 'output=log', but that's not currently implemented.")
+        _logger.warning(
+            "process '{}' asked for 'output=log', but that's not currently implemented.")
 
 
 def _on_process_exited(context: launch.LaunchContext):


### PR DESCRIPTION
Use [non-deprecated method](https://docs.python.org/3.7/library/logging.html#logging.Logger.warning).

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6367)](https://ci.ros2.org/job/ci_linux/6367/)