### PR TITLE
Log launch logging config before running.

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -289,6 +289,9 @@ class LaunchService:
             sigint_received = False
             run_loop_task = self.__loop_from_run_thread.create_task(self.__run_loop())
 
+            # Log logging configuration details.
+            launch.logging.log_launch_config(logger=self.__logger)
+
             # Setup custom signal hanlders for SIGINT, SIGQUIT, and SIGTERM.
             def _on_sigint(signum, frame):
                 # Ignore additional interrupts until we finish processing this one.

--- a/launch/launch/logging.py
+++ b/launch/launch/logging.py
@@ -164,6 +164,15 @@ def launch_config(
         launch_config.log_dir = log_dir
 
 
+def log_launch_config(*, logger=logging.root):
+    """Log logging configuration details relevant for a user with the given logger."""
+    if any(launch_config.file_handlers):
+        logger.info('All log files can be found below {}'.format(launch_config.log_dir))
+    logger.info('Default logging verbosity is set to {}'.format(logging.getLevelName(
+        logging.root.getEffectiveLevel()
+    )))
+
+
 def get_logger(name=None):
     """Get named logger, configured to output to screen and launch main log file."""
     logger = logging.getLogger(name)


### PR DESCRIPTION
Fixes #213. Sample output shown below:

```bash
michel@8c3558e80425:~/Workspaces/ros2_bionic_ws$ python3 test_launch.py 
[INFO] [launch]: All log files can be found below /home/michel/.ros/log/2019-03-25-14-11-18-298080-8c3558e80425-3919
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [talker-1]: process started with pid [3928]
[INFO] [listener-2]: process started with pid [3929]
[talker-1] [INFO] [talker]: Publishing: 'Hello World: 1'
[talker-1] [INFO] [talker]: Publishing: 'Hello World: 2'
[talker-1] [INFO] [talker]: Publishing: 'Hello World: 3'
[talker-1] [INFO] [talker]: Publishing: 'Hello World: 4'
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[INFO] [talker-1]: process has finished cleanly [pid 3928]
[INFO] [listener-2]: process has finished cleanly [pid 3929]
[talker-1] [INFO] [rclcpp]: signal_handler(signal_value=2)
michel@8c3558e80425:~/Workspaces/ros2_bionic_ws$ ls /home/michel/.ros/log/2019-03-25-14-11-18-298080-8c3558e80425-3919
launch.log
```