### PR TITLE
Fix proc lookup for processes with multiple command-line arguments

### DIFF
--- a/launch_testing/example_processes/good_proc
+++ b/launch_testing/example_processes/good_proc
@@ -22,8 +22,8 @@ import time
 # an exit code of zero
 if __name__ == "__main__":
 
-    # if sys.argv[1:]:    
-    #     print("Called with arguments {}".format(sys.argv[1:]))
+    if sys.argv[1:]:
+        print("Called with arguments {}".format(sys.argv[1:]))
 
     print("Starting Up")
 

--- a/launch_testing/launch_testing/util/proc_lookup.py
+++ b/launch_testing/launch_testing/util/proc_lookup.py
@@ -68,7 +68,7 @@ def _str_name_to_process(info_obj, proc_name, cmd_args):
         elif cmd_args is NO_CMD_ARGS:
             return len(proc.process_details['cmd']) == 1
         else:
-            return cmd_args in proc.process_details['cmd'][1:]
+            return all(arg in proc.process_details['cmd'][1:] for arg in cmd_args)
 
     matches = [proc for proc in info_obj.processes()
                if name_match_fn(proc) and cmd_match_fn(proc)]
@@ -97,6 +97,12 @@ def resolveProcesses(info_obj, *, process=None, cmd_args=None, strict_proc_match
     :returns: A list of one or more matching processes taken from the info_obj.  If no processes
     in info_obj match, a NoMatchingProcessException will be raised.
     """
+    # Old versions of this let you pass a string for cmd_args, but there was no way to search
+    # for multiple arguments when you did that.  For backwards compatibility, we'll wrap string
+    # cmd_args in a list
+    if isinstance(cmd_args, str):
+        cmd_args = [cmd_args]
+
     if process is None:
         # We want to search all processes
         all_procs = info_obj.processes()

--- a/launch_testing/launch_testing/util/proc_lookup.py
+++ b/launch_testing/launch_testing/util/proc_lookup.py
@@ -97,12 +97,6 @@ def resolveProcesses(info_obj, *, process=None, cmd_args=None, strict_proc_match
     :returns: A list of one or more matching processes taken from the info_obj.  If no processes
     in info_obj match, a NoMatchingProcessException will be raised.
     """
-    # Old versions of this let you pass a string for cmd_args, but there was no way to search
-    # for multiple arguments when you did that.  For backwards compatibility, we'll wrap string
-    # cmd_args in a list
-    if isinstance(cmd_args, str):
-        cmd_args = [cmd_args]
-
     if process is None:
         # We want to search all processes
         all_procs = info_obj.processes()
@@ -122,6 +116,13 @@ def resolveProcesses(info_obj, *, process=None, cmd_args=None, strict_proc_match
     elif isinstance(process, str):
         # We want to search one (or more) processes that match a particular string.  The 'or more'
         # part is controlled by the strict_proc_matching argument
+
+        # Old versions of this let you pass a string for cmd_args, but there was no way to search
+        # for multiple arguments when you did that.  For backwards compatibility, we'll wrap string
+        # cmd_args in a list
+        if isinstance(cmd_args, str):
+            cmd_args = [cmd_args]
+
         matches = _str_name_to_process(info_obj, process, cmd_args)
         if len(matches) == 0:
             names = ', '.join(sorted(_proc_to_name_and_args(p) for p in info_obj.processes()))

--- a/launch_testing/test/launch_testing/test_resolve_process.py
+++ b/launch_testing/test/launch_testing/test_resolve_process.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 import types
 import unittest
 
@@ -89,17 +90,17 @@ class TestStringProcessResolution(unittest.TestCase):
 
         def generate_test_description(ready_fn):
             no_arg_proc = launch.actions.ExecuteProcess(
-                cmd=[proc_command],
+                cmd=[sys.executable],
                 env=proc_env
             )
 
             one_arg_proc = launch.actions.ExecuteProcess(
-                cmd=[proc_command, '--one-arg'],
+                cmd=[sys.executable, proc_command, '--one-arg'],
                 env=proc_env
             )
 
             two_arg_proc = launch.actions.ExecuteProcess(
-                cmd=[proc_command, '--two-arg', 'arg_two'],
+                cmd=[sys.executable, proc_command, '--two-arg', 'arg_two'],
                 env=proc_env
             )
 
@@ -146,7 +147,7 @@ class TestStringProcessResolution(unittest.TestCase):
     def test_proc_string_lookup_multiple_args(self):
         found_proc = launch_testing.util.resolveProcesses(
             self.proc_info,
-            process='good_proc',
+            process=os.path.basename(sys.executable),
             cmd_args=['--two-arg', 'arg_two']
         )
 
@@ -155,7 +156,7 @@ class TestStringProcessResolution(unittest.TestCase):
     def test_proc_string_lookup_no_args(self):
         found_proc = launch_testing.util.resolveProcesses(
             self.proc_info,
-            process='good_proc',
+            process=os.path.basename(sys.executable),
             cmd_args=launch_testing.util.NO_CMD_ARGS
         )
 
@@ -165,12 +166,12 @@ class TestStringProcessResolution(unittest.TestCase):
         with self.assertRaisesRegexp(Exception, 'Found multiple processes'):
             launch_testing.util.resolveProcesses(
                 self.proc_info,
-                process='good_proc',
+                process=os.path.basename(sys.executable),
             )
 
         found_proc = launch_testing.util.resolveProcesses(
             self.proc_info,
-            process='good_proc',
+            process=os.path.basename(sys.executable),
             strict_proc_matching=False
         )
 
@@ -183,7 +184,7 @@ class TestStringProcessResolution(unittest.TestCase):
 
         found_proc = launch_testing.util.resolveProcesses(
             self.proc_info,
-            process='good_proc',
+            process=os.path.basename(sys.executable),
             cmd_args='--one-arg',
         )
 

--- a/launch_testing/test/launch_testing/test_resolve_process.py
+++ b/launch_testing/test/launch_testing/test_resolve_process.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import types
 import unittest
 
+import ament_index_python
 import launch.actions
 import launch.substitutions
 import launch_testing
+from launch_testing.loader import LoadTestsFromPythonModule
+from launch_testing.test_runner import LaunchTestRunner
 import launch_testing.util
 
 
@@ -66,3 +71,120 @@ class TestResolveProcess(unittest.TestCase):
         # Since the process wasn't launched yet, and it has substitutions that need to be
         # resolved by the launch system, we won't be able to take a guess at the command
         self.assertIn('Unknown', str(cm.exception))
+
+
+class TestStringProcessResolution(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Run a launch so we can get some real looking proc_info and proc_output objects to test
+        # against
+        proc_command = os.path.join(
+            ament_index_python.get_package_prefix('launch_testing'),
+            'lib/launch_testing',
+            'good_proc',
+        )
+        proc_env = os.environ.copy()
+        proc_env['PYTHONUNBUFFERED'] = '1'
+
+        def generate_test_description(ready_fn):
+            no_arg_proc = launch.actions.ExecuteProcess(
+                cmd=[proc_command],
+                env=proc_env
+            )
+
+            one_arg_proc = launch.actions.ExecuteProcess(
+                cmd=[proc_command, '--one-arg'],
+                env=proc_env
+            )
+
+            two_arg_proc = launch.actions.ExecuteProcess(
+                cmd=[proc_command, '--two-arg', 'arg_two'],
+                env=proc_env
+            )
+
+            ld = launch.LaunchDescription([
+                no_arg_proc,
+                one_arg_proc,
+                two_arg_proc,
+                launch.actions.OpaqueFunction(function=lambda ctx: ready_fn())
+            ])
+
+            return (ld, locals())
+
+        arr = []
+
+        class PreShutdownTests(unittest.TestCase):
+
+            def test_wait_self(self,
+                               proc_output,
+                               proc_info,
+                               no_arg_proc,
+                               one_arg_proc,
+                               two_arg_proc):
+                proc_output.assertWaitFor('--one-arg')
+                proc_output.assertWaitFor('--two-arg')
+                proc_output.assertWaitFor('arg_two')
+
+                arr.append(proc_info)
+
+        # Set up a fake module containing the test data:
+        test_module = types.ModuleType('test_module')
+        test_module.generate_test_description = generate_test_description
+        test_module.FakePreShutdownTests = PreShutdownTests
+
+        # Run the test:
+        runner = LaunchTestRunner(
+            LoadTestsFromPythonModule(test_module)
+        )
+
+        runner.run()
+
+        # Grab the very realistic proc_info object to use for tests below
+        cls.proc_info = arr[0]
+
+    def test_proc_string_lookup_multiple_args(self):
+        found_proc = launch_testing.util.resolveProcesses(
+            self.proc_info,
+            process='good_proc',
+            cmd_args=['--two-arg', 'arg_two']
+        )
+
+        assert found_proc
+
+    def test_proc_string_lookup_no_args(self):
+        found_proc = launch_testing.util.resolveProcesses(
+            self.proc_info,
+            process='good_proc',
+            cmd_args=launch_testing.util.NO_CMD_ARGS
+        )
+
+        assert found_proc
+
+    def test_strict_proc_matching(self):
+        with self.assertRaisesRegexp(Exception, 'Found multiple processes'):
+            launch_testing.util.resolveProcesses(
+                self.proc_info,
+                process='good_proc',
+            )
+
+        found_proc = launch_testing.util.resolveProcesses(
+            self.proc_info,
+            process='good_proc',
+            strict_proc_matching=False
+        )
+
+        assert len(found_proc) == 3
+
+    def test_string_cmd_args(self):
+        # Old versions let you pass a string to cmd_args instead of a list of strings
+        # but that made it impossible to match multiple command line arguments.
+        # This test checks the old way still works
+
+        found_proc = launch_testing.util.resolveProcesses(
+            self.proc_info,
+            process='good_proc',
+            cmd_args='--one-arg',
+        )
+
+        assert found_proc


### PR DESCRIPTION
This is built on top of https://github.com/ros2/launch/pull/215.  Only the last commit is new

Taken from here: https://github.com/ApexAI/apex_rostest/pull/43

Previously looking up processes via strings was broken in cases where you wanted to disambiguate processes with multiple command-line arguments.  This PR fixes the issue by making cmd_args an array of strings, and attempting to match all args against the launched processes's action `process_details['cmd'][1:]`