### PR TITLE
Stop using 'launch' logger

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -89,7 +89,7 @@ class LaunchService:
         self.__debug = debug
 
         # Setup logging
-        self.__logger = launch.logging.get_logger('launch')
+        self.__logger = launch.logging.get_logger(__name__)
         # Install signal handlers if not already installed, will raise if not
         # in main-thread, call manually in main-thread to avoid this.
         install_signal_handlers()


### PR DESCRIPTION
Fixes #242. Since most classes in the `launch` package use the logger named after the module they are in, the `'launch'` logger would route all their traffic due to the hierarchical log propagation feature that Python's `logging` module comes with.

Alternatively, we _could_ disable propagation altogether, but that closes the door to creative uses of that feature in `launch`. Having said that, I don't have a strong preference.