### PR TITLE
More idiomatic typecheck-only imports

### DIFF
--- a/launch/launch/event_handler.py
+++ b/launch/launch/event_handler.py
@@ -25,7 +25,7 @@ from .event import Event
 from .some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from .launch_context import LaunchContext
+    from .launch_context import LaunchContext  #noqa: F401
 
 
 class BaseEventHandler:

--- a/launch/launch/event_handler.py
+++ b/launch/launch/event_handler.py
@@ -19,13 +19,13 @@ from typing import List
 from typing import Optional
 from typing import Text
 from typing import Tuple
+from typing import TYPE_CHECKING
 
 from .event import Event
 from .some_actions_type import SomeActionsType
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from .launch_context import LaunchContext  # noqa
+if TYPE_CHECKING:
+    from .launch_context import LaunchContext
 
 
 class BaseEventHandler:

--- a/launch/launch/event_handler.py
+++ b/launch/launch/event_handler.py
@@ -25,7 +25,7 @@ from .event import Event
 from .some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from .launch_context import LaunchContext  #noqa: F401
+    from .launch_context import LaunchContext  # noqa: F401
 
 
 class BaseEventHandler:

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -20,6 +20,7 @@ from typing import cast
 from typing import List  # noqa
 from typing import Optional
 from typing import Text
+from typing import TYPE_CHECKING
 from typing import Union
 
 from ..event import Event
@@ -29,10 +30,8 @@ from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 
-
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from ..actions import ExecuteProcess  # noqa
+if TYPE_CHECKING:
+    from ..actions import ExecuteProcess
 
 
 class OnProcessExit(BaseEventHandler):

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -31,7 +31,7 @@ from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from ..actions import ExecuteProcess
+    from ..actions import ExecuteProcess  #noqa: F401
 
 
 class OnProcessExit(BaseEventHandler):

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -31,7 +31,7 @@ from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from ..actions import ExecuteProcess  #noqa: F401
+    from ..actions import ExecuteProcess  # noqa: F401
 
 
 class OnProcessExit(BaseEventHandler):

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -27,7 +27,7 @@ from ..launch_context import LaunchContext
 from ..some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from ..actions import ExecuteProcess  # noqa
+    from ..actions import ExecuteProcess  #noqa: F401
 
 
 class OnProcessIO(BaseEventHandler):

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -27,7 +27,7 @@ from ..launch_context import LaunchContext
 from ..some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from ..actions import ExecuteProcess  #noqa: F401
+    from ..actions import ExecuteProcess  # noqa: F401
 
 
 class OnProcessIO(BaseEventHandler):

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -18,6 +18,7 @@ from typing import Callable
 from typing import cast
 from typing import Optional
 from typing import Text
+from typing import TYPE_CHECKING
 
 from ..event import Event
 from ..event_handler import BaseEventHandler
@@ -25,8 +26,7 @@ from ..events.process import ProcessIO
 from ..launch_context import LaunchContext
 from ..some_actions_type import SomeActionsType
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
+if TYPE_CHECKING:
     from ..actions import ExecuteProcess  # noqa
 
 

--- a/launch/launch/event_handlers/on_process_start.py
+++ b/launch/launch/event_handlers/on_process_start.py
@@ -31,7 +31,7 @@ from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from ..actions import ExecuteProcess
+    from ..actions import ExecuteProcess  #noqa: F401
 
 
 class OnProcessStart(BaseEventHandler):

--- a/launch/launch/event_handlers/on_process_start.py
+++ b/launch/launch/event_handlers/on_process_start.py
@@ -31,7 +31,7 @@ from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 
 if TYPE_CHECKING:
-    from ..actions import ExecuteProcess  #noqa: F401
+    from ..actions import ExecuteProcess  # noqa: F401
 
 
 class OnProcessStart(BaseEventHandler):

--- a/launch/launch/event_handlers/on_process_start.py
+++ b/launch/launch/event_handlers/on_process_start.py
@@ -20,6 +20,7 @@ from typing import cast
 from typing import List  # noqa
 from typing import Optional
 from typing import Text
+from typing import TYPE_CHECKING
 from typing import Union
 
 from ..event import Event
@@ -29,10 +30,8 @@ from ..launch_context import LaunchContext
 from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 
-
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from ..actions import ExecuteProcess  # noqa
+if TYPE_CHECKING:
+    from ..actions import ExecuteProcess
 
 
 class OnProcessStart(BaseEventHandler):

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -28,7 +28,7 @@ from ..some_actions_type import SomeActionsType
 from ..utilities import is_a_subclass
 
 if TYPE_CHECKING:
-    from ..launch_context import LaunchContext
+    from ..launch_context import LaunchContext  #noqa: F401
 
 
 class OnShutdown(BaseEventHandler):

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -28,7 +28,7 @@ from ..some_actions_type import SomeActionsType
 from ..utilities import is_a_subclass
 
 if TYPE_CHECKING:
-    from ..launch_context import LaunchContext  #noqa: F401
+    from ..launch_context import LaunchContext  # noqa: F401
 
 
 class OnShutdown(BaseEventHandler):

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -19,6 +19,7 @@ from typing import cast
 from typing import Optional
 from typing import overload
 from typing import Text
+from typing import TYPE_CHECKING
 
 from ..event import Event
 from ..event_handler import BaseEventHandler
@@ -26,9 +27,8 @@ from ..events import Shutdown
 from ..some_actions_type import SomeActionsType
 from ..utilities import is_a_subclass
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from ..launch_context import LaunchContext  # noqa
+if TYPE_CHECKING:
+    from ..launch_context import LaunchContext
 
 
 class OnShutdown(BaseEventHandler):

--- a/launch/launch/events/process/process_matchers.py
+++ b/launch/launch/events/process/process_matchers.py
@@ -19,7 +19,7 @@ from typing import Text
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess
+    from ...actions import ExecuteProcess  #noqa: F401
 
 
 def matches_pid(pid: int) -> Callable[['ExecuteProcess'], bool]:

--- a/launch/launch/events/process/process_matchers.py
+++ b/launch/launch/events/process/process_matchers.py
@@ -19,7 +19,7 @@ from typing import Text
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  #noqa: F401
+    from ...actions import ExecuteProcess  # noqa: F401
 
 
 def matches_pid(pid: int) -> Callable[['ExecuteProcess'], bool]:

--- a/launch/launch/events/process/process_matchers.py
+++ b/launch/launch/events/process/process_matchers.py
@@ -16,10 +16,10 @@
 
 from typing import Callable
 from typing import Text
+from typing import TYPE_CHECKING
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from ...actions import ExecuteProcess  # noqa
+if TYPE_CHECKING:
+    from ...actions import ExecuteProcess
 
 
 def matches_pid(pid: int) -> Callable[['ExecuteProcess'], bool]:

--- a/launch/launch/events/process/process_targeted_event.py
+++ b/launch/launch/events/process/process_targeted_event.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from ...event import Event
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  #noqa: F401
+    from ...actions import ExecuteProcess  # noqa: F401
 
 
 class ProcessTargetedEvent(Event):

--- a/launch/launch/events/process/process_targeted_event.py
+++ b/launch/launch/events/process/process_targeted_event.py
@@ -15,11 +15,11 @@
 """Module for ProcessTargetedEvent event."""
 
 from typing import Callable
+from typing import TYPE_CHECKING
 
 from ...event import Event
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
+if TYPE_CHECKING:
     from ...actions import ExecuteProcess  # noqa
 
 

--- a/launch/launch/events/process/process_targeted_event.py
+++ b/launch/launch/events/process/process_targeted_event.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from ...event import Event
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  # noqa
+    from ...actions import ExecuteProcess  #noqa: F401
 
 
 class ProcessTargetedEvent(Event):

--- a/launch/launch/events/process/running_process_event.py
+++ b/launch/launch/events/process/running_process_event.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from ...event import Event
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  #noqa: F401
+    from ...actions import ExecuteProcess  # noqa: F401
 
 
 class RunningProcessEvent(Event):

--- a/launch/launch/events/process/running_process_event.py
+++ b/launch/launch/events/process/running_process_event.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from ...event import Event
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess
+    from ...actions import ExecuteProcess  #noqa: F401
 
 
 class RunningProcessEvent(Event):

--- a/launch/launch/events/process/running_process_event.py
+++ b/launch/launch/events/process/running_process_event.py
@@ -18,12 +18,12 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Text
+from typing import TYPE_CHECKING
 
 from ...event import Event
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from ...actions import ExecuteProcess  # noqa
+if TYPE_CHECKING:
+    from ...actions import ExecuteProcess
 
 
 class RunningProcessEvent(Event):

--- a/launch/launch/events/process/shutdown_process.py
+++ b/launch/launch/events/process/shutdown_process.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from .process_targeted_event import ProcessTargetedEvent
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  #noqa: F401
+    from ...actions import ExecuteProcess  # noqa: F401
 
 
 class ShutdownProcess(ProcessTargetedEvent):

--- a/launch/launch/events/process/shutdown_process.py
+++ b/launch/launch/events/process/shutdown_process.py
@@ -15,11 +15,11 @@
 """Module for ShutdownProcess event."""
 
 from typing import Callable
+from typing import TYPE_CHECKING
 
 from .process_targeted_event import ProcessTargetedEvent
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
+if TYPE_CHECKING:
     from ...actions import ExecuteProcess  # noqa
 
 

--- a/launch/launch/events/process/shutdown_process.py
+++ b/launch/launch/events/process/shutdown_process.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from .process_targeted_event import ProcessTargetedEvent
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  # noqa
+    from ...actions import ExecuteProcess  #noqa: F401
 
 
 class ShutdownProcess(ProcessTargetedEvent):

--- a/launch/launch/events/process/signal_process.py
+++ b/launch/launch/events/process/signal_process.py
@@ -17,13 +17,13 @@
 import signal as signal_module  # to avoid confusion with .signal property in type annotations
 from typing import Callable
 from typing import Text
+from typing import TYPE_CHECKING
 from typing import Union
 
 from .process_targeted_event import ProcessTargetedEvent
 from ...utilities import ensure_argument_type
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
+if TYPE_CHECKING:
     from ...actions import ExecuteProcess  # noqa
 
 

--- a/launch/launch/events/process/signal_process.py
+++ b/launch/launch/events/process/signal_process.py
@@ -24,7 +24,7 @@ from .process_targeted_event import ProcessTargetedEvent
 from ...utilities import ensure_argument_type
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  #noqa: F401
+    from ...actions import ExecuteProcess  # noqa: F401
 
 
 class SignalProcess(ProcessTargetedEvent):

--- a/launch/launch/events/process/signal_process.py
+++ b/launch/launch/events/process/signal_process.py
@@ -24,7 +24,7 @@ from .process_targeted_event import ProcessTargetedEvent
 from ...utilities import ensure_argument_type
 
 if TYPE_CHECKING:
-    from ...actions import ExecuteProcess  # noqa
+    from ...actions import ExecuteProcess  #noqa: F401
 
 
 class SignalProcess(ProcessTargetedEvent):

--- a/launch/launch/events/timer_event.py
+++ b/launch/launch/events/timer_event.py
@@ -14,11 +14,12 @@
 
 """Module for TimerEvent event."""
 
+from typing import TYPE_CHECKING
+
 from ..event import Event
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from ...actions import TimerAction  # noqa
+if TYPE_CHECKING:
+    from ..actions import TimerAction
 
 
 class TimerEvent(Event):

--- a/launch/launch/events/timer_event.py
+++ b/launch/launch/events/timer_event.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 from ..event import Event
 
 if TYPE_CHECKING:
-    from ..actions import TimerAction  #noqa: F401
+    from ..actions import TimerAction  # noqa: F401
 
 
 class TimerEvent(Event):

--- a/launch/launch/events/timer_event.py
+++ b/launch/launch/events/timer_event.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 from ..event import Event
 
 if TYPE_CHECKING:
-    from ..actions import TimerAction
+    from ..actions import TimerAction  #noqa: F401
 
 
 class TimerEvent(Event):

--- a/launch/launch/launch_description_entity.py
+++ b/launch/launch/launch_description_entity.py
@@ -23,7 +23,7 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .launch_context import LaunchContext  # noqa
+    from .launch_context import LaunchContext  #noqa: F401
 
 
 class LaunchDescriptionEntity:

--- a/launch/launch/launch_description_entity.py
+++ b/launch/launch/launch_description_entity.py
@@ -23,7 +23,7 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .launch_context import LaunchContext  #noqa: F401
+    from .launch_context import LaunchContext  # noqa: F401
 
 
 class LaunchDescriptionEntity:

--- a/launch/launch/launch_description_entity.py
+++ b/launch/launch/launch_description_entity.py
@@ -20,9 +20,9 @@ from typing import List
 from typing import Optional
 from typing import Text
 from typing import Tuple
+from typing import TYPE_CHECKING
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
+if TYPE_CHECKING:
     from .launch_context import LaunchContext  # noqa
 
 

--- a/launch/launch/substitution.py
+++ b/launch/launch/substitution.py
@@ -18,7 +18,7 @@ from typing import Text
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .launch_context import LaunchContext  #noqa: F401
+    from .launch_context import LaunchContext  # noqa: F401
 
 
 class Substitution:

--- a/launch/launch/substitution.py
+++ b/launch/launch/substitution.py
@@ -15,10 +15,10 @@
 """Module for the Substitution class."""
 
 from typing import Text
+from typing import TYPE_CHECKING
 
-if False:
-    # imports here would cause loops, but are only used as forward-references for type-checking
-    from .launch_context import LaunchContext  # noqa
+if TYPE_CHECKING:
+    from .launch_context import LaunchContext
 
 
 class Substitution:

--- a/launch/launch/substitution.py
+++ b/launch/launch/substitution.py
@@ -18,7 +18,7 @@ from typing import Text
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .launch_context import LaunchContext
+    from .launch_context import LaunchContext  #noqa: F401
 
 
 class Substitution:


### PR DESCRIPTION
Use `if TYPE_CHECKING` rather than `if FALSE` for typechecker imports.
It's rather more self-documenting.

Also fixed one broken relative import