### PR TITLE
Sync missing parametrization commits

### DIFF
--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -52,8 +52,10 @@ class TestRun:
         # If we're parametrized, extend the test names so we can tell more easily what
         # params they were run with
         if self.param_args:
-            for tc in itertools.chain(_iterate_tests_in_test_suite(pre_shutdown_tests),
-                                      _iterate_tests_in_test_suite(post_shutdown_tests)):
+            for tc in itertools.chain(
+                _iterate_tests_in_test_suite(pre_shutdown_tests),
+                _iterate_tests_in_test_suite(post_shutdown_tests)
+            ):
                 test_method = getattr(tc, tc._testMethodName)
                 new_name = tc._testMethodName + self._format_params()
                 setattr(tc, '_testMethodName', new_name)

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -225,7 +225,7 @@ class LaunchTestRunner(object):
 
         for index, run in enumerate(self._test_runs):
             if len(self._test_runs) > 1:
-                print('Starting test run {}'.format(index + 1))
+                print('\n***** Starting test run {} *****'.format(run))
             try:
                 worker = _RunnerWorker(run, self._launch_file_arguments, self._debug)
                 results[run] = worker.run()

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -222,7 +222,7 @@ class LaunchTestRunner(object):
         # We will return the results as a {test_run: TestResult)}
         results = {}
 
-        for index, run in enumerate(self._test_runs):
+        for run in self._test_runs:
             if len(self._test_runs) > 1:
                 print('\n***** Starting test run {} *****'.format(run))
             try:

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -224,7 +224,7 @@ class LaunchTestRunner(object):
 
         for run in self._test_runs:
             if len(self._test_runs) > 1:
-                print('\n***** Starting test run {} *****'.format(run))
+                print('Starting test run {}'.format(run))
             try:
                 worker = _RunnerWorker(run, self._launch_file_arguments, self._debug)
                 results[run] = worker.run()

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -75,7 +75,6 @@ class _RunnerWorker():
         proc_info = ActiveProcInfoHandler()
         proc_output = ActiveIoHandler()
         full_context = dict(test_context, **self._test_run.param_args)
-        # TODO pete: this can be simplified as a call to the dict ctor:
         parsed_launch_arguments = parse_launch_arguments(self._launch_file_arguments)
         test_args = {}
 
@@ -247,4 +246,31 @@ class LaunchTestRunner(object):
         # Make sure the function signature of the launch configuration
         # generator is correct
         for run in self._test_runs:
+            # Drill down into any parametrized test descriptions and make sure the argument names
+            # are correct.  A simpler check can use getcallargs, but then you won't get a very
+            # helpful message.
+            base_fn = inspect.unwrap(run.test_description_function)
+            base_args = inspect.getfullargspec(base_fn)
+            base_args = base_args.args + base_args.kwonlyargs
+
+            # Check that the parametrized arguments all have a place to go
+            for argname in run.param_args.keys():
+                if argname not in base_args:
+                    raise Exception(
+                        'Could not find an argument in generate_test_description matching '
+                        "prametrized argument '{}'".format(argname)
+                    )
+
+            # Check for extra args in generate_test_description
+            for argname in base_args:
+                if argname == 'ready_fn':
+                    continue
+                if argname not in run.param_args.keys():
+                    raise Exception(
+                        "generate_test_description has unexpected extra argument '{}'".format(
+                            argname
+                        )
+                    )
+
+            # This is a double-check
             inspect.getcallargs(run.test_description_function, ready_fn=lambda: None)

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -224,7 +224,7 @@ class LaunchTestRunner(object):
 
         for run in self._test_runs:
             if len(self._test_runs) > 1:
-                print('Starting test run {}'.format(run))
+                print('\nStarting test run {}'.format(run))
             try:
                 worker = _RunnerWorker(run, self._launch_file_arguments, self._debug)
                 results[run] = worker.run()

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import imp
 import unittest
 
-from launch_testing.loader import TestRun as TR  # Named TR so pytest doesn't think it's a test
+import launch_testing
+from launch_testing.loader import LoadTestsFromPythonModule
 from launch_testing.test_runner import LaunchTestRunner
+
+
+def make_test_run_for_dut(generate_test_description_function):
+    module = imp.new_module('test_module')
+    module.generate_test_description = generate_test_description_function
+    return LoadTestsFromPythonModule(module)
 
 
 class TestLaunchTestRunnerValidation(unittest.TestCase):
@@ -23,26 +31,41 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
     def test_catches_bad_signature(self):
 
         dut = LaunchTestRunner(
-            [TR(
-                '',
-                test_description_function=lambda: None,
-                param_args={},
-                pre_shutdown_tests=None,
-                post_shutdown_tests=None,
-            )]
+            make_test_run_for_dut(
+                lambda: None
+            )
         )
 
         with self.assertRaises(TypeError):
             dut.validate()
 
         dut = LaunchTestRunner(
-            [TR(
-                '',
-                test_description_function=lambda ready_fn: None,
-                param_args={},
-                pre_shutdown_tests=None,
-                post_shutdown_tests=None,
-            )]
+            make_test_run_for_dut(
+                lambda ready_fn: None
+            )
         )
 
         dut.validate()
+
+    def test_too_many_arguments(self):
+
+        dut = LaunchTestRunner(
+            make_test_run_for_dut(lambda ready_fn, extra_arg: None)
+        )
+
+        with self.assertRaisesRegex(Exception, "unexpected extra argument 'extra_arg'"):
+            dut.validate()
+
+    def test_bad_parametrization_argument(self):
+
+        @launch_testing.parametrize('bad_argument', [1, 2, 3])
+        def bad_launch_description(ready_fn):
+            pass  # pragma: no cover
+
+        dut = LaunchTestRunner(
+            make_test_run_for_dut(bad_launch_description)
+        )
+
+        with self.assertRaisesRegex(Exception, 'Could not find an argument') as cm:
+            dut.validate()
+        self.assertIn('bad_argument', str(cm.exception))


### PR DESCRIPTION
When the parametrization stuff moved from apex_rostest to ros2:launch, it was WIP.  It looks like two commits didn't make it over to launch.  I noticed this [here](https://github.com/ros2/launch/pull/228#discussion_r281209795)

This PR adds the two missing commits.  The changes are:
1) Give individual test cases names that contain the value of the parameter used for the test (if parametrized).
2) Give better error messages when parametrization argument binding goes wrong

Side-note:  After this PR and the process lookup PR, I'm going to blow away the apex version of launch_testing and switch to the ros2 version, so there shouldn't be any more upstream syncing issues.