### PR TITLE
Stop randomizing ROS_DOMAIN_ID by default in launch tests

### DIFF
--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -59,7 +59,7 @@ def main():
                         action='store_true',
                         default=False,
                         help=('Isolate tests using a custom ROS_DOMAIN_ID.'
-                              'Useful for test paralellization.'))
+                              'Useful for test parallelization.'))
 
     parser.add_argument(
         'launch_arguments',

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -54,10 +54,12 @@ def main():
                         default=False,
                         help='Show arguments that may be given to the test file.')
 
-    parser.add_argument('--disable-ros-isolation',
+    # TODO(hidmic): Provide this option for rostests only.
+    parser.add_argument('-i', '--isolated',
                         action='store_true',
                         default=False,
-                        help='Do not set a ROS_DOMAIN_ID.  Useful for debugging ROS tests')
+                        help=('Isolate tests using a custom ROS_DOMAIN_ID.'
+                              'Useful for test paralellization.'))
 
     parser.add_argument(
         'launch_arguments',
@@ -85,7 +87,7 @@ def main():
         _logger_.setLevel(logging.DEBUG)
         _logger_.debug('Running with verbose output')
 
-    if not args.disable_ros_isolation:
+    if args.isolated:
         domain_id = get_coordinated_domain_id()  # Must copy this to a local to keep it alive
         _logger_.debug('Running with ROS_DOMAIN_ID {}'.format(domain_id))
         os.environ['ROS_DOMAIN_ID'] = str(domain_id)


### PR DESCRIPTION
This pull request drops the `--disable-ros-isolation` option in `launch_test` in favor of `--isolated`, effectively negating the default behavior.

Running CI (only on Linux, testing `test_communication` and `launch_testing` only)

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7117)](https://ci.ros2.org/job/ci_linux/7117/)