### PR TITLE
Convert retreived path to CMake path for use.

### DIFF
--- a/launch_testing_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ament_cmake/CMakeLists.txt
@@ -23,7 +23,6 @@ if(BUILD_TESTING)
   if(NOT LAUNCH_TESTING_INSTALL_PREFIX)
       message(FATAL_ERROR "launch_testing package not found")
   endif()
-  file(TO_CMAKE_PATH "${LAUNCH_TESTING_INSTALL_PREFIX}" LAUNCH_TESTING_INSTALL_PREFIX)
 
   # Test argument passing.  This test won't pass unless you give it an argument
   add_launch_test(

--- a/launch_testing_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ament_cmake/CMakeLists.txt
@@ -23,6 +23,7 @@ if(BUILD_TESTING)
   if(NOT LAUNCH_TESTING_INSTALL_PREFIX)
       message(FATAL_ERROR "launch_testing package not found")
   endif()
+  file(TO_CMAKE_PATH "${LAUNCH_TESTING_INSTALL_PREFIX}" LAUNCH_TESTING_INSTALL_PREFIX)
 
   # Test argument passing.  This test won't pass unless you give it an argument
   add_launch_test(

--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -102,6 +102,9 @@ endmacro()
 # :param ARGS: Launch arguments to pass to the launch test
 # :type ARGS: string
 function(add_launch_test filename)
+  # Convert filename to CMake path before calling macro to
+  # avoid problems with backslashes in the filename string.
+  file(TO_CMAKE_PATH "${filename}" filename)
   parse_launch_test_arguments(_launch_test ${filename} ${ARGN})
 
   set(cmd


### PR DESCRIPTION
While working I encountered an error due to mixed CMake and Windows
style paths from this package (Example below).

With this change the path will be converted to a CMake path as soon as
it is validated.

```
CMake Error at cmake/add_launch_test.cmake:67 (if):
  Syntax error in cmake code at

    C:/Users/Administrator/jacob_ws/src/ros2/launch/launch_testing_ament_cmake/cmake/add_launch_test.cmake:67

  when parsing string

    c:\Users\Administrator\jacob_ws\install\launch_testing/share/launch_testing/examples/args.test.py

  Invalid character escape '\U'.
Call Stack (most recent call first):
  cmake/add_launch_test.cmake:105 (parse_launch_test_arguments)
  CMakeLists.txt:28 (add_launch_test)
```