### PR TITLE
Revert "Include cmake extras for testing (#245)"

### DIFF
--- a/launch_testing_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ament_cmake/CMakeLists.txt
@@ -17,9 +17,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(launch_testing_ament_cmake_pytests test)
 
-  # Include 'add_launch_test' and it's package dependencies
-  set(launch_testing_ament_cmake_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-  include(${PROJECT_NAME}-extras.cmake)
+  include(cmake/add_launch_test.cmake)
 
   ament_index_has_resource(LAUNCH_TESTING_INSTALL_PREFIX packages launch_testing)
   if(NOT LAUNCH_TESTING_INSTALL_PREFIX)


### PR DESCRIPTION
This reverts commit df1ae8a4dc04470058897c12899a8ef949832e2e.

Which broke Linux builds.