### PR TITLE
fix detection of arguments passed when including a launch description

### DIFF
--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -17,6 +17,7 @@
 from typing import List
 from typing import Optional
 from typing import Text
+from typing import TYPE_CHECKING
 
 import launch.logging
 
@@ -26,6 +27,9 @@ from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
+
+if TYPE_CHECKING:
+    from ..actions import IncludeLaunchDescription  # noqa
 
 
 class DeclareLaunchArgument(Action):
@@ -94,6 +98,13 @@ class DeclareLaunchArgument(Action):
         # Its value will be read and set at different times and so the value
         # may change depending at different times based on the context.
         self._conditionally_included = False
+
+        # This is used later to determine if the instance of
+        # IncludeLaunchDescription which included this action passed the
+        # required arguments.
+        # Its value will be read and set at different times and so the value
+        # may change depending at different times based on the context.
+        self._include_launch_description_parent: Optional['IncludeLaunchDescription'] = None
 
     @property
     def name(self) -> Text:

--- a/launch/launch/launch_description_source.py
+++ b/launch/launch/launch_description_source.py
@@ -49,7 +49,7 @@ class LaunchDescriptionSource:
         """
         self.__launch_description: Optional[LaunchDescription] = launch_description
         self.__expanded_location: Optional[Text] = None
-        self.__location: SomeSubstitutionsType = normalize_to_list_of_substitutions(location)
+        self.__location = normalize_to_list_of_substitutions(location)
         self.__method: str = method
         self.__logger = launch.logging.get_logger(__name__)
 

--- a/launch/launch/launch_description_sources/python_launch_description_source.py
+++ b/launch/launch/launch_description_sources/python_launch_description_source.py
@@ -45,4 +45,7 @@ class PythonLaunchDescriptionSource(LaunchDescriptionSource):
             launch_file_path,
             'interpreted python launch file'
         )
-        self._get_launch_description = get_launch_description_from_python_launch_file
+
+    def _get_launch_description(self, location):
+        """Get the LaunchDescription from location."""
+        return get_launch_description_from_python_launch_file(location)


### PR DESCRIPTION
Potential alternative to https://github.com/ros2/launch/pull/249 and fix for #248.

@mxgrey FYI

I used this pair of launch files to test it:

```python
# test.launch.py
import launch


def generate_launch_description():
    return launch.LaunchDescription([
        launch.actions.DeclareLaunchArgument('other2', default_value='pingpong'),
        launch.actions.IncludeLaunchDescription(
            launch.launch_description_sources.PythonLaunchDescriptionSource('./other.launch.py'),
            # Does not work, missing 'other2':
            # launch_arguments={'other': 'foobar'}.items(),

            # Does not work, missing 'other' and 'other2':
            # launch_arguments={'msg': 'world hello'}.items(),

            # Works:
            launch_arguments={
                'other': 'foobar',
                'other2': launch.substitutions.LaunchConfiguration('other2')
            }.items(),
        ),
    ])
```

```python
# other.launch.py
import launch


def generate_launch_description():
    return launch.LaunchDescription([
        launch.actions.DeclareLaunchArgument('msg', default_value='hello world'),
        launch.actions.DeclareLaunchArgument('other'),
        launch.actions.DeclareLaunchArgument('other2'),
        launch.actions.LogInfo(msg=launch.substitutions.LaunchConfiguration('msg')),
        launch.actions.LogInfo(msg=launch.substitutions.LaunchConfiguration('other')),
        launch.actions.LogInfo(msg=launch.substitutions.LaunchConfiguration('other2')),
    ])
```

I haven't made a test case yet, but I wanted to get this up for review asap. I'll keep working on a test case.

This change is different from #249 in that it uses the arguments passed to the "parent" `IncludeLaunchDescription` action, whether that be the one used by `ros2 launch` or the one the user used to nest a launch file into another one, when evaluating whether or not a non-optional `DeclareLaunchArgument` action has been satisfied. Whereas #249 just ignores nested `DeclareLaunchArguments` (if I'm understanding the issue correctly).