### PR TITLE
Fix EventHandler type hints

### DIFF
--- a/launch/launch/actions/register_event_handler.py
+++ b/launch/launch/actions/register_event_handler.py
@@ -15,7 +15,7 @@
 """Module for the RegisterEventHandler action."""
 
 from ..action import Action
-from ..event_handler import EventHandler
+from ..event_handler import BaseEventHandler
 from ..launch_context import LaunchContext
 
 
@@ -32,13 +32,13 @@ class RegisterEventHandler(Action):
     place.
     """
 
-    def __init__(self, event_handler: EventHandler, **kwargs) -> None:
+    def __init__(self, event_handler: BaseEventHandler, **kwargs) -> None:
         """Constructor."""
         super().__init__(**kwargs)
         self.__event_handler = event_handler
 
     @property
-    def event_handler(self) -> EventHandler:
+    def event_handler(self) -> BaseEventHandler:
         """Getter for self.__event_handler."""
         return self.__event_handler
 

--- a/launch/launch/actions/unregister_event_handler.py
+++ b/launch/launch/actions/unregister_event_handler.py
@@ -15,20 +15,20 @@
 """Module for the UnregisterEventHandler action."""
 
 from ..action import Action
-from ..event_handler import EventHandler
+from ..event_handler import BaseEventHandler
 from ..launch_context import LaunchContext
 
 
 class UnregisterEventHandler(Action):
     """Action that unregisters an event handler."""
 
-    def __init__(self, event_handler: EventHandler, **kwargs) -> None:
+    def __init__(self, event_handler: BaseEventHandler, **kwargs) -> None:
         """Constructor."""
         super().__init__(**kwargs)
         self.__event_handler = event_handler
 
     @property
-    def event_handler(self) -> EventHandler:
+    def event_handler(self) -> BaseEventHandler:
         """Getter for self.__event_handler."""
         return self.__event_handler
 

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -26,7 +26,7 @@ from typing import Text
 import launch.logging
 
 from .event import Event
-from .event_handler import EventHandler
+from .event_handler import BaseEventHandler
 from .substitution import Substitution
 
 
@@ -161,11 +161,11 @@ class LaunchContext:
         """Check whether an event would be handled or not."""
         return any(handler.matches(event) for handler in self._event_handlers)
 
-    def register_event_handler(self, event_handler: EventHandler) -> None:
+    def register_event_handler(self, event_handler: BaseEventHandler) -> None:
         """Register a event handler."""
         self._event_handlers.appendleft(event_handler)
 
-    def unregister_event_handler(self, event_handler: EventHandler) -> None:
+    def unregister_event_handler(self, event_handler: BaseEventHandler) -> None:
         """Unregister an event handler."""
         self._event_handlers.remove(event_handler)
 

--- a/launch/launch/launch_introspector.py
+++ b/launch/launch/launch_introspector.py
@@ -23,7 +23,7 @@ from .actions import EmitEvent
 from .actions import ExecuteProcess
 from .actions import LogInfo
 from .actions import RegisterEventHandler
-from .event_handler import EventHandler
+from .event_handler import BaseEventHandler
 from .launch_description import LaunchDescription
 from .launch_description_entity import LaunchDescriptionEntity
 from .some_substitutions_type import SomeSubstitutionsType
@@ -80,7 +80,7 @@ def format_substitutions(substitutions: SomeSubstitutionsType) -> Text:
     return ' + '.join([sub.describe() for sub in normalized_substitutions])
 
 
-def format_event_handler(event_handler: EventHandler) -> List[Text]:
+def format_event_handler(event_handler: BaseEventHandler) -> List[Text]:
     """Return a text representation of an event handler."""
     if hasattr(event_handler, 'describe'):
         # TODO(wjwwood): consider supporting mode complex descriptions of branching


### PR DESCRIPTION
Previously, the type hints for EventHandler methods were misleading, since they would reject objects inheriting from BaseEventHandler (like OnProcessExit). Now this code would typecheck.

Screenshot from a type-checking IDE:
![Screenshot from 2019-06-18 13-25-15](https://user-images.githubusercontent.com/119948/59710527-b9eb3200-91ce-11e9-8d8e-2a0df864211b.png)
