### PR TITLE
Replace characters with marker when there is a decoding error

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -300,7 +300,7 @@ class ExecuteProcess(Action):
     def __on_process_stdout(
         self, event: ProcessIO
     ) -> Optional[SomeActionsType]:
-        for line in event.text.decode().splitlines():
+        for line in event.text.decode(errors='replace').splitlines():
             self.__stdout_logger.info(
                 self.__output_format.format(line=line, this=self)
             )
@@ -308,7 +308,7 @@ class ExecuteProcess(Action):
     def __on_process_stderr(
         self, event: ProcessIO
     ) -> Optional[SomeActionsType]:
-        for line in event.text.decode().splitlines():
+        for line in event.text.decode(errors='replace').splitlines():
             self.__stderr_logger.info(
                 self.__output_format.format(line=line, this=self)
             )


### PR DESCRIPTION
Resolves ros2/build_cop#174

Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux&build=1400)](https://ci.ros2.org/view/packaging/job/packaging_linux/1400/)