### PR TITLE
Always accept posix paths in LaunchDescriptionSource

### DIFF
--- a/launch/launch/launch_description_source.py
+++ b/launch/launch/launch_description_source.py
@@ -14,6 +14,7 @@
 
 """Module for the LaunchDescriptionSource class."""
 
+from pathlib import Path
 import traceback
 from typing import Optional
 from typing import Text
@@ -77,8 +78,9 @@ class LaunchDescriptionSource:
     def get_launch_description(self, context: LaunchContext) -> LaunchDescription:
         """Get the LaunchDescription, loading it if necessary."""
         if self.__expanded_location is None:
-            self.__expanded_location = \
+            self.__expanded_location = str(Path(
                 perform_substitutions(context, self.__location)
+            ))
         if self.__launch_description is None:
             self.__launch_description = \
                 self._get_launch_description(self.__expanded_location)


### PR DESCRIPTION
On Linux/Mac, `LaunchDescriptionSource` will work as before.
On Windows:
- `LaunchDescriptionSource` will still accept paths in the windows way(e.g.: `'path\\to\\file'`).
- Will also accept path in the posix style (e.g. `'path/to/file'`).

It will avoid unnecessary usage of `os.path.join` or `pathlib.Path` in many launch files.
It will also allow always using posix style in the new [launch xml and yaml formats](https://github.com/ros2/launch/pull/226). I can do another workaround for that, but this seems like a better change.