### PR TITLE
Add default value to EnvironmentVariable substitution

### DIFF
--- a/launch/launch/substitutions/environment_variable.py
+++ b/launch/launch/substitutions/environment_variable.py
@@ -30,8 +30,12 @@ class EnvironmentVariable(Substitution):
     If the environment variable is not found, it returns empty string.
     """
 
-    def __init__(self, name: SomeSubstitutionsType, *,
-                 default_value: SomeSubstitutionsType = '') -> None:
+    def __init__(
+        self,
+        name: SomeSubstitutionsType,
+        *,
+        default_value: SomeSubstitutionsType = ''
+    ) -> None:
         """Constructor."""
         super().__init__()
 
@@ -46,7 +50,7 @@ class EnvironmentVariable(Substitution):
 
     @property
     def default_value(self) -> List[Substitution]:
-        """Getter for default."""
+        """Getter for default_value."""
         return self.__default_value
 
     def describe(self) -> Text:
@@ -58,4 +62,5 @@ class EnvironmentVariable(Substitution):
         from ..utilities import perform_substitutions  # import here to avoid loop
         return os.environ.get(
             perform_substitutions(context, self.name),
-            perform_substitutions(context, self.default_value))
+            perform_substitutions(context, self.default_value)
+        )

--- a/launch/launch/substitutions/environment_variable.py
+++ b/launch/launch/substitutions/environment_variable.py
@@ -30,17 +30,24 @@ class EnvironmentVariable(Substitution):
     If the environment variable is not found, it returns empty string.
     """
 
-    def __init__(self, name: SomeSubstitutionsType) -> None:
+    def __init__(self, name: SomeSubstitutionsType, *,
+                 default_value: SomeSubstitutionsType = '') -> None:
         """Constructor."""
         super().__init__()
 
         from ..utilities import normalize_to_list_of_substitutions  # import here to avoid loop
         self.__name = normalize_to_list_of_substitutions(name)
+        self.__default_value = normalize_to_list_of_substitutions(default_value)
 
     @property
     def name(self) -> List[Substitution]:
         """Getter for name."""
         return self.__name
+
+    @property
+    def default_value(self) -> List[Substitution]:
+        """Getter for default."""
+        return self.__default_value
 
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
@@ -49,4 +56,6 @@ class EnvironmentVariable(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by looking up the environment variable."""
         from ..utilities import perform_substitutions  # import here to avoid loop
-        return os.environ.get(perform_substitutions(context, self.name), '')
+        return os.environ.get(
+            perform_substitutions(context, self.name),
+            perform_substitutions(context, self.default_value))


### PR DESCRIPTION
It will be needed for the front-end substitution `$(env env-var [default-value])`.
See [article]( https://github.com/ros2/design/blob/d3a35d7ea201721892993e85e28a5a223cdaa001/articles/151_roslaunch_xml.md).