### PR TITLE
Add assertWaitForStartup method to match assertWaitForShutdown

### DIFF
--- a/launch/launch/event_handlers/__init__.py
+++ b/launch/launch/event_handlers/__init__.py
@@ -19,6 +19,7 @@ from .on_execution_complete import OnExecutionComplete
 from .on_include_launch_description import OnIncludeLaunchDescription
 from .on_process_exit import OnProcessExit
 from .on_process_io import OnProcessIO
+from .on_process_start import OnProcessStart
 from .on_shutdown import OnShutdown
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     'OnIncludeLaunchDescription',
     'OnProcessExit',
     'OnProcessIO',
+    'OnProcessStart',
     'OnShutdown',
 ]

--- a/launch_testing/launch_testing/proc_info_handler.py
+++ b/launch_testing/launch_testing/proc_info_handler.py
@@ -14,6 +14,7 @@
 
 import threading
 from launch.actions import ExecuteProcess  # noqa
+from launch.events.process import ProcessExited
 
 from .util import NoMatchingProcessException
 from .util import resolveProcesses
@@ -118,7 +119,7 @@ class ActiveProcInfoHandler(ProcInfoHandler):
                 )[0]
 
                 process_event = self._proc_info_handler[resolved_process]
-                return hasattr(process_event, 'returncode')
+                return isinstance(process_event, ProcessExited)
             except NoMatchingProcessException:
                 return False
 

--- a/launch_testing/launch_testing/proc_info_handler.py
+++ b/launch_testing/launch_testing/proc_info_handler.py
@@ -129,3 +129,30 @@ class ActiveProcInfoHandler(ProcInfoHandler):
             )
 
         assert success, "Timed out waiting for process '{}' to finish".format(process)
+
+    def assertWaitForStartup(self,
+                             process,
+                             cmd_args=None,
+                             *,
+                             timeout=10):
+        success = False
+
+        def proc_is_started():
+            try:
+                resolveProcesses(
+                    info_obj=self._proc_info_handler,
+                    process=process,
+                    cmd_args=cmd_args,
+                    strict_proc_matching=True
+                )
+                return True
+            except NoMatchingProcessException:
+                return False
+
+        with self._sync_lock:
+            success = self._sync_lock.wait_for(
+                proc_is_started,
+                timeout=timeout
+            )
+
+        assert success, "Timed out waiting for process '{}' to start".format(process)

--- a/launch_testing/launch_testing/proc_info_handler.py
+++ b/launch_testing/launch_testing/proc_info_handler.py
@@ -110,13 +110,15 @@ class ActiveProcInfoHandler(ProcInfoHandler):
 
         def proc_is_shutdown():
             try:
-                resolveProcesses(
+                resolved_process = resolveProcesses(
                     info_obj=self._proc_info_handler,
                     process=process,
                     cmd_args=cmd_args,
                     strict_proc_matching=True
-                )
-                return True
+                )[0]
+
+                process_event = self._proc_info_handler[resolved_process]
+                return hasattr(process_event, 'returncode')
             except NoMatchingProcessException:
                 return False
 

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -20,8 +20,9 @@ import launch
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit, OnProcessStart
+from launch.event_handlers import OnProcessExit
 from launch.event_handlers import OnProcessIO
+from launch.event_handlers import OnProcessStart
 
 from .io_handler import ActiveIoHandler
 from .parse_arguments import parse_launch_arguments

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -20,7 +20,7 @@ import launch
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
+from launch.event_handlers import OnProcessExit, OnProcessStart
 from launch.event_handlers import OnProcessIO
 
 from .io_handler import ActiveIoHandler
@@ -125,6 +125,9 @@ class _RunnerWorker():
             launch.actions.IncludeLaunchDescription(
                 launch.LaunchDescriptionSource(launch_description=test_ld),
                 launch_arguments=parsed_launch_arguments
+            ),
+            RegisterEventHandler(
+                OnProcessStart(on_start=lambda info, unused: proc_info.append(info))
             ),
             RegisterEventHandler(
                 OnProcessExit(on_exit=lambda info, unused: proc_info.append(info))

--- a/launch_testing/test/conftest.py
+++ b/launch_testing/test/conftest.py
@@ -31,14 +31,14 @@ def _source_test_loader(generate_test_description_fn,
     and modules.
     Rather than refactoring launch_testing and python unittest, we leverage what we already have.
     This method stuffs test methods into unittest.TestCase classes, and then stuffs those
-    classes into modules before loading them as a TestRun
+    classes into modules before loading them as a TestRun.
 
     :param: generate_test_description_fn A python function with a signature matching
-        generate_test_description.
+        `generate_test_description`'s.
     :param: pre_shutdown_tests A list of test methods to run concurrently with the processes
-        described by the generate_test_description function
+        described by `generate_test_description`.
     :param: post_shutdown_tests A list of test methods to run after the launched processes
-        have shut down
+        have shut down.
     """
     test_module = types.ModuleType('test_module')
     test_module.generate_test_description = generate_test_description_fn

--- a/launch_testing/test/conftest.py
+++ b/launch_testing/test/conftest.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+import unittest
+
+from launch_testing import post_shutdown_test
+from launch_testing.loader import LoadTestsFromPythonModule
+import pytest
+
+
+def _source_test_loader(generate_test_description_fn,
+                        pre_shutdown_tests=[],
+                        post_shutdown_tests=[]):
+
+    # The launch_testing API knows how to load tests from python modules.  Rather than
+    # refactoring launch_testing and python unittest, we'll leverage what we already have
+    # by stuffing test cases into a module first, then using the existing infrastructure to
+    # load it
+
+    test_module = types.ModuleType('test_module')
+    test_module.generate_test_description = generate_test_description_fn
+
+    if pre_shutdown_tests:
+        class PreShutdownTestClass(unittest.TestCase):
+            pass
+
+        for test_func in pre_shutdown_tests:
+            setattr(PreShutdownTestClass, test_func.__name__, test_func)
+
+        setattr(test_module, 'PreShutdownTests', PreShutdownTestClass)
+
+    if post_shutdown_tests:
+        @post_shutdown_test()
+        class PostShutdownTestClass(unittest.TestCase):
+            pass
+
+        for test_func in post_shutdown_tests:
+            setattr(PostShutdownTestClass, test_func.__name__, test_func)
+
+        setattr(test_module, 'PostShutdownTests', PostShutdownTestClass)
+
+    return LoadTestsFromPythonModule(test_module)
+
+
+@pytest.fixture
+def source_test_loader():
+
+    return _source_test_loader
+
+
+@pytest.fixture(scope='class')
+def source_test_loader_class_fixture(request):
+
+    def wrapper(self, *args, **kwargs):
+        return _source_test_loader(*args, **kwargs)
+
+    request.cls.source_test_loader = wrapper

--- a/launch_testing/test/conftest.py
+++ b/launch_testing/test/conftest.py
@@ -23,12 +23,23 @@ import pytest
 def _source_test_loader(generate_test_description_fn,
                         pre_shutdown_tests=[],
                         post_shutdown_tests=[]):
+    """
+    Create a TestRun from python functions.
 
-    # The launch_testing API knows how to load tests from python modules.  Rather than
-    # refactoring launch_testing and python unittest, we'll leverage what we already have
-    # by stuffing test cases into a module first, then using the existing infrastructure to
-    # load it
+    The launch_testing API knows how to load tests from files on disk and from python modules.
+    When we want to create a TestRun from a unit test, we usually have functions, not files
+    and modules.
+    Rather than refactoring launch_testing and python unittest, we leverage what we already have.
+    This method stuffs test methods into unittest.TestCase classes, and then stuffs those
+    classes into modules before loading them as a TestRun
 
+    :param: generate_test_description_fn A python function with a signature matching
+        generate_test_description.
+    :param: pre_shutdown_tests A list of test methods to run concurrently with the processes
+        described by the generate_test_description function
+    :param: post_shutdown_tests A list of test methods to run after the launched processes
+        have shut down
+    """
     test_module = types.ModuleType('test_module')
     test_module.generate_test_description = generate_test_description_fn
 
@@ -56,13 +67,28 @@ def _source_test_loader(generate_test_description_fn,
 
 @pytest.fixture
 def source_test_loader():
-
+    """Pytest fixture to be used by pytest-style tests."""
     return _source_test_loader
 
 
 @pytest.fixture(scope='class')
 def source_test_loader_class_fixture(request):
+    """
+    Pytest fixture to be used for old style unittest.TestCase classes.
 
+    This will add the source_test_loader attribute onto the test class.
+
+    Example:
+    -------
+        @pytest.mark.usefixtures('source_test_loader_class_fixture')
+        class TestClass(unittest.TestCase):
+
+            def test(self):
+                test_runs = self.source_test_loader(  # <--Added by the fixture
+                    . . .
+                )
+
+    """
     def wrapper(self, *args, **kwargs):
         return _source_test_loader(*args, **kwargs)
 

--- a/launch_testing/test/launch_testing/test_proc_info_assertions.py
+++ b/launch_testing/test/launch_testing/test_proc_info_assertions.py
@@ -51,10 +51,10 @@ def test_wait_for_shutdown():
                         event=launch.events.process.SignalProcess(
                             signal_number=signal.SIGINT,
                             process_matcher=lambda proc: proc is good_process
-                        ) 
+                        )
                     )
                 ]
-            ), 
+            ),
             launch.actions.OpaqueFunction(function=lambda context: ready_fn())
         ]), {'good_process': good_process}
 
@@ -64,11 +64,8 @@ def test_wait_for_shutdown():
     class ProcInfoTests(unittest.TestCase):
 
         def test_01_check_running_process(self, proc_info, good_process):
-            try:
+            with self.assertRaisesRegexp(AssertionError, 'Timed out waiting for process'):
                 proc_info.assertWaitForShutdown(good_process, timeout=3)  # Should raise
-                assert False, "assertWaitForShutdown did not raise"
-            except AssertionError as e:
-                assert "Timed out waiting for process" in str(e)
 
         def test_02_check_when_process_exits(self, proc_info, good_process):
             proc_info.assertWaitForShutdown(good_process, timeout=15)
@@ -104,7 +101,7 @@ def test_wait_for_startup():
             launch.actions.TimerAction(
                 period=10.0,
                 actions=[good_process]
-            ), 
+            ),
             launch.actions.OpaqueFunction(function=lambda context: ready_fn())
         ]), {'good_process': good_process}
 
@@ -114,11 +111,8 @@ def test_wait_for_startup():
     class ProcInfoTests(unittest.TestCase):
 
         def test_01_check_for_non_running_process(self, proc_info, good_process):
-            try:
+            with self.assertRaisesRegexp(AssertionError, 'Timed out waiting for process'):
                 proc_info.assertWaitForStartup(good_process, timeout=3)  # Should raise
-                assert False, "assertWaitForStartup did not raise"
-            except AssertionError as e:
-                assert "Timed out waiting for process" in str(e)
 
         def test_02_check_when_process_runs(self, proc_info, good_process):
             # The process we're waiting for should start about 7 seconds into this wait

--- a/launch_testing/test/launch_testing/test_proc_info_assertions.py
+++ b/launch_testing/test/launch_testing/test_proc_info_assertions.py
@@ -1,0 +1,86 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import signal
+import sys
+import types
+import unittest
+
+import ament_index_python
+import launch
+import launch.actions
+import launch.events.process
+from launch_testing.loader import LoadTestsFromPythonModule
+from launch_testing.test_runner import LaunchTestRunner
+import launch_testing.util
+
+
+def test_wait_for_shutdown():
+
+    def generate_test_description(ready_fn):
+        TEST_PROC_PATH = os.path.join(
+            ament_index_python.get_package_prefix('launch_testing'),
+            'lib/launch_testing',
+            'good_proc'
+        )
+
+        good_process = launch.actions.ExecuteProcess(
+                cmd=[sys.executable, TEST_PROC_PATH],
+        )
+
+        # Let 'good_process' run for 10 seconds, then terminate it
+        return launch.LaunchDescription([
+            good_process,
+            launch_testing.util.KeepAliveProc(),
+            launch.actions.TimerAction(
+                period=10.0,
+                actions=[
+                    launch.actions.EmitEvent(
+                        event=launch.events.process.SignalProcess(
+                            signal_number=signal.SIGINT,
+                            process_matcher=lambda proc: proc is good_process
+                        ) 
+                    )
+                ]
+            ), 
+            launch.actions.OpaqueFunction(function=lambda context: ready_fn())
+        ]), {'good_process': good_process}
+
+    # This is kind of a weird test-within-a-test, but it's the easiest way to get
+    # all of the proc_info handlers hooked up correctly without digging deep into
+    # the guts of the runner
+    class ProcInfoTests(unittest.TestCase):
+
+        def test_01_check_running_process(self, proc_info, good_process):
+            try:
+                proc_info.assertWaitForShutdown(good_process, timeout=3)  # Should raise
+                assert False, "assertWaitForShutdown did not raise"
+            except AssertionError as e:
+                assert "Timed out waiting for process" in str(e)
+
+        def test_02_check_when_process_exits(self, proc_info, good_process):
+            proc_info.assertWaitForShutdown(good_process, timeout=15)
+
+    test_module = types.ModuleType('test_module')
+    test_module.generate_test_description = generate_test_description
+    test_module.ProcInfoTests = ProcInfoTests
+
+    runner = LaunchTestRunner(
+        LoadTestsFromPythonModule(test_module)
+    )
+    results = runner.run()
+
+    for result in results.values():
+        assert result.wasSuccessful()


### PR DESCRIPTION
Previously, a test could easily wait for a process to shut down, but there was no way for a test to wait for a process to start.  When testing complicated launch files, it's as important to be able to assert on started processes as it is to assert on stopped processes.

Before, a process was only added into the proc_info object on shutdown.  After this change, processes are added to the proc_info object when the start, and then again when they shutdown, overwriting the previous entry.  That means if a process is in proc_info, it's started up.  We need to check if an exit_code is present to know that a process shut down.

This PR also adds two tests - one for the assertWaitForShutdown method which was previously not covered by unit tests - and one for the new method.

Finally, over in 'launch' it looks like an OnProcessStart EventHandler was added, but it wasn't added to the event handler module's '__init__.py' file so it was difficult to import.