### PR TITLE
Moved some common code to LaunchDescriptionSource

### DIFF
--- a/launch/launch/launch_description_sources/python_launch_description_source.py
+++ b/launch/launch/launch_description_sources/python_launch_description_source.py
@@ -43,6 +43,6 @@ class PythonLaunchDescriptionSource(LaunchDescriptionSource):
         super().__init__(
             None,
             launch_file_path,
-            'interpreted python launch file',
-            get_method=get_launch_description_from_python_launch_file
+            'interpreted python launch file'
         )
+        self._get_launch_description = get_launch_description_from_python_launch_file

--- a/launch/test/launch/test_launch_description_source.py
+++ b/launch/test/launch/test_launch_description_source.py
@@ -31,7 +31,8 @@ def test_launch_description_source_constructors():
 def test_launch_description_source_methods():
     """Test the methods of the LaunchDescriptionSource class."""
     class MockLaunchContext:
-        ...
+        def perform_substitution(self, substitution):
+            return substitution.perform(None)
 
     lds = LaunchDescriptionSource()
     with pytest.raises(RuntimeError):

--- a/launch/test/launch/test_launch_description_source.py
+++ b/launch/test/launch/test_launch_description_source.py
@@ -31,6 +31,7 @@ def test_launch_description_source_constructors():
 def test_launch_description_source_methods():
     """Test the methods of the LaunchDescriptionSource class."""
     class MockLaunchContext:
+
         def perform_substitution(self, substitution):
             return substitution.perform(None)
 


### PR DESCRIPTION
Replaces #232 (see discussion there).

The idea of this, is to have some common code in `LaunchDescriptionSource`. The only derived class now is `PythonLaunchDescriptionSource`, but we will soon have `XMLLaunchDescriptionSource` and `YAMLLaunchDescriptionSource` which will need similar logic.

In those cases, the only that will be needed is to pass a different `get_method` to `LaunchDescriptionSource` constructor.

Note: `LaunchDescriptionSource` can still be used to wrap a `LaunchDescription`, as it is used in some places. This doesn't break api, but it adds new features to `LaunchDescriptionSource`.