### PR TITLE
Avoid logging messages duplication and improve its looks

### DIFF
--- a/launch/launch/actions/log_info.py
+++ b/launch/launch/actions/log_info.py
@@ -45,7 +45,7 @@ class LogInfo(Action):
         super().__init__(**kwargs)
 
         self.__msg = normalize_to_list_of_substitutions(msg)
-        self.__logger = launch.logging.get_logger(__name__)
+        self.__logger = launch.logging.get_logger('launch.user')
 
     @property
     def msg(self) -> List[Substitution]:

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -394,6 +394,9 @@ class LaunchLogger(logging.getLoggerClass()):
         LaunchLogger.all_loggers.append(instance)
         return instance
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.propagate = False
 
 default_log_dir = _make_unique_log_dir(
     base_path=os.path.join(os.path.expanduser('~'), '.ros/log')

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -398,6 +398,7 @@ class LaunchLogger(logging.getLoggerClass()):
         super().__init__(*args, **kwargs)
         self.propagate = False
 
+
 default_log_dir = _make_unique_log_dir(
     base_path=os.path.join(os.path.expanduser('~'), '.ros/log')
 )


### PR DESCRIPTION
Closes #242. Follow up PR after the discussion that took place on #246. 

The output of the sample snippet provided in the aforementioned issue is now: 

```sh
$ ros2 launch ./test.launch.py 
[INFO] [launch]: All log files can be found below /home/michel/.ros/log/2019-05-22-14-59-15-283743-67a2a85ea748-12856
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [launch.user]: hello world
```