### PR TITLE
Add async run method to LaunchService

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -403,11 +403,6 @@ class LaunchService:
 
         :param: shutdown_when_idle if True (default), the service will shutdown when idle
         """
-        # Make sure this has not been called from any thread but the main thread.
-        if threading.current_thread() is not threading.main_thread():
-            raise RuntimeError(
-                'LaunchService can only be run in the main thread.'
-            )
         loop = osrf_pycommon.process_utils.get_loop()
         run_async_task = loop.create_task(self.run_async(
             shutdown_when_idle=shutdown_when_idle, loop=loop

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -32,10 +32,6 @@ def on_sigint(handler):
     Set the signal handler to be called on SIGINT.
 
     Pass None for no custom handler.
-    Note that if a custom handler is set (anything other than None is given),
-    then KeyboardInterrupt is caught and ignored around the original signal
-    handler (the once captured when install_signal_handlers() was called).
-    Passing None for handler will undo this behavior.
 
     install_signal_handlers() must have been called in the main thread before.
     It is called automatically by the constructor of `launch.LaunchService`.
@@ -114,8 +110,8 @@ def install_signal_handlers():
 
     def __on_sigint(signum, frame):
         if callable(__custom_sigint_handler):
-            __custom_sigint_handler(signum, frame)
-        if callable(__original_sigint_handler):
+            __custom_sigint_handler(signum, frame, __original_sigint_handler)
+        elif callable(__original_sigint_handler):
             __original_sigint_handler(signum, frame)
 
     if platform.system() != 'Windows':
@@ -124,14 +120,14 @@ def install_signal_handlers():
 
         def __on_sigquit(signum, frame):
             if callable(__custom_sigquit_handler):
-                __custom_sigquit_handler(signum, frame)
-            if callable(__original_sigquit_handler):
+                __custom_sigquit_handler(signum, frame, __original_sigquit_handler)
+            elif callable(__original_sigquit_handler):
                 __original_sigquit_handler(signum, frame)
 
     def __on_sigterm(signum, frame):
         if callable(__custom_sigterm_handler):
-            __custom_sigterm_handler(signum, frame)
-        if callable(__original_sigterm_handler):
+            __custom_sigterm_handler(signum, frame, __original_sigterm_handler)
+        elif callable(__original_sigterm_handler):
             __original_sigterm_handler(signum, frame)
 
     # signals must be registered in the main thread, but print a nicer message if we're not there


### PR DESCRIPTION
This pull request enables asynchronous launch runs. This popped up in a discussion I had with @wjwwood as an alternative to pushing a launch run to a background thread (see #126), which is unsupported (explicitly after these changes).

Consider the following snippet for an example of the new async API:

```python
#!/usr/bin/env python3

import asyncio
import osrf_pycommon

from launch import LaunchDescription
from launch import LaunchService
import launch_ros.actions


def main():
    ld = LaunchDescription([
        launch_ros.actions.Node(
            package='demo_nodes_cpp',
            node_executable='listener',
            output='screen'
        ),
    ])

    loop = osrf_pycommon.process_utils.get_loop()
    ls = LaunchService(debug=True)
    ls.include_launch_description(ld)
    print(">>> Do some work")
    launch_task = loop.create_task(ls.run_async())
    print(">>> Sleep time!")
    loop.run_until_complete(asyncio.sleep(5, loop=loop))
    print(">>> I'm awake!")
    if not launch_task.done():
        print(">>> Wrapping up")
        asyncio.ensure_future(ls.shutdown(), loop=loop)
        loop.run_until_complete(launch_task)
    print(">>> Bye bye")
    return launch_task.result()


if __name__=="__main__":
    main()
```

Hopefully, this will simplify launch based fixtures for testing.

cc @pbaughman for awareness.