### PR TITLE
Add parsing method to PythonExpression substitution

### DIFF
--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -15,15 +15,18 @@
 """Module for the PythonExpression substitution."""
 
 import collections.abc
+from typing import Iterable
 from typing import List
 from typing import Text
 
+from ..frontend import expose_substitution
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import ensure_argument_type
 
 
+@expose_substitution('eval')
 class PythonExpression(Substitution):
     """
     Substitution that can access contextual local variables.
@@ -44,6 +47,13 @@ class PythonExpression(Substitution):
 
         from ..utilities import normalize_to_list_of_substitutions
         self.__expression = normalize_to_list_of_substitutions(expression)
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `PythonExpression` substitution."""
+        if len(data) != 1:
+            raise TypeError('eval substitution expects 1 argument')
+        return cls, {'expression': data[0]}
 
     @property
     def expression(self) -> List[Substitution]:

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -18,6 +18,7 @@ from launch import LaunchContext
 from launch.frontend.expose import expose_substitution
 from launch.frontend.parse_substitution import parse_substitution
 from launch.substitutions import EnvironmentVariable
+from launch.substitutions import PythonExpression
 from launch.substitutions import TextSubstitution
 from launch.substitutions import ThisLaunchFileDir
 
@@ -151,3 +152,11 @@ def test_env_subst():
     assert isinstance(env, EnvironmentVariable)
     assert 'asd' == ''.join([x.perform(None) for x in env.name])
     assert '' == ''.join([x.perform(None) for x in env.default_value])
+
+
+def test_eval_subst():
+    subst = parse_substitution(r'$(eval "\'asd\' + \'bsd\'")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+    assert 'asdbsd' == expr.perform(LaunchContext())


### PR DESCRIPTION
This one was missing. It was available in ROS 1 roslaunch XML format: http://wiki.ros.org/roslaunch/XML.