### PR TITLE
Add PathJoinSubstitution

### DIFF
--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -18,6 +18,7 @@ from .environment_variable import EnvironmentVariable
 from .find_executable import FindExecutable
 from .launch_configuration import LaunchConfiguration
 from .local_substitution import LocalSubstitution
+from .path_join_substitution import PathJoinSubstitution
 from .python_expression import PythonExpression
 from .substitution_failure import SubstitutionFailure
 from .text_substitution import TextSubstitution
@@ -28,6 +29,7 @@ __all__ = [
     'FindExecutable',
     'LaunchConfiguration',
     'LocalSubstitution',
+    'PathJoinSubstitution',
     'PythonExpression',
     'SubstitutionFailure',
     'TextSubstitution',

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -1,0 +1,45 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the LocalSubstitution substitution."""
+
+import os
+from typing import Iterable
+from typing import Text
+
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+
+
+class PathJoinSubstitution(Substitution):
+    """Substitution that join paths, in a platform independent way."""
+
+    def __init__(self, substitutions: Iterable[SomeSubstitutionsType]) -> None:
+        from ..utilities import normalize_to_list_of_substitutions
+        self.__substitutions = normalize_to_list_of_substitutions(substitutions)
+
+    @property
+    def substitutions(self) -> Iterable[Substitution]:
+        """Getter for variable_name."""
+        return self.__substitutions
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return "LocalVar('{}')".format(' + '.join([s.describe() for s in self.substitutions]))
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution by retrieving the local variable."""
+        performed_substitutions = [sub.perform(context) for sub in self.__substitutions]
+        return os.path.join(*performed_substitutions)

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for the LocalSubstitution substitution."""
+"""Module for the PathJoinSubstitution substitution."""
 
 import os
 from typing import Iterable
@@ -27,6 +27,7 @@ class PathJoinSubstitution(Substitution):
     """Substitution that join paths, in a platform independent way."""
 
     def __init__(self, substitutions: Iterable[SomeSubstitutionsType]) -> None:
+        """Constructor."""
         from ..utilities import normalize_to_list_of_substitutions
         self.__substitutions = normalize_to_list_of_substitutions(substitutions)
 

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -1,0 +1,26 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ThisLaunchFileDir substitution class."""
+
+import os
+
+from launch.substitutions import PathJoinSubstitution
+
+
+def test_this_launch_file_path():
+    """Test the constructors for ThisLaunchFileDir class."""
+    path = ['asd', 'bsd', 'cds']
+    sub = PathJoinSubstitution(path)
+    assert sub.perform(None) == os.path.join(*path)

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the ThisLaunchFileDir substitution class."""
+"""Tests for the PathJoinSubstitution substitution class."""
 
 import os
 
@@ -20,7 +20,6 @@ from launch.substitutions import PathJoinSubstitution
 
 
 def test_this_launch_file_path():
-    """Test the constructors for ThisLaunchFileDir class."""
     path = ['asd', 'bsd', 'cds']
     sub = PathJoinSubstitution(path)
     assert sub.perform(None) == os.path.join(*path)


### PR DESCRIPTION
Convenient substitution.

For example here:
https://github.com/ros2/ros2cli/blob/96c3a7d49cbf6fabcfe587c63bca3f01577a8b6c/test_ros2cli/test/test_process_output_customizable.py.in#L38
from https://github.com/ros2/ros2cli/pull/287.
It would be better to use:
```python3
 cmd = [PathJoinSubstitution([FindPackage('ros2cli'), 'bin', 'ros2']), verb]
```