### PR TITLE
Include cmake extras for testing

### DIFF
--- a/launch_testing_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ament_cmake/CMakeLists.txt
@@ -17,7 +17,9 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(launch_testing_ament_cmake_pytests test)
 
-  include(cmake/add_launch_test.cmake)
+  # Include 'add_launch_test' and it's package dependencies
+  set(launch_testing_ament_cmake_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  include(${PROJECT_NAME}-extras.cmake)
 
   ament_index_has_resource(LAUNCH_TESTING_INSTALL_PREFIX packages launch_testing)
   if(NOT LAUNCH_TESTING_INSTALL_PREFIX)


### PR DESCRIPTION
This ensures that the package dependencies are also included for add_launch_test().

Fixes [CI failure](https://ci.ros2.org/job/ci_windows/6980/testReport/junit/(root)/projectroot/C__J_workspace_ci_windows_ws_install_share_launch_testing_examples_args_test_py/).

Windows Debug: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6993)](https://ci.ros2.org/job/ci_windows/6993/)