### PR TITLE
fix linter warnings

### DIFF
--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -24,8 +24,8 @@ from .launch_context import LaunchContext
 from .launch_description_entity import LaunchDescriptionEntity
 
 if False:
-    from .frontend import Entity
-    from .frontend import Parser
+    from .frontend import Entity  # noqa: F401
+    from .frontend import Parser  # noqa: F401
 
 
 class Action(LaunchDescriptionEntity):

--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -23,7 +23,7 @@ import launch.logging
 from ..action import Action
 from ..frontend import Entity
 from ..frontend import expose_action
-from ..frontend import Parser
+from ..frontend import Parser  # noqa: F401
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -23,8 +23,8 @@ from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 
 if False:
-    from .entity import Entity
-    from .parser import Parser
+    from .entity import Entity  # noqa: F401
+    from .parser import Parser  # noqa: F401
 
 action_parse_methods = {}
 substitution_parse_methods = {}

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -36,7 +36,7 @@ interpolation_fuctions = {
 }
 
 if False:
-    from ..launch_description import LaunchDescription
+    from ..launch_description import LaunchDescription  # noqa: F401
 
 
 class Parser:
@@ -83,7 +83,8 @@ class Parser:
 
     def parse_description(self, entity: Entity) -> 'LaunchDescription':
         """Parse a launch description."""
-        from ..launch_description import LaunchDescription  # Avoid recursive import
+        # Avoid recursive import
+        from ..launch_description import LaunchDescription  # noqa: F811
         if entity.type_name != 'launch':
             raise RuntimeError("Expected 'launch' as root tag")
         actions = [self.parse_action(child) for child in entity.children]


### PR DESCRIPTION
Addresses the warnings reported in the [CI nightly build](http://build.ros2.org/view/Eci/job/Eci__nightly-fastrtps_ubuntu_bionic_amd64/20/testReport/launch.test/test_flake8/test_flake8/): [![Build Status](http://build.ros2.org/buildStatus/icon?job=Eci__overlay_ubuntu_bionic_amd64&build=2)](http://build.ros2.org/job/Eci__overlay_ubuntu_bionic_amd64/2/) (CI overlay before)

With the fix the warnings are resolved: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Eci__overlay_ubuntu_bionic_amd64&build=11)](http://build.ros2.org/job/Eci__overlay_ubuntu_bionic_amd64/11/)