### PR TITLE
Make launchtest junit XML match pytest XML more closely

### DIFF
--- a/launch_testing/launch_testing/junitxml.py
+++ b/launch_testing/launch_testing/junitxml.py
@@ -81,7 +81,8 @@ def unittestCaseToXml(test_result, test_case):
     class needs to be a launch_testing.TestResult class
     """
     case_xml = ET.Element('testcase')
-    case_xml.set('name', type(test_case).__name__ + '.' + test_case._testMethodName)
+    case_xml.set('classname', type(test_case).__name__)
+    case_xml.set('name', test_case._testMethodName)
     case_xml.set('time', str(round(test_result.testTimes[test_case], 3)))
 
     for failure in test_result.failures:
@@ -101,7 +102,7 @@ def unittestCaseToXml(test_result, test_case):
     for skip in test_result.skipped:
         if skip[0] == test_case:
             skip_xml = ET.Element('skipped')
-            skip_xml.text = skip[1]
+            skip_xml.set('message', skip[1])
             case_xml.append(skip_xml)
 
     return case_xml

--- a/launch_testing/launch_testing/junitxml.py
+++ b/launch_testing/launch_testing/junitxml.py
@@ -27,24 +27,26 @@ def unittestResultsToXml(*, name='launch_test', test_results={}):
     # were active, and one from tests that ran after processes were shut down
     test_suites = ET.Element('testsuites')
     test_suites.set('name', name)
-    # test_suites.set('time', ????) skipping 'time' attribute
 
     # To get tests, failures, and errors, we just want to iterate the results once
     tests = 0
     failures = 0
     errors = 0
+    time = 0
 
     for result in test_results.values():
         tests += result.testsRun
         failures += len(result.failures)
         errors += len(result.errors)
+        time += sum(result.testTimes.values())
 
     test_suites.set('tests', str(tests))
     test_suites.set('failures', str(failures))
     test_suites.set('errors', str(errors))
+    test_suites.set('time', str(round(time, 3)))
 
-    for (key, value) in test_results.items():
-        test_suites.append(unittestResultToXml(str(key), value))
+    for (name, test_result) in test_results.items():
+        test_suites.append(unittestResultToXml(str(name), test_result))
 
     return ET.ElementTree(test_suites)
 

--- a/launch_testing/launch_testing/junitxml.py
+++ b/launch_testing/launch_testing/junitxml.py
@@ -83,7 +83,8 @@ def unittestCaseToXml(test_result, test_case):
     class needs to be a launch_testing.TestResult class
     """
     case_xml = ET.Element('testcase')
-    case_xml.set('classname', type(test_case).__name__)
+    full_classname = type(test_case).__module__ + '.' + type(test_case).__name__
+    case_xml.set('classname', full_classname)
     case_xml.set('name', test_case._testMethodName)
     case_xml.set('time', str(round(test_result.testTimes[test_case], 3)))
 

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -73,6 +73,12 @@ def main():
         help='write junit XML style report to specified path'
     )
 
+    parser.add_argument(
+        '--test-name',
+        action='store',
+        default=None,
+        help='a name for the test'
+    )
     args = parser.parse_args()
 
     if args.verbose:
@@ -93,6 +99,8 @@ def main():
 
     args.test_file = os.path.abspath(args.test_file)
     test_module = _load_python_file_as_module(args.test_file)
+    if not args.test_name:
+        args.test_name = os.path.splitext(os.path.basename(args.test_file))[0]
 
     _logger_.debug('Checking for generate_test_description')
     if not hasattr(test_module, 'generate_test_description'):
@@ -102,7 +110,7 @@ def main():
 
     # This is a list of TestRun objects.  Each run corresponds to one launch.  There may be
     # multiple runs if the launch is parametrized
-    test_runs = LoadTestsFromPythonModule(test_module)
+    test_runs = LoadTestsFromPythonModule(test_module, name=args.test_name + '.launch_tests')
 
     # The runner handles sequcing the launches
     runner = LaunchTestRunner(
@@ -130,7 +138,7 @@ def main():
         _logger_.debug('Done running integration test')
 
         if args.xmlpath:
-            xml_report = unittestResultsToXml(test_results=results)
+            xml_report = unittestResultsToXml(test_results=results, name=args.test_name)
             xml_report.write(args.xmlpath, encoding='utf-8', xml_declaration=True)
 
         # There will be one result for every test run (see above where we load the tests)

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -27,10 +27,10 @@ from .test_runner import LaunchTestRunner
 _logger_ = logging.getLogger(__name__)
 
 
-def _load_python_file_as_module(python_file_path):
+def _load_python_file_as_module(test_module_name, python_file_path):
     """Load a given Python launch file (by path) as a Python module."""
     # Taken from launch_testing to not introduce a weird dependency thing
-    loader = SourceFileLoader('python_launch_file', python_file_path)
+    loader = SourceFileLoader(test_module_name, python_file_path)
     return loader.load_module()
 
 
@@ -98,7 +98,7 @@ def main():
         parser.error("Test file '{}' does not exist".format(args.test_file))
 
     args.test_file = os.path.abspath(args.test_file)
-    test_module = _load_python_file_as_module(args.test_file)
+    test_module = _load_python_file_as_module(args.test_name, args.test_file)
     if not args.test_name:
         args.test_name = os.path.splitext(os.path.basename(args.test_file))[0]
 

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -131,7 +131,7 @@ def main():
 
         if args.xmlpath:
             xml_report = unittestResultsToXml(test_results=results)
-            xml_report.write(args.xmlpath, xml_declaration=True)
+            xml_report.write(args.xmlpath, encoding='utf-8', xml_declaration=True)
 
         # There will be one result for every test run (see above where we load the tests)
         for result in results.values():

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -76,6 +76,10 @@ class TestRun:
         """
         return self.test_description_function(lambda: None)
 
+    def all_cases(self):
+        yield from _iterate_tests_in_test_suite(self.pre_shutdown_tests)
+        yield from _iterate_tests_in_test_suite(self.post_shutdown_tests)
+
     def __str__(self):
         if not self.param_args:
             return 'launch'

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -34,11 +34,12 @@ def _normalize_ld(launch_description_fn):
 class TestRun:
 
     def __init__(self,
+                 name,
                  test_description_function,
                  param_args,
                  pre_shutdown_tests,
                  post_shutdown_tests):
-
+        self.name = name
         self.test_description_function = test_description_function
         self.normalized_test_description = _normalize_ld(test_description_function)
 
@@ -81,13 +82,12 @@ class TestRun:
         yield from _iterate_tests_in_test_suite(self.post_shutdown_tests)
 
     def __str__(self):
-        if not self.param_args:
-            return 'launch'
-        else:
-            return 'TODO Parametrize'
+        if self.param_args:
+            return self.name + '[some_parameter]'
+        return self.name
 
 
-def LoadTestsFromPythonModule(module):
+def LoadTestsFromPythonModule(module, *, name='launch_tests'):
 
     if hasattr(module.generate_test_description, '__parametrized__'):
         normalized_test_description_func = module.generate_test_description
@@ -96,7 +96,8 @@ def LoadTestsFromPythonModule(module):
 
     # If our test description is parameterized, we'll load a set of tests for each
     # individual launch
-    return [TestRun(description,
+    return [TestRun(name,
+                    description,
                     args,
                     PreShutdownTestLoader().loadTestsFromModule(module),
                     PostShutdownTestLoader().loadTestsFromModule(module))

--- a/launch_testing/launch_testing/test_result.py
+++ b/launch_testing/launch_testing/test_result.py
@@ -36,24 +36,20 @@ class FailResult(unittest.TestResult):
 class SkipResult(unittest.TestResult):
     """For test runs with a skip decorator on the generate_test_description function."""
 
-    class __skipped_test_case:
-
-        def __init__(self):
-            self._testMethodName = 'skipped_launch'
-
-    def __init__(self, stream=None, descriptions=None, verbosity=None, msg=''):
-        super().__init__(stream, descriptions, verbosity)
-        self.__tc = SkipResult.__skipped_test_case()
-        self.skipped.append((self.__tc, msg))
+    def __init__(self, test_run, skip_reason=''):
+        super().__init__()
+        for case in test_run.all_cases():
+            self.addSkip(case, skip_reason)
+            self.testsRun += 1
 
     @property
     def testCases(self):
-        return [self.__tc]
+        return [skipped[0] for skipped in self.skipped]
 
     @property
     def testTimes(self):
         """Get a dict of {test_case: elapsed_time}."""
-        return {self.__tc: 0}
+        return {skipped[0]: 0 for skipped in self.skipped}
 
     def wasSuccessful(self):
         return True

--- a/launch_testing/launch_testing/test_result.py
+++ b/launch_testing/launch_testing/test_result.py
@@ -33,6 +33,32 @@ class FailResult(unittest.TestResult):
         return False
 
 
+class SkipResult(unittest.TestResult):
+    """For test runs with a skip decorator on the generate_test_description function."""
+
+    class __skipped_test_case:
+
+        def __init__(self):
+            self._testMethodName = 'skipped_launch'
+
+    def __init__(self, stream=None, descriptions=None, verbosity=None, msg=''):
+        super().__init__(stream, descriptions, verbosity)
+        self.__tc = SkipResult.__skipped_test_case()
+        self.skipped.append((self.__tc, msg))
+
+    @property
+    def testCases(self):
+        return [self.__tc]
+
+    @property
+    def testTimes(self):
+        """Get a dict of {test_case: elapsed_time}."""
+        return {self.__tc: 0}
+
+    def wasSuccessful(self):
+        return True
+
+
 class TestResult(unittest.TextTestResult):
     """
     Subclass of unittest.TestResult that collects more information about the tests that ran.

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -26,7 +26,7 @@ from launch.event_handlers import OnProcessIO
 from .io_handler import ActiveIoHandler
 from .parse_arguments import parse_launch_arguments
 from .proc_info_handler import ActiveProcInfoHandler
-from .test_result import FailResult, TestResult
+from .test_result import FailResult, SkipResult, TestResult
 
 
 class _LaunchDiedException(Exception):
@@ -229,6 +229,12 @@ class LaunchTestRunner(object):
             try:
                 worker = _RunnerWorker(run, self._launch_file_arguments, self._debug)
                 results[run] = worker.run()
+            except unittest.case.SkipTest as skip_exception:
+                # If a 'skip' decorator was placed on the generate_launch_description function,
+                # we skip all the tests for that run
+                print('{} is skipped: {}'.format(run, skip_exception))
+                results[run] = SkipResult(msg=str(skip_exception))
+                continue
             except _LaunchDiedException:
                 # The most likely cause was ctrl+c, so we'll abort the test run
                 results[run] = FailResult()

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -220,7 +220,7 @@ class LaunchTestRunner(object):
         :return: A tuple of two unittest.Results - one for tests that ran while processes were
         active, and another set for tests that ran after processes were shutdown
         """
-        # We will return the results as a {test_run: (active_results, post_shutdown_results)}
+        # We will return the results as a {test_run: TestResult)}
         results = {}
 
         for index, run in enumerate(self._test_runs):
@@ -233,7 +233,7 @@ class LaunchTestRunner(object):
                 # If a 'skip' decorator was placed on the generate_test_description function,
                 # we skip all the tests for that run
                 print('{} is skipped: {}'.format(run, skip_exception))
-                results[run] = SkipResult(msg=str(skip_exception))
+                results[run] = SkipResult(test_run=run, skip_reason=str(skip_exception))
                 continue
             except _LaunchDiedException:
                 # The most likely cause was ctrl+c, so we'll abort the test run

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -230,7 +230,7 @@ class LaunchTestRunner(object):
                 worker = _RunnerWorker(run, self._launch_file_arguments, self._debug)
                 results[run] = worker.run()
             except unittest.case.SkipTest as skip_exception:
-                # If a 'skip' decorator was placed on the generate_launch_description function,
+                # If a 'skip' decorator was placed on the generate_test_description function,
                 # we skip all the tests for that run
                 print('{} is skipped: {}'.format(run, skip_exception))
                 results[run] = SkipResult(msg=str(skip_exception))

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -24,6 +24,7 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
 
         dut = LaunchTestRunner(
             [TR(
+                '',
                 test_description_function=lambda: None,
                 param_args={},
                 pre_shutdown_tests=None,
@@ -36,6 +37,7 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
 
         dut = LaunchTestRunner(
             [TR(
+                '',
                 test_description_function=lambda ready_fn: None,
                 param_args={},
                 pre_shutdown_tests=None,

--- a/launch_testing/test/launch_testing/test_runner_results.py
+++ b/launch_testing/test/launch_testing/test_runner_results.py
@@ -234,6 +234,9 @@ def test_skipped_launch_description():
         def test_fail_always(self):
             assert False  # pragma: no cover
 
+        def test_pass_always(self):
+            pass  # pragma: no cover
+
     test_module = types.ModuleType('test_module')
     test_module.generate_test_description = generate_test_description
     test_module.FakePreShutdownTests = FakePreShutdownTests
@@ -245,5 +248,12 @@ def test_skipped_launch_description():
     )
 
     results = runner.run()
-    # Should just get one result, even though there were multiple tests
+    # Just one test run expected
     assert len(results.values()) == 1
+
+    skip_result = next(iter(results.values()))
+    # Make sure it looks like all three tests were skipped
+    assert len(skip_result.skipped) == 3
+    assert skip_result.testsRun == 3
+
+    # XML Structure is checked in test_xml_output.py

--- a/launch_testing/test/launch_testing/test_runner_results.py
+++ b/launch_testing/test/launch_testing/test_runner_results.py
@@ -52,7 +52,7 @@ def test_dut_that_shuts_down(capsys):
 
     with mock.patch('launch_testing.test_runner._RunnerWorker._run_test'):
         runner = LaunchTestRunner(
-            [TR(generate_test_description, {}, [], [])]
+            [TR('', generate_test_description, {}, [], [])]
         )
 
         results = runner.run()
@@ -99,7 +99,7 @@ def test_dut_that_has_exception(capsys):
 
     with mock.patch('launch_testing.test_runner._RunnerWorker._run_test'):
         runner = LaunchTestRunner(
-            [TR(generate_test_description, {}, [], [])]
+            [TR('', generate_test_description, {}, [], [])]
         )
 
         results = runner.run()

--- a/launch_testing/test/launch_testing/test_xml_output.py
+++ b/launch_testing/test/launch_testing/test_xml_output.py
@@ -22,6 +22,7 @@ import ament_index_python
 
 from launch_testing.junitxml import unittestResultsToXml
 from launch_testing.test_result import FailResult
+from launch_testing.test_result import SkipResult
 from launch_testing.test_result import TestResult as TR
 
 
@@ -66,12 +67,30 @@ class TestGoodXmlOutput(unittest.TestCase):
         # Drilling down a little further, we expect the class names to show up in the testcase
         # names
         case_names = [case.attrib['name'] for case in test_suite]
-        self.assertIn('TestGoodProcess.test_count_to_four', case_names)
-        self.assertIn('TestProcessOutput.test_full_output', case_names)
+        self.assertIn('test_count_to_four', case_names)
+        self.assertIn('test_full_output', case_names)
 
 
 class TestXmlFunctions(unittest.TestCase):
     # This are closer to unit tests - just call the functions that generate XML
+
+    def unit_test_result_factory(self, test_case_list):
+        # Use the unittest library to run some fake test functions and generate a real TestResult
+        # that we can serialize to XML
+
+        class TestHost(unittest.TestCase):
+            pass
+
+        for n, test_case in enumerate(test_case_list):
+            setattr(TestHost, 'test_{}'.format(n), test_case)
+
+        cases = unittest.TestLoader().loadTestsFromTestCase(TestHost)
+        with open(os.devnull, 'w') as nullstream:
+            runner = unittest.TextTestRunner(
+                stream=nullstream,
+                resultclass=TR
+            )
+            return runner.run(cases)
 
     def test_fail_results_serialize(self):
         xml_tree = unittestResultsToXml(
@@ -85,6 +104,23 @@ class TestXmlFunctions(unittest.TestCase):
         child_names = [chld.attrib['name'] for chld in xml_tree.getroot()]
         self.assertEqual(set(child_names), {'active_tests'})
 
+    def test_skip_results_serialize(self):
+        xml_tree = unittestResultsToXml(
+            name='skip_xml',
+            test_results={
+                'active_tests': SkipResult(msg='skip message')
+            }
+        )
+
+        # Make sure the message got into the 'skip' element
+        testsuites_element = xml_tree.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        skip_element = testcase_element.find('skipped')
+
+        self.assertEqual('1', testsuite_element.attrib['skipped'])
+        self.assertEqual('skip message', skip_element.attrib['message'])
+
     def test_multiple_test_results(self):
         xml_tree = unittestResultsToXml(
             name='multiple_launches',
@@ -97,3 +133,152 @@ class TestXmlFunctions(unittest.TestCase):
 
         child_names = [chld.attrib['name'] for chld in xml_tree.getroot()]
         self.assertEqual(set(child_names), {'launch_1', 'launch_2', 'launch_3'})
+
+    def test_result_that_ran(self):
+        # This mostly validates the test setup
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    lambda self: None
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . />
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+
+        # The bare minimum XML we require:
+        self.assertEqual('0', testsuite_element.attrib['failures'])
+        self.assertEqual('0', testsuite_element.attrib['errors'])
+        self.assertEqual('1', testsuite_element.attrib['tests'])
+        self.assertEqual('test_0', testcase_element.attrib['name'])
+        self.assertEqual('TestHost', testcase_element.attrib['classname'])
+
+    def test_result_with_skipped_test(self):
+
+        @unittest.skip('My reason is foo')
+        def test_that_is_skipped(self):
+            pass  # pragma: no cover
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    test_that_is_skipped
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . >
+        #       <skipped message="My reason is foo" . . . />
+        #     </testcase>
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        skip_element = testcase_element.find('skipped')
+
+        self.assertEqual('1', testsuite_element.attrib['skipped'])
+        self.assertEqual('My reason is foo', skip_element.attrib['message'])
+
+    def test_result_with_failure(self):
+
+        def test_that_fails(self):
+            assert 1 == 2
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    test_that_fails
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . >
+        #       <failure message="assert 1 == 2" . . .>
+        #       </failure>
+        #     </testcase>
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        failure_element = testcase_element.find('failure')
+
+        self.assertEqual('1', testsuite_element.attrib['failures'])
+        self.assertIn('1 == 2', failure_element.attrib['message'])
+
+    def test_result_with_error(self):
+
+        def test_that_errors(self):
+            raise Exception('This is an error')
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    test_that_errors
+                ])
+            }
+        )
+
+        # The expected structure for this test is:
+        # <testsuites>
+        #   <testsuite name="run1" . . . >
+        #     <testcase classname="TestHost" name="test_0" . . . >
+        #       <error message="This is an error" . . .>
+        #       </failure>
+        #     </testcase>
+        #   </testsuite>
+        # <testsuites>
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+        testcase_element = testsuite_element.find('testcase')
+        error_element = testcase_element.find('error')
+
+        self.assertEqual('1', testsuite_element.attrib['errors'])
+        self.assertIn('This is an error', error_element.attrib['message'])
+
+    def test_with_multiple_results(self):
+
+        def good_test(self):
+            pass
+
+        def error_test(self):
+            raise Exception('I am an error')
+
+        def fail_test(self):
+            assert 1 == 2
+
+        dut_xml = unittestResultsToXml(
+            test_results={
+                'run1': self.unit_test_result_factory([
+                    good_test,
+                    error_test,
+                    fail_test,
+                ])
+            }
+        )
+
+        testsuites_element = dut_xml.getroot()
+        testsuite_element = testsuites_element.find('testsuite')
+
+        self.assertEqual('1', testsuite_element.attrib['failures'])
+        self.assertEqual('1', testsuite_element.attrib['errors'])
+        self.assertEqual('3', testsuite_element.attrib['tests'])

--- a/launch_testing/test/launch_testing/test_xml_output.py
+++ b/launch_testing/test/launch_testing/test_xml_output.py
@@ -50,6 +50,7 @@ class TestGoodXmlOutput(unittest.TestCase):
                 'launch_test',
                 path,
                 '--junit-xml', os.path.join(cls.tmpdir.name, 'junit.xml'),
+                '--test-name', 'good_proc'
             ],
         ).returncode
 
@@ -65,7 +66,7 @@ class TestGoodXmlOutput(unittest.TestCase):
         test_suite = root[0]
 
         # Expecting an element called 'launch' since this was not parametrized
-        self.assertEqual(test_suite.attrib['name'], 'launch')
+        self.assertEqual(test_suite.attrib['name'], 'good_proc.launch_tests')
 
         # Drilling down a little further, we expect the class names to show up in the testcase
         # names
@@ -173,12 +174,14 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_that_ran(self):
         """
-        # The expected XML output for this test looks like this
-        # <testsuites>
-        #   <testsuite name="run1" . . . >
-        #     <testcase classname="TestHost" name="test_0" . . . />
-        #   </testsuite>
-        # <testsuites>
+        Test we have output as a result of a test being run.
+
+        The expected XML output for this test is:
+        <testsuites>
+          <testsuite name="run1" . . . >
+            <testcase classname="TestHost" name="test_0" . . . />
+          </testsuite>
+        <testsuites>
         """
         # This mostly validates the test setup is good for the other tests
         dut_xml = unittestResultsToXml(
@@ -202,7 +205,9 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_with_skipped_test(self):
         """
-        The expected XML output for this test looks like:
+        Test we have output as a result of a skipped test.
+
+        The expected XML output for this test is:
         <testsuites>
           <testsuite name="run1" skipped="1". . . >
             <testcase classname="TestHost" name="test_0" . . . >
@@ -210,6 +215,7 @@ class TestXmlFunctions(unittest.TestCase):
             </testcase>
           </testsuite>
         <testsuites>
+
         Notice the extra 'skipped' child-element of testcase.
         """
         @unittest.skip('My reason is foo')
@@ -224,7 +230,6 @@ class TestXmlFunctions(unittest.TestCase):
             }
         )
 
-
         testsuites_element = dut_xml.getroot()
         testsuite_element = testsuites_element.find('testsuite')
         testcase_element = testsuite_element.find('testcase')
@@ -235,7 +240,10 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_with_failure(self):
         """
-        The expected XML output for this test is
+        Test we have output as a result of failed test.
+
+        The expected XML output for this test is:
+
         <testsuites>
           <testsuite name="run1" failures="1". . . >
             <testcase classname="TestHost" name="test_0" . . . >
@@ -246,9 +254,8 @@ class TestXmlFunctions(unittest.TestCase):
         <testsuites>
 
         Notice there's a failure message child-element of the testcase and
-        a count of failed tests
+        a count of failed tests.
         """
-
         def test_that_fails(self):
             assert 1 == 2
 
@@ -270,7 +277,10 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_with_error(self):
         """
+        Test we have output as a result of an error in a test.
+
         The expected XML output for this test is:
+
         <testsuites>
           <testsuite name="run1" errors="1". . . >
             <testcase classname="TestHost" name="test_0" . . . >
@@ -281,9 +291,8 @@ class TestXmlFunctions(unittest.TestCase):
         <testsuites>
 
         Python unittest treats exceptions other than AssertionError exceptions
-        as 'errors' not failures so they get a different tag, and count
+        as 'errors' not failures so they get a different tag, and count.
         """
-
         def test_that_errors(self):
             raise Exception('This is an error')
 

--- a/launch_testing/test/launch_testing/test_xml_output.py
+++ b/launch_testing/test/launch_testing/test_xml_output.py
@@ -50,7 +50,7 @@ class TestGoodXmlOutput(unittest.TestCase):
                 'launch_test',
                 path,
                 '--junit-xml', os.path.join(cls.tmpdir.name, 'junit.xml'),
-                '--test-name', 'good_proc'
+                '--package-name', 'test_xml_output'
             ],
         ).returncode
 
@@ -65,8 +65,11 @@ class TestGoodXmlOutput(unittest.TestCase):
         self.assertEqual(len(root), 1)
         test_suite = root[0]
 
-        # Expecting an element called 'launch' since this was not parametrized
-        self.assertEqual(test_suite.attrib['name'], 'good_proc.launch_tests')
+        # Expecting an element called '{package}.{test_base_name}.launch_tests' since this
+        # was not parametrized
+        self.assertEqual(
+            test_suite.attrib['name'], 'test_xml_output.good_proc.test.launch_tests'
+        )
 
         # Drilling down a little further, we expect the class names to show up in the testcase
         # names
@@ -201,7 +204,8 @@ class TestXmlFunctions(unittest.TestCase):
         self.assertEqual('0', testsuite_element.attrib['errors'])
         self.assertEqual('1', testsuite_element.attrib['tests'])
         self.assertEqual('test_0', testcase_element.attrib['name'])
-        self.assertEqual('TestHost', testcase_element.attrib['classname'])
+        # Expect a fully qualified class name
+        self.assertEqual('test_xml_output.TestHost', testcase_element.attrib['classname'])
 
     def test_result_with_skipped_test(self):
         """

--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -97,6 +97,7 @@ function(add_launch_test file)
     string(REPLACE "/" "_" _add_launch_test_TARGET ${_add_launch_test_TARGET})
   endif()
 
+  set(test_name "${PROJECT_NAME}.${_add_launch_test_TARGET}")
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${_add_launch_test_TARGET}.xunit.xml")
 
   set(cmd
@@ -106,6 +107,7 @@ function(add_launch_test file)
     "${_file_name}"
     "${_add_launch_test_ARGS}"
     "--junit-xml=${result_file}"
+    "--test-name=${test_name}"
   )
 
   ament_add_test(

--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -97,7 +97,6 @@ function(add_launch_test file)
     string(REPLACE "/" "_" _add_launch_test_TARGET ${_add_launch_test_TARGET})
   endif()
 
-  set(test_name "${PROJECT_NAME}.${_add_launch_test_TARGET}")
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${_add_launch_test_TARGET}.xunit.xml")
 
   set(cmd
@@ -107,7 +106,7 @@ function(add_launch_test file)
     "${_file_name}"
     "${_add_launch_test_ARGS}"
     "--junit-xml=${result_file}"
-    "--test-name=${test_name}"
+    "--package-name=${PROJECT_NAME}"
   )
 
   ament_add_test(


### PR DESCRIPTION
 - Use the `classname` attribute in the `testcase` element instead of jamming everything into `name`
 - Use the `message` attribute for `skipped` elements
 - Handle the case where @unittest.skip("Skip Message") is added to the generate_launch_description function

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>

I noticed some of our internal tooling was choking on apex_launchtest XML, so I've made the generated XML match pytest's XML more closely

Example pytest XML using same classnames and test names as the good_proc.test.py example, but with empty test methods:
```
<?xml version="1.0" encoding="utf-8"?>
<testsuite errors="0" failures="0" name="pytest" skipped="1" tests="4" time="0.110">
  <testcase classname="example_pytest.TestGoodProcess" file="example_pytest.py" line="55" name="test_count_to_four" time="0.001"/>
  <testcase classname="example_pytest.TestProcessOutput" file="example_pytest.py" line="68" name="test_exit_code" time="0.001">
    <skipped message="Example of a skip" type="pytest.skip">example_pytest.py:68: Example of a skip</skipped>
  </testcase>
  <testcase classname="example_pytest.TestProcessOutput" file="example_pytest.py" line="75" name="test_full_output" time="0.001"/>
  <testcase classname="example_pytest.TestProcessOutput" file="example_pytest.py" line="85" name="test_out_of_order" time="0.001"/>
</testsuite>
```

Example launchtest XML:
```
<?xml version="1.0" encoding="us-ascii"?>
<testsuites errors="0" failures="0" name="apex_launchtest" tests="4">
  <testsuite errors="0" failures="0" name="good_proc.test.py" skipped="1" tests="4" time="4.111">
    <testcase classname="TestGoodProcess" name="test_count_to_four" time="4.11"/>
    <testcase classname="TestProcessOutput" name="test_full_output" time="0.0"/>
    <testcase classname="TestProcessOutput" name="test_exit_code" time="0.0">
      <skipped message="Example of a skip"/>
    </testcase>
    <testcase classname="TestProcessOutput" name="test_out_of_order" time="0.0"/>
  </testsuite>
</testsuites>
```
It's not spot-on, but it's sufficient for our internal test reporting tooling.  I'm open to feedback about what parts of the pytest junit XML are important.

This PR matches is my internal PR https://github.com/ApexAI/apex_rostest/pull/41 on the Apex AI repo