### PR TITLE
Fix build_cop #214

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -328,6 +328,7 @@ class ExecuteProcess(Action):
             else:
                 last_line = line
                 break
+        self.__stdout_buffer.seek(0)
         self.__stdout_buffer.truncate(0)
         if last_line is not None:
             self.__stdout_buffer.write(last_line)
@@ -346,6 +347,7 @@ class ExecuteProcess(Action):
             else:
                 last_line = line
                 break
+        self.__stderr_buffer.seek(0)
         self.__stderr_buffer.truncate(0)
         if last_line is not None:
             self.__stderr_buffer.write(last_line)


### PR DESCRIPTION
truncate method doesn't change the position in the stream (https://docs.python.org/3/library/io.html#io.IOBase.truncate).

The error was introduced in https://github.com/ros2/launch/pull/255 after https://github.com/ros2/launch/pull/255/commits/3b0f53b36bab7ff0fa747df3502164812412603b.

Fixes ros2/build_cop#214

I was sure I tested it correctly, but it seems that I didn't :man_facepalming:.