### PR TITLE
Fix get_launch_arguments to not crash on conditional sub entities

### DIFF
--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -103,8 +103,10 @@ class LaunchDescription(LaunchDescriptionEntity):
                         continue
                     process_entities(
                         entity.describe_sub_entities(), _conditional_inclusion=False)
-                    process_entities(
-                        entity.describe_conditional_sub_entities(), _conditional_inclusion=True)
+                    for conditional_sub_entity in entity.describe_conditional_sub_entities():
+                        process_entities(
+                            conditional_sub_entity[1],
+                            _conditional_inclusion=True)
 
         process_entities(self.entities, _conditional_inclusion=conditional_inclusion)
 

--- a/launch/test/launch/test_launch_description.py
+++ b/launch/test/launch/test_launch_description.py
@@ -70,6 +70,19 @@ def test_launch_description_get_launch_arguments():
     la = ld.get_launch_arguments()
     assert len(la) == 0
 
+    # From issue #144: get_launch_arguments was broken when an entitity had conditional
+    # sub entities
+    class EntityWithConditional(LaunchDescriptionEntity):
+
+        def describe_conditional_sub_entities(self):
+            return [('String describing condition', [DeclareLaunchArgument('foo')])]
+
+    ld = LaunchDescription([
+        EntityWithConditional()
+    ])
+    la = ld.get_launch_arguments()
+    assert len(la) == 1
+
 
 def test_launch_description_add_things():
     """Test adding things to the LaunchDescription class."""


### PR DESCRIPTION
  - This resolves #144 where the bug was being triggered by a TimerAction
  - Test case added to test_launch_description.py

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>