### PR TITLE
Use --isolated if no ROS_DOMAIN_ID is set to help parallel testing

### DIFF
--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -159,6 +159,19 @@ launch_test examples/args.test.py dut_arg:=value
 
 See the [launch_testing example with arguments](examples/args.test.py) for further reference.
 
+## ROS_DOMAIN_ID Isolation
+
+If the ROS_DOMAIN_ID environment variable isn't set, `launch_test` will automatically coordinate with other `launch_test` processes running on the same host
+to use a unique ROS_DOMAIN_ID for the launched processes.
+This allows multiple instances to run in parallel (the default with `colcon test`).
+Note that `launch_test` cannot coordinate unique domains across multiple hosts.  
+If the ROS_DOMAIN_ID environment variable is already set, `launch_test` respects the environment variable and won't attempt to select a different ID.
+In this case it's the responsibility of the user to design tests that can be safely run in parallel, or not use parallel test workers.
+
+When working on a system without a ROS_DOMAIN_ID set, the automatic domain isolation behavior can be disabled with the --disable-isolation flag.
+This can be useful for debugging tests by running without isolation and running a command like `ros2 topic echo` in another terminal window to see what's
+happening in the test as it runs.
+
 ## Using CMake
 
 To run launch tests from a CMakeLists.txt file, you'll need to declare a dependency on

--- a/launch_testing/launch_testing/domain_coordinator.py
+++ b/launch_testing/launch_testing/domain_coordinator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import random
 import socket
 
 # To coordinate ROS_DOMAIN_IDs between multiple instances of launch_test, we
@@ -36,7 +35,17 @@ class _default_selector:
     # value, then increment from there until we find one that isn't taken
 
     def __init__(self):
-        self._value = random.randint(1, 100)
+        # When we need to coordinate 10 or 20 domains, it's about 10x faster
+        # to start with a random seed value here.  It's also the difference between
+        # 1ms and 100us so it's totally insignificant
+        # Leaving this here in case it's ever useful in the future to speed up
+        # domain selection
+        # self._value = random.randint(1, 100)
+
+        # Slower, but deterministic:
+        # Always start at '1' so if there's weirdness where domains are colliding when
+        # they shouldn't, it's easier to debug
+        self._value = 1
 
     def __call__(self):
         retval = ((self._value - 1) % 100) + 1

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -80,11 +80,10 @@ def run(parser, args, test_runner_cls=LaunchTestRunner):
     # This is to allow launch_test to run in parallel and not have ROS cross-talk.
     # If the user needs to debug a test and they don't have ROS_DOMAIN_ID set in their environment
     # they can disable isolation by passing the --disable-isolation flag.
-    if 'ROS_DOMAIN_ID' not in os.environ:
-        if not args.disable_isolation:
-            domain_id = get_coordinated_domain_id()  # Must keep this as a local to keep it alive
-            _logger_.info('Running with ROS_DOMAIN_ID {}'.format(domain_id))
-            os.environ['ROS_DOMAIN_ID'] = str(domain_id)
+    if 'ROS_DOMAIN_ID' not in os.environ and not args.disable_isolation:
+        domain_id = get_coordinated_domain_id()  # Must keep this as a local to keep it alive
+        _logger_.info('Running with ROS_DOMAIN_ID {}'.format(domain_id))
+        os.environ['ROS_DOMAIN_ID'] = str(domain_id)
 
     # Load the test file as a module and make sure it has the required
     # components to run it as a launch test

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -65,7 +65,8 @@ def add_arguments(parser):
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description='Launch integration testing tool.'
+        description='Launch integration testing tool. Uses a unique domain id '
+                    "if the environment variable ROS_DOMAIN_ID isn't set."
     )
     add_arguments(parser)
     return parser, parser.parse_args()

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -50,8 +50,8 @@ def add_arguments(parser):
     )
     # TODO(hidmic): Provide this option for rostests only.
     parser.add_argument(
-        '-i', '--isolated', action='store_true', default=False,
-        help='Isolate tests using a custom ROS_DOMAIN_ID. Useful for test parallelization.'
+        '--disable-isolation', action='store_true', default=False,
+        help='Disable automatic ROS_DOMAIN_ID isolation.'
     )
     parser.add_argument(
         'launch_arguments', nargs='*',
@@ -72,10 +72,18 @@ def parse_arguments():
 
 
 def run(parser, args, test_runner_cls=LaunchTestRunner):
-    if args.isolated:
-        domain_id = get_coordinated_domain_id()  # Must copy this to a local to keep it alive
-        _logger_.info('Running with ROS_DOMAIN_ID {}'.format(domain_id))
-        os.environ['ROS_DOMAIN_ID'] = str(domain_id)
+
+    # If ROS_DOMAIN_ID is already set, launch_test will respect that domain ID and use it.
+    # If ROS_DOMAIN_ID is not set, launch_test will pick a ROS_DOMAIN_ID that's not being used
+    # by another launch_test process.
+    # This is to allow launch_test to run in parallel and not have ROS cross-talk.
+    # If the user needs to debug a test and they don't have ROS_DOMAIN_ID set in their environment
+    # they can disable isolation by passing the --disable-isolation flag.
+    if 'ROS_DOMAIN_ID' not in os.environ:
+        if not args.disable_isolation:
+            domain_id = get_coordinated_domain_id()  # Must keep this as a local to keep it alive
+            _logger_.info('Running with ROS_DOMAIN_ID {}'.format(domain_id))
+            os.environ['ROS_DOMAIN_ID'] = str(domain_id)
 
     # Load the test file as a module and make sure it has the required
     # components to run it as a launch test

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -74,7 +74,7 @@ def parse_arguments():
 def run(parser, args, test_runner_cls=LaunchTestRunner):
     if args.isolated:
         domain_id = get_coordinated_domain_id()  # Must copy this to a local to keep it alive
-        _logger_.debug('Running with ROS_DOMAIN_ID {}'.format(domain_id))
+        _logger_.info('Running with ROS_DOMAIN_ID {}'.format(domain_id))
         os.environ['ROS_DOMAIN_ID'] = str(domain_id)
 
     # Load the test file as a module and make sure it has the required


### PR DESCRIPTION
#### Description
Some background discussion can be found here: https://github.com/ros2/launch/pull/240

Prior to PR 240, launch_testing would coordinate a random domain ID with all other launch_testing instances so that two tests run at the same time didn't conflict with one another.

This is a problem if you're also using the ROS_DOMAIN_ID to prevent multiple machines on the same network from talking to one-another.  When launch_testing ran with a random domain ID, this broke the machine-to-machine isolation that OSRF had set up because `launch_testing` would pick a random domain ID that belonged to some other machine.  Domain isolation was changed to be off by default.

This PR lets launch_testing use the ROS_DOMAIN_ID for process-to-process isolation when running as part of `colcon test` **only if**  no ROS_DOMAIN_ID environment variable is set.  **Note** the environment variable is checked when you do `colcon build` not `colcon test`.  Some may find this confusing or unintuitive.

To address @tfoote 's concern [here](https://github.com/ros2/launch/pull/240#issuecomment-494188886) I'm also ditching the code that picks a random ROS_DOMAIN_ID in an effort to get a unique ID on the first try.  This was meant to make selecting a domain ID faster, but it turns out opening sockets  is so fast, even if we do it the 'slow' way it only takes about 1 millisecond longer.

#### Changes
  * launch_testing_ament_cmake - pass the --isolated flag to launch_testing if no ROS_DOMAIN_ID environment variable is set
  * launch_testing  - When picking isolated domains, always start at 1 and count up until an unused domain is found.
  * launch_testing - Make the isolated ROS_DOMAIN_ID selection into an 'info' level log message instead of a 'debug' level log message so it's captured in the logs saved when you do `colcon test`

#### Testing:
I ran the following commands with ROS_DOMAIN_ID set, and unset and verified the correct behavior by looking at the logs
```
cd /launch
colcon build --cmake-args -DBUILD_TESTING=1
colcon test --packages-select launch_testing_ament_cmake 
cat log/latest_test/launch_testing_ament_cmake/stdout_stderr.log
```

#### Conclusion:
If you want to use ROS_DOMAIN_ID to isolate multiple computers, launch_testing will not interfere with that.  In this case, you may not be able to run `launch_test` in parallel.

If you have another mechanism to isolate multiple computers, you can leave ROS_DOMAIN_ID unset and `launch_test` will isolate itself from other `launch_test` processes when run as part of `colcon test`
