### PR TITLE
Revert "Revert "[execute_process] emulate_tty configurable and defaults to true""

### DIFF
--- a/launch/examples/disable_emulate_tty_counters.py
+++ b/launch/examples/disable_emulate_tty_counters.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Script that demonstrates disabling tty emulation.
+
+This is most significant for python processes which, without tty
+emulation, will be buffered by default and have various other
+capabilities disabled."
+"""
+
+import os
+import sys
+from typing import cast
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))  # noqa
+
+import launch
+
+
+def generate_launch_description():
+    ld = launch.LaunchDescription()
+
+    # Disable tty emulation (on by default).
+    ld.add_action(launch.actions.SetLaunchConfiguration('emulate_tty', 'false'))
+
+    # Wire up stdout from processes
+    def on_output(event: launch.Event) -> None:
+        for line in event.text.decode().splitlines():
+            print('[{}] {}'.format(
+                cast(launch.events.process.ProcessIO, event).process_name, line))
+
+    ld.add_action(launch.actions.RegisterEventHandler(launch.event_handlers.OnProcessIO(
+        on_stdout=on_output,
+    )))
+
+    # Execute
+    ld.add_action(launch.actions.ExecuteProcess(
+        cmd=[sys.executable, './counter.py']
+    ))
+    return ld
+
+
+if __name__ == '__main__':
+    # ls = LaunchService(argv=argv, debug=True)  # Use this instead to get more debug messages.
+    ls = launch.LaunchService(argv=sys.argv[1:])
+    ls.include_launch_description(generate_launch_description())
+    sys.exit(ls.run())

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -38,6 +38,8 @@ import launch.logging
 from osrf_pycommon.process_utils import async_execute_process
 from osrf_pycommon.process_utils import AsyncSubprocessProtocol
 
+import yaml
+
 from .emit_event import EmitEvent
 from .opaque_function import OpaqueFunction
 from .timer_action import TimerAction
@@ -95,6 +97,7 @@ class ExecuteProcess(Action):
             'sigterm_timeout', default=5),
         sigkill_timeout: SomeSubstitutionsType = LaunchConfiguration(
             'sigkill_timeout', default=5),
+        emulate_tty: bool = True,
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Text = 'log',
         output_format: Text = '[{this.name}] {line}',
@@ -173,6 +176,8 @@ class ExecuteProcess(Action):
             as a string or a list of strings and Substitutions to be resolved
             at runtime, defaults to the LaunchConfiguration called
             'sigkill_timeout'
+        :param: emulate_tty emulate a tty (terminal), defaults to
+            the LaunchConfiguration called 'emulate_tty'
         :param: prefix a set of commands/arguments to preceed the cmd, used for
             things like gdb/valgrind and defaults to the LaunchConfiguration
             called 'launch-prefix'
@@ -211,6 +216,7 @@ class ExecuteProcess(Action):
         self.__shell = shell
         self.__sigterm_timeout = normalize_to_list_of_substitutions(sigterm_timeout)
         self.__sigkill_timeout = normalize_to_list_of_substitutions(sigkill_timeout)
+        self.__emulate_tty = emulate_tty
         self.__prefix = normalize_to_list_of_substitutions(
             LaunchConfiguration('launch-prefix', default='') if prefix is None else prefix
         )
@@ -578,6 +584,16 @@ class ExecuteProcess(Action):
                 ', '.join(cmd), cwd, 'True' if env is not None else 'False'
             ))
         try:
+            emulate_tty = yaml.safe_load(
+                context.launch_configurations['emulate_tty']
+            )
+            if type(emulate_tty) is not bool:
+                raise TypeError('emulate_tty is not boolean [{}]'.format(
+                    type(emulate_tty)
+                ))
+        except KeyError:
+            emulate_tty = self.__emulate_tty
+        try:
             transport, self._subprocess_protocol = await async_execute_process(
                 lambda **kwargs: self.__ProcessProtocol(
                     self, context, process_event_args, **kwargs
@@ -586,7 +602,7 @@ class ExecuteProcess(Action):
                 cwd=cwd,
                 env=env,
                 shell=self.__shell,
-                emulate_tty=False,
+                emulate_tty=emulate_tty,
                 stderr_to_stdout=False,
             )
         except Exception:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -43,7 +43,7 @@ from .opaque_function import OpaqueFunction
 from .timer_action import TimerAction
 
 from ..action import Action
-from ..condition import evaluate_condition_expression
+from ..conditions import evaluate_condition_expression
 from ..event import Event
 from ..event_handler import EventHandler
 from ..event_handlers import OnProcessExit

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -96,7 +96,7 @@ class ExecuteProcess(Action):
             'sigterm_timeout', default=5),
         sigkill_timeout: SomeSubstitutionsType = LaunchConfiguration(
             'sigkill_timeout', default=5),
-        emulate_tty: bool = True,
+        emulate_tty: bool = False,
         prefix: Optional[SomeSubstitutionsType] = None,
         output: Text = 'log',
         output_format: Text = '[{this.name}] {line}',
@@ -175,7 +175,7 @@ class ExecuteProcess(Action):
             as a string or a list of strings and Substitutions to be resolved
             at runtime, defaults to the LaunchConfiguration called
             'sigkill_timeout'
-        :param: emulate_tty emulate a tty (terminal), defaults to True, but can
+        :param: emulate_tty emulate a tty (terminal), defaults to False, but can
             be overridden with the LaunchConfiguration called 'emulate_tty',
             the value of which is evaluated as true or false according to
             :py:func:`evaluate_condition_expression`.

--- a/launch/test/launch/actions/test_emulate_tty.py
+++ b/launch/test/launch/actions/test_emulate_tty.py
@@ -36,7 +36,7 @@ def tty_expected_unless_windows():
 
 @pytest.mark.parametrize('test_input,expected', [
     # use the default defined by ExecuteProcess
-    (None, tty_expected_unless_windows()),
+    (None, not tty_expected_unless_windows()),
     # redundantly override the default via LaunchConfiguration
     ('true', tty_expected_unless_windows()),
     # override the default via LaunchConfiguration

--- a/launch/test/launch/actions/test_emulate_tty.py
+++ b/launch/test/launch/actions/test_emulate_tty.py
@@ -1,0 +1,70 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for emulate_tty configuration of ExecuteProcess actions."""
+
+import platform
+import sys
+
+import launch
+import pytest
+
+
+class OnExit(object):
+
+    def __init__(self):
+        self.returncode = None
+
+    def handle(self, event, context):
+        self.returncode = event.returncode
+
+
+def tty_expected_unless_windows():
+    return 1 if platform.system() != 'Windows' else 0
+
+
+@pytest.mark.parametrize('test_input,expected', [
+    # use the default defined by ExecuteProcess
+    (None, tty_expected_unless_windows()),
+    # redundantly override the default via LaunchConfiguration
+    ('true', tty_expected_unless_windows()),
+    # override the default via LaunchConfiguration
+    ('false', 0)
+])
+def test_emulate_tty(test_input, expected):
+    on_exit = OnExit()
+    ld = launch.LaunchDescription()
+    ld.add_action(launch.actions.ExecuteProcess(
+        cmd=[sys.executable,
+             '-c',
+             'import sys; sys.exit(sys.stdout.isatty())'
+             ]
+        )
+    )
+    if test_input is not None:
+        ld.add_action(
+            launch.actions.SetLaunchConfiguration(
+                'emulate_tty',
+                test_input
+            )
+        )
+    ld.add_action(
+        launch.actions.RegisterEventHandler(
+            launch.event_handlers.OnProcessExit(on_exit=on_exit.handle)
+        )
+    )
+    ls = launch.LaunchService()
+    ls.include_launch_description(ld)
+    ls.run()
+    assert on_exit.returncode == expected

--- a/launch/test/launch/actions/test_include_launch_description.py
+++ b/launch/test/launch/actions/test_include_launch_description.py
@@ -110,7 +110,7 @@ def test_include_launch_description_launch_arguments():
     lc2 = LaunchContext()
     with pytest.raises(RuntimeError) as excinfo2:
         action2.visit(lc2)
-    assert 'Included launch description missing required argument' in str(excinfo2)
+    assert 'Included launch description missing required argument' in str(excinfo2.value)
 
     # test that a declared argument that is not provided raises an error, but with other args set
     ld2 = LaunchDescription([DeclareLaunchArgument('foo')])
@@ -121,8 +121,8 @@ def test_include_launch_description_launch_arguments():
     lc2 = LaunchContext()
     with pytest.raises(RuntimeError) as excinfo2:
         action2.visit(lc2)
-    assert 'Included launch description missing required argument' in str(excinfo2)
-    assert 'not_foo' in str(excinfo2)
+    assert 'Included launch description missing required argument' in str(excinfo2.value)
+    assert 'not_foo' in str(excinfo2.value)
 
     # test that a declared argument with a default value that is not provided does not raise
     ld2 = LaunchDescription([DeclareLaunchArgument('foo', default_value='FOO')])

--- a/launch_testing/launch_testing/asserts/assert_output.py
+++ b/launch_testing/launch_testing/asserts/assert_output.py
@@ -19,6 +19,17 @@ from ..util import resolveProcesses
 from osrf_pycommon.terminal_color import remove_ansi_escape_senquences
 
 
+def normalize_lineseps(lines):
+    """
+    Normalize and then return the given lines to all use `\n`.
+    """
+    lines = lines.replace(os.linesep, '\n')
+    # This happens (even on Linux and macOS) when capturing I/O from an
+    # emulated tty.
+    lines = lines.replace('\r\n', '\n')
+    return lines
+
+
 def get_matching_function(expected_output):
     if isinstance(expected_output, (list, tuple)):
         if len(expected_output) > 0:
@@ -35,7 +46,7 @@ def get_matching_function(expected_output):
             if hasattr(expected_output[0], 'search'):
                 def _match(expected, actual):
                     start = 0
-                    actual = actual.replace(os.linesep, '\n')
+                    actual = normalize_lineseps(actual)
                     for pattern in expected:
                         match = pattern.search(actual, start)
                         if match is None:
@@ -47,7 +58,7 @@ def get_matching_function(expected_output):
         return lambda expected, actual: expected in actual
     elif hasattr(expected_output, 'search'):
         return lambda expected, actual: (
-            expected.search(actual.replace(os.linesep, '\n')) is not None
+            expected.search(normalize_lineseps(actual)) is not None
         )
     raise ValueError('Unknown format for expected output')
 

--- a/launch_testing/launch_testing/asserts/assert_output.py
+++ b/launch_testing/launch_testing/asserts/assert_output.py
@@ -14,15 +14,13 @@
 
 import os
 
-from ..util import resolveProcesses
-
 from osrf_pycommon.terminal_color import remove_ansi_escape_senquences
+
+from ..util import resolveProcesses
 
 
 def normalize_lineseps(lines):
-    """
-    Normalize and then return the given lines to all use `\n`.
-    """
+    r"""Normalize and then return the given lines to all use '\n'."""
     lines = lines.replace(os.linesep, '\n')
     # This happens (even on Linux and macOS) when capturing I/O from an
     # emulated tty.

--- a/launch_testing/launch_testing/asserts/assert_output.py
+++ b/launch_testing/launch_testing/asserts/assert_output.py
@@ -16,6 +16,8 @@ import os
 
 from ..util import resolveProcesses
 
+from osrf_pycommon.terminal_color import remove_ansi_escape_senquences
+
 
 def get_matching_function(expected_output):
     if isinstance(expected_output, (list, tuple)):
@@ -56,7 +58,8 @@ def assertInStdout(proc_output,
                    cmd_args=None,
                    *,
                    output_filter=None,
-                   strict_proc_matching=True):
+                   strict_proc_matching=True,
+                   strip_ansi_escape_sequences=True):
     """
     Assert that 'output' was found in the standard out of a process.
 
@@ -82,6 +85,11 @@ def assertInStdout(proc_output,
     of proc and cmd_args matches multiple processes, then strict_proc_matching=True will raise
     an error.
     :type strict_proc_matching: bool
+
+    :param strip_ansi_escape_sequences: If True (default), strip ansi escape
+    sequences from actual output before comparing with the output filter or
+    expected output.
+    :type strip_ansi_escape_sequences: bool
     """
     resolved_procs = resolveProcesses(
         info_obj=proc_output,
@@ -98,6 +106,8 @@ def assertInStdout(proc_output,
         full_output = ''.join(
             output.text.decode() for output in proc_output[proc] if output.from_stdout
         )
+        if strip_ansi_escape_sequences:
+            full_output = remove_ansi_escape_senquences(full_output)
         if output_filter is not None:
             full_output = output_filter(full_output)
         if output_match(expected_output, full_output):

--- a/launch_testing/launch_testing/io_handler.py
+++ b/launch_testing/launch_testing/io_handler.py
@@ -134,6 +134,7 @@ class ActiveIoHandler(IoHandler):
         strict_proc_matching=True,
         output_filter=None,
         timeout=10,
+        strip_ansi_escape_sequences=True
     ):
         success = False
 
@@ -145,7 +146,8 @@ class ActiveIoHandler(IoHandler):
                     process=process,
                     cmd_args=cmd_args,
                     output_filter=output_filter,
-                    strict_proc_matching=strict_proc_matching
+                    strict_proc_matching=strict_proc_matching,
+                    strip_ansi_escape_sequences=strip_ansi_escape_sequences,
                 )
                 return True
             except NoMatchingProcessException:

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -122,10 +122,6 @@ class _RunnerWorker():
         # the test and add our own event handlers for process IO and process exit:
         launch_description = LaunchDescription([
             *self._test_run_preamble,
-            launch.actions.IncludeLaunchDescription(
-                launch.LaunchDescriptionSource(launch_description=test_ld),
-                launch_arguments=parsed_launch_arguments
-            ),
             RegisterEventHandler(
                 OnProcessExit(on_exit=lambda info, unused: proc_info.append(info))
             ),
@@ -134,6 +130,10 @@ class _RunnerWorker():
                     on_stdout=proc_output.append,
                     on_stderr=proc_output.append,
                 )
+            ),
+            launch.actions.IncludeLaunchDescription(
+                launch.LaunchDescriptionSource(launch_description=test_ld),
+                launch_arguments=parsed_launch_arguments
             ),
         ])
 

--- a/launch_testing/package.xml
+++ b/launch_testing/package.xml
@@ -10,8 +10,9 @@
   <author>Esteve Fernandez</author>
   <license>Apache License 2.0</license>
 
-  <exec_depend>launch</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>osrf_pycommon</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/launch_testing/test/launch_testing/test_resolve_process.py
+++ b/launch_testing/test/launch_testing/test_resolve_process.py
@@ -161,7 +161,7 @@ class TestStringProcessResolution(unittest.TestCase):
         assert found_proc
 
     def test_strict_proc_matching(self):
-        with self.assertRaisesRegexp(Exception, 'Found multiple processes'):
+        with self.assertRaisesRegex(Exception, 'Found multiple processes'):
             launch_testing.util.resolveProcesses(
                 self.proc_info,
                 process=os.path.basename(sys.executable),


### PR DESCRIPTION
This is a refactor of https://github.com/ros2/launch/pull/265 so that it doesn't break our other tests.

Detecting it in the first place was my fault because I narrowed our CI testing too much and so didn't exercise the failing tests.

Reverts ros2/launch#276