### PR TITLE
Make 'ros2 launch' work again.

### DIFF
--- a/launch_ros/examples/lifecycle_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_pub_sub_launch.py
@@ -95,7 +95,7 @@ def main(argv=sys.argv[1:]):
 
     # ls = launch.LaunchService(argv=argv, debug=True)
     ls = launch.LaunchService(argv=argv)
-    ls.include_launch_description(get_default_launch_description(prefix_output_with_name=False))
+    ls.include_launch_description(get_default_launch_description())
     ls.include_launch_description(ld)
     return ls.run()
 

--- a/launch_ros/examples/pub_sub_launch.py
+++ b/launch_ros/examples/pub_sub_launch.py
@@ -49,7 +49,7 @@ def main(argv=sys.argv[1:]):
 
     # ls = LaunchService(debug=True)
     ls = LaunchService()
-    ls.include_launch_description(get_default_launch_description(prefix_output_with_name=False))
+    ls.include_launch_description(get_default_launch_description())
     ls.include_launch_description(ld)
     return ls.run()
 

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -143,7 +143,6 @@ def launch_a_python_launch_file(*, python_launch_file_path, launch_file_argument
     rclpy.init(args=launch_file_arguments, context=context)
     launch_service.include_launch_description(
         launch_ros.get_default_launch_description(
-            prefix_output_with_name=False,
             rclpy_context=context,
         )
     )


### PR DESCRIPTION
After commit 7611f7bd8f517b744f84dac630a7e40be145a7ef,
get_default_launch_description() no longer takes
'prefix_output_with_name' anymore.  Remove the use from
the examples and from the 'ros2 launch' command implementation.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>