### PR TITLE
Don't create a log directory every time the launch logger is imported.

### DIFF
--- a/launch/examples/launch_counters.py
+++ b/launch/examples/launch_counters.py
@@ -39,11 +39,9 @@ import launch.substitutions
 def main(argv=sys.argv[1:]):
     """Main."""
     # Configure rotating logs.
-    launch.logging.launch_config(
-        log_handler_factory=lambda path, encoding=None:
-            launch.logging.handlers.RotatingFileHandler(
-                path, maxBytes=1024, backupCount=3, encoding=encoding)
-    )
+    launch.logging.launch_config.log_handler_factory = \
+        lambda path, encoding=None: launch.logging.handlers.RotatingFileHandler(
+            path, maxBytes=1024, backupCount=3, encoding=encoding)
 
     # Any number of actions can optionally be given to the constructor of LaunchDescription.
     # Or actions/entities can be added after creating the LaunchDescription.

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -87,9 +87,7 @@ class LaunchService:
         :param: debug if True (not default), asyncio the logger are seutp for debug
         """
         # Setup logging and debugging.
-        launch.logging.launch_config.configure(
-            level=logging.DEBUG if debug else logging.INFO
-        )
+        launch.logging.launch_config.level = logging.DEBUG if debug else logging.INFO
         self.__debug = debug
 
         # Setup logging

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -87,7 +87,7 @@ class LaunchService:
         :param: debug if True (not default), asyncio the logger are seutp for debug
         """
         # Setup logging and debugging.
-        launch.logging.launch_config(
+        launch.logging.launch_config.configure(
             level=logging.DEBUG if debug else logging.INFO
         )
         self.__debug = debug

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -41,56 +41,15 @@ class LaunchConfig:
     """Launch Logging Configuration class."""
 
     def __init__(self):
-        self._log_dir = None
-        self.file_handlers = {}
-        self.screen_handler = None
-        self.screen_formatter = None
-        self._log_handler_factory = None
+        self.reset()
 
     def reset(self):
         self._log_dir = None
         self.file_handlers = {}
         self.screen_handler = None
         self.screen_formatter = None
+        self.file_formatter = None
         self._log_handler_factory = None
-
-    def configure(
-        self,
-        *,
-        log_format=None,
-        log_style=None,
-    ):
-        """
-        Set up launch logging.
-
-        This function allows you to:
-
-          - Configure log file formats.
-
-        Setup only has side effects for the arguments provided.
-        The setup process is idempotent.
-
-        :param log_format: the format used when logging to the main launch log file,
-            as expected by the `logging.Formatter` constructor.
-            Alternatively, the 'default' alias can be given to log verbosity level,
-            logger name and logged message.
-        :param log_style: the log style used if no alias is given for log_format.
-            No style can be provided if a format alias is given.
-        """
-        if log_format is not None:
-            if log_format == 'default':
-                log_format = '{created:.7f} [{levelname}] [{name}]: {msg}'
-                if log_style is not None:
-                    raise ValueError(
-                        'Cannot set a custom format style for the "default" log format.'
-                    )
-            if log_style is None:
-                log_style = '{'
-            self.file_formatter = logging.Formatter(
-                log_format, style=log_style
-            )
-            for handler in self.file_handlers.values():
-                handler.setFormatter(self.file_formatter)
 
     def set_level(self, new_level):
         """
@@ -209,6 +168,34 @@ class LaunchConfig:
             self.screen_handler = handlers.StreamHandler(stream)
             self.screen_handler.setFormatter(self.screen_formatter)
         return self.screen_handler
+
+    def set_log_format(self, log_format, log_style):
+        """
+        Set up launch log file format.
+
+        :param log_format: the format used when logging to the main launch log file,
+            as expected by the `logging.Formatter` constructor.
+            Alternatively, the 'default' alias can be given to log verbosity level,
+            logger name and logged message.
+        :param log_style: the log style used if no alias is given for log_format.
+            No style can be provided if a format alias is given.
+        """
+        if log_format is not None:
+            if log_format == 'default':
+                log_format = '{created:.7f} [{levelname}] [{name}]: {msg}'
+                if log_style is not None:
+                    raise ValueError(
+                        'Cannot set a custom format style for the "default" log format.'
+                    )
+            if log_style is None:
+                log_style = '{'
+            self.file_formatter = logging.Formatter(
+                log_format, style=log_style
+            )
+            for handler in self.file_handlers.values():
+                handler.setFormatter(self.file_formatter)
+        else:
+            self.file_formatter = None
 
     def get_log_file_path(self, file_name='launch.log'):
         """
@@ -461,9 +448,9 @@ def reset():
         logger.setLevel(logging.NOTSET)
         del logger.handlers[:]
     launch_config.reset()
-    launch_config.configure(log_format='default')
     launch_config.level = logging.INFO
     launch_config.set_screen_format('default', None)
+    launch_config.set_log_format('default', None)
     logging.setLoggerClass(LaunchLogger)
 
 

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -30,123 +30,187 @@ from . import handlers
 
 __all__ = [
     'get_logger',
-    'get_log_file_handler',
-    'get_log_file_path',
     'get_output_loggers',
-    'get_screen_handler',
     'handlers',
     'launch_config',
     'reset',
 ]
 
 
-def attributes(**attr):
-    """Inject attributes into a function (a singleton by definition)."""
-    def _decorator(f):
-        for name, value in attr.items():
-            setattr(f, name, value)
-        return f
-    return _decorator
+class LaunchConfig:
+    """Launch Logging Configuration class."""
+
+    def __init__(self):
+        self._log_dir = None
+        self.file_handlers = {}
+        self.screen_handler = None
+        self.log_handler_factory = None
+
+    def reset(self):
+        self._log_dir = None
+        self.file_handlers = {}
+        self.screen_handler = None
+        self.log_handler_factory = None
+
+    def configure(
+        self,
+        *,
+        level=None,
+        log_dir=None,
+        screen_format=None,
+        screen_style=None,
+        log_format=None,
+        log_style=None,
+        log_handler_factory=None
+    ):
+        """
+        Set up launch logging.
+
+        This function allows you to:
+
+          - Set the default verbosity level for all loggers.
+          - Configure the location of log files on disk.
+          - Configure screen and log file formats.
+
+        Setup only has side effects for the arguments provided.
+        The setup process is idempotent.
+
+        For the ``screen_format`` argument there are a few aliases:
+
+          - 'default' to log verbosity level, logger name and logged message
+          - 'default_with_timestamp' to add timestamps to the 'default' format
+
+        :param level: the default log level used for all loggers.
+        :param log_dir: used as base path for all log file collections.
+        :param screen_format: format specification used when logging to the screen,
+            as expected by the `logging.Formatter` constructor.
+            Alternatively, aliases for common formats are available, see above.
+        :param screen_style: the screen style used if no alias is used for
+            screen_format.
+            No style can be provided if a format alias is given.
+        :param log_format: the format used when logging to the main launch log file,
+            as expected by the `logging.Formatter` constructor.
+            Alternatively, the 'default' alias can be given to log verbosity level,
+            logger name and logged message.
+        :param log_style: the log style used if no alias is given for log_format.
+            No style can be provided if a format alias is given.
+        :param log_handler_factory: a callable to build log file handler.
+           It takes a path to the log file and it must return a `logging.Handler`
+           variant with per logger formatting support.
+           See `launch.logging.handlers` module for further reference and easy reuse
+           of existing standard `logging.handlers` module handlers.
+           Defaults to regular log file handlers for logging if no factory is given.
+        """
+        if level is not None:
+            logging.root.setLevel(level)
+        if screen_format is not None:
+            if screen_format == 'default':
+                screen_format = '[{levelname}] [{name}]: {msg}'
+                if screen_style is not None:
+                    raise ValueError(
+                        'Cannot set a custom format style for the "default" screen format.'
+                    )
+            if screen_format == 'default_with_timestamp':
+                screen_format = '{created:.7f} [{levelname}] [{name}]: {msg}'
+                if screen_style is not None:
+                    raise ValueError(
+                        'Cannot set a custom format style for the '
+                        '"default_with_timestamp" screen format.'
+                    )
+            if screen_style is None:
+                screen_style = '{'
+            self.screen_formatter = logging.Formatter(
+                screen_format, style=screen_style
+            )
+            if self.screen_handler is not None:
+                self.screen_handler.setFormatter(self.screen_formatter)
+        if log_format is not None:
+            if log_format == 'default':
+                log_format = '{created:.7f} [{levelname}] [{name}]: {msg}'
+                if log_style is not None:
+                    raise ValueError(
+                        'Cannot set a custom format style for the "default" log format.'
+                    )
+            if log_style is None:
+                log_style = '{'
+            self.file_formatter = logging.Formatter(
+                log_format, style=log_style
+            )
+            for handler in self.file_handlers.values():
+                handler.setFormatter(self.file_formatter)
+        if log_handler_factory is not None:
+            self.log_handler_factory = log_handler_factory
+        if log_dir is not None:
+            if any(self.file_handlers):
+                import warnings
+                warnings.warn((
+                    'Loggers have been already configured to output to log files below {}. '
+                    'Proceed at your own risk.'
+                ).format(self._log_dir))
+            if not os.path.isdir(log_dir):
+                raise ValueError('{} is not a directory'.format(log_dir))
+        self._log_dir = log_dir
+
+    def get_screen_handler(self):
+        """
+        Get the one and only screen logging handler.
+
+        See launch_config() documentation for screen logging configuration.
+        """
+        if self.screen_handler is None:
+            stream = codecs.StreamWriter(sys.stdout, errors='replace')
+            stream.encode = lambda msg, errors='replace': (
+                msg.encode(locale.getpreferredencoding(False), errors).decode(
+                    locale.getpreferredencoding(False), errors=errors),
+                msg)
+            self.screen_handler = handlers.StreamHandler(stream)
+            self.screen_handler.setFormatter(self.screen_formatter)
+        return self.screen_handler
+
+    def get_log_file_path(self, file_name='launch.log'):
+        """
+        Get the absolute path to the given log file.
+
+        :param: file_name of the log file from which to get the absolute path.
+        :return: the absolute path to the log file.
+        """
+        return os.path.join(self.log_dir, file_name)
+
+    def get_log_file_handler(self, file_name='launch.log'):
+        """
+        Get the logging handler to a log file.
+
+        See launch_config() documentation for application wide log file
+        logging configuration.
+
+        :param: file_name of the log file whose handler is to be retrieved.
+        :return: the logging handler associated to the file (always the same
+        once constructed).
+        """
+        if file_name not in self.file_handlers:
+            if self.log_handler_factory is None:
+                if os.name != 'nt':
+                    self.log_handler_factory = handlers.WatchedFileHandler
+                else:
+                    self.log_handler_factory = handlers.FileHandler
+            file_path = self.get_log_file_path(file_name)
+            file_handler = self.log_handler_factory(
+                file_path, encoding='utf-8')
+            file_handler.setFormatter(self.file_formatter)
+            self.file_handlers[file_name] = file_handler
+        return self.file_handlers[file_name]
+
+    @property
+    def log_dir(self):
+        if self._log_dir is None:
+            self._log_dir = _make_unique_log_dir(
+                base_path=os.path.join(os.path.expanduser('~'), '.ros/log')
+            )
+
+        return self._log_dir
 
 
-@attributes(screen_handler=None, file_handlers={}, log_handler_factory=None)
-def launch_config(
-    *,
-    level=None,
-    log_dir=None,
-    screen_format=None,
-    screen_style=None,
-    log_format=None,
-    log_style=None,
-    log_handler_factory=None,
-):
-    """
-    Set up launch logging.
-
-    This function allows you to:
-
-      - Set the default verbosity level for all loggers.
-      - Configure the location of log files on disk.
-      - Configure screen and log file formats.
-
-    Setup only has side effects for the arguments provided.
-    The setup process is idempotent.
-
-    For the ``screen_format`` argument there are a few aliases:
-
-      - 'default' to log verbosity level, logger name and logged message
-      - 'default_with_timestamp' to add timestamps to the 'default' format
-
-    :param level: the default log level used for all loggers.
-    :param log_dir: used as base path for all log file collections.
-    :param screen_format: format specification used when logging to the screen,
-        as expected by the `logging.Formatter` constructor.
-        Alternatively, aliases for common formats are available, see above.
-    :param screen_style: the screen style used if no alias is used for
-        screen_format.
-        No style can be provided if a format alias is given.
-    :param log_format: the format used when logging to the main launch log file,
-        as expected by the `logging.Formatter` constructor.
-        Alternatively, the 'default' alias can be given to log verbosity level,
-        logger name and logged message.
-    :param log_style: the log style used if no alias is given for log_format.
-        No style can be provided if a format alias is given.
-    :param log_handler_factory: a callable to build log file handler.
-       It takes a path to the log file and it must return a `logging.Handler`
-       variant with per logger formatting support.
-       See `launch.logging.handlers` module for further reference and easy reuse
-       of existing standard `logging.handlers` module handlers.
-       Defaults to regular log file handlers for logging if no factory is given.
-    """
-    if level is not None:
-        logging.root.setLevel(level)
-    if screen_format is not None:
-        if screen_format == 'default':
-            screen_format = '[{levelname}] [{name}]: {msg}'
-            if screen_style is not None:
-                raise ValueError(
-                    'Cannot set a custom format style for the "default" screen format.'
-                )
-        if screen_format == 'default_with_timestamp':
-            screen_format = '{created:.7f} [{levelname}] [{name}]: {msg}'
-            if screen_style is not None:
-                raise ValueError(
-                    'Cannot set a custom format style for the '
-                    '"default_with_timestamp" screen format.'
-                )
-        if screen_style is None:
-            screen_style = '{'
-        launch_config.screen_formatter = logging.Formatter(
-            screen_format, style=screen_style
-        )
-        if launch_config.screen_handler is not None:
-            launch_config.screen_handler.setFormatter(launch_config.screen_formatter)
-    if log_format is not None:
-        if log_format == 'default':
-            log_format = '{created:.7f} [{levelname}] [{name}]: {msg}'
-            if log_style is not None:
-                raise ValueError(
-                    'Cannot set a custom format style for the "default" log format.'
-                )
-        if log_style is None:
-            log_style = '{'
-        launch_config.file_formatter = logging.Formatter(
-            log_format, style=log_style
-        )
-        for handler in launch_config.file_handlers.values():
-            handler.setFormatter(launch_config.file_formatter)
-    if log_handler_factory is not None:
-        launch_config.log_handler_factory = log_handler_factory
-    if log_dir is not None:
-        if any(launch_config.file_handlers):
-            import warnings
-            warnings.warn((
-                'Loggers have been already configured to output to log files below {}. '
-                'Proceed at your own risk.'
-            ).format(launch_config.log_dir))
-        if not os.path.isdir(log_dir):
-            raise ValueError('{} is not a directory'.format(log_dir))
-        launch_config.log_dir = log_dir
+launch_config = LaunchConfig()
 
 
 def log_launch_config(*, logger=logging.root):
@@ -161,10 +225,10 @@ def log_launch_config(*, logger=logging.root):
 def get_logger(name=None):
     """Get named logger, configured to output to screen and launch main log file."""
     logger = logging.getLogger(name)
-    screen_handler = get_screen_handler()
+    screen_handler = launch_config.get_screen_handler()
     if screen_handler not in logger.handlers:
         logger.addHandler(screen_handler)
-    launch_log_file_handler = get_log_file_handler()
+    launch_log_file_handler = launch_config.get_log_file_handler()
     if launch_log_file_handler not in logger.handlers:
         logger.addHandler(launch_log_file_handler)
     return logger
@@ -282,7 +346,7 @@ def get_output_loggers(process_name, output_config):
         # If a 'screen' output is configured for this source or for
         # 'both' sources, this logger should output to screen.
         if 'screen' in (output_config['both'] | output_config[source]):
-            screen_handler = get_screen_handler()
+            screen_handler = launch_config.get_screen_handler()
             # Add screen handler if necessary.
             if screen_handler not in logger.handlers:
                 screen_handler.setFormatterFor(
@@ -293,7 +357,7 @@ def get_output_loggers(process_name, output_config):
         # If a 'log' output is configured for this source or for
         # 'both' sources, this logger should output to launch main log file.
         if 'log' in (output_config['both'] | output_config[source]):
-            launch_log_file_handler = get_log_file_handler()
+            launch_log_file_handler = launch_config.get_log_file_handler()
             # Add launch main log file handler if necessary.
             if launch_log_file_handler not in logger.handlers:
                 launch_log_file_handler.setFormatterFor(
@@ -304,7 +368,7 @@ def get_output_loggers(process_name, output_config):
         # If an 'own_log' output is configured for this source, this logger
         # should output to its own log file.
         if 'own_log' in output_config[source]:
-            own_log_file_handler = get_log_file_handler(
+            own_log_file_handler = launch_config.get_log_file_handler(
                 '{}-{}.log'.format(process_name, source)
             )
             own_log_file_handler.setFormatter(logging.Formatter(fmt=None))
@@ -314,7 +378,7 @@ def get_output_loggers(process_name, output_config):
         # If an 'own_log' output is configured for 'both' sources,
         # this logger should output to a combined log file.
         if 'own_log' in output_config['both']:
-            combined_log_file_handler = get_log_file_handler(process_name + '.log')
+            combined_log_file_handler = launch_config.get_log_file_handler(process_name + '.log')
             combined_log_file_handler.setFormatter(logging.Formatter('{msg}', style='{'))
             # Add combined log file handler if necessary.
             if combined_log_file_handler not in logger.handlers:
@@ -324,52 +388,6 @@ def get_output_loggers(process_name, output_config):
         logging.getLogger(process_name + '-stdout'),
         logging.getLogger(process_name + '-stderr')
     )
-
-
-def get_screen_handler():
-    """
-    Get the one and only screen logging handler.
-
-    See launch_config() documentation for screen logging configuration.
-    """
-    if launch_config.screen_handler is None:
-        stream = codecs.StreamWriter(sys.stdout, errors='replace')
-        stream.encode = lambda msg, errors='replace': (
-            msg.encode(locale.getpreferredencoding(False), errors).decode(
-                locale.getpreferredencoding(False), errors=errors),
-            msg)
-        launch_config.screen_handler = handlers.StreamHandler(stream)
-        launch_config.screen_handler.setFormatter(launch_config.screen_formatter)
-    return launch_config.screen_handler
-
-
-def get_log_file_path(file_name='launch.log'):
-    return os.path.join(launch_config.log_dir, file_name)
-
-
-def get_log_file_handler(file_name='launch.log'):
-    """
-    Get the logging handler to a log file.
-
-    See launch_config() documentation for application wide log file
-    logging configuration.
-
-    :param: file_name of the log file whose handler is to be retrieved.
-    :return: the logging handler associated to the file (always the same
-    once constructed).
-    """
-    if file_name not in launch_config.file_handlers:
-        if launch_config.log_handler_factory is None:
-            if os.name != 'nt':
-                launch_config.log_handler_factory = handlers.WatchedFileHandler
-            else:
-                launch_config.log_handler_factory = handlers.FileHandler
-        file_path = get_log_file_path(file_name)
-        file_handler = launch_config.log_handler_factory(
-            file_path, encoding='utf-8')
-        file_handler.setFormatter(launch_config.file_formatter)
-        launch_config.file_handlers[file_name] = file_handler
-    return launch_config.file_handlers[file_name]
 
 
 def _make_unique_log_dir(*, base_path):
@@ -407,25 +425,15 @@ class LaunchLogger(logging.getLoggerClass()):
         self.propagate = False
 
 
-default_log_dir = _make_unique_log_dir(
-    base_path=os.path.join(os.path.expanduser('~'), '.ros/log')
-)
-
-
 def reset():
     """Reset logging."""
     # Reset existing logging infrastructure
     for logger in LaunchLogger.all_loggers:
         logger.setLevel(logging.NOTSET)
         del logger.handlers[:]
-    # Back to default logging setup
-    launch_config.log_dir = None
-    launch_config.file_handlers = {}
-    launch_config.screen_handler = None
-    launch_config(
-        level=logging.INFO, log_dir=default_log_dir,
-        log_format='default', screen_format='default'
-    )
+    launch_config.reset()
+    launch_config.configure(level=logging.INFO, log_dir=None,
+                            log_format='default', screen_format='default')
     logging.setLoggerClass(LaunchLogger)
 
 

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -55,7 +55,6 @@ class LaunchConfig:
     def configure(
         self,
         *,
-        level=None,
         log_dir=None,
         screen_format=None,
         screen_style=None,
@@ -68,7 +67,6 @@ class LaunchConfig:
 
         This function allows you to:
 
-          - Set the default verbosity level for all loggers.
           - Configure the location of log files on disk.
           - Configure screen and log file formats.
 
@@ -80,7 +78,6 @@ class LaunchConfig:
           - 'default' to log verbosity level, logger name and logged message
           - 'default_with_timestamp' to add timestamps to the 'default' format
 
-        :param level: the default log level used for all loggers.
         :param log_dir: used as base path for all log file collections.
         :param screen_format: format specification used when logging to the screen,
             as expected by the `logging.Formatter` constructor.
@@ -101,8 +98,6 @@ class LaunchConfig:
            of existing standard `logging.handlers` module handlers.
            Defaults to regular log file handlers for logging if no factory is given.
         """
-        if level is not None:
-            logging.root.setLevel(level)
         if screen_format is not None:
             if screen_format == 'default':
                 screen_format = '[{levelname}] [{name}]: {msg}'
@@ -150,6 +145,16 @@ class LaunchConfig:
             if not os.path.isdir(log_dir):
                 raise ValueError('{} is not a directory'.format(log_dir))
         self._log_dir = log_dir
+
+    def set_level(self, new_level):
+        """
+        Set up launch logging verbosity level for all loggers.
+
+        :param level: the default log level used for all loggers.
+        """
+        logging.root.setLevel(new_level)
+
+    level = property(None, set_level)
 
     def get_screen_handler(self):
         """
@@ -432,8 +437,8 @@ def reset():
         logger.setLevel(logging.NOTSET)
         del logger.handlers[:]
     launch_config.reset()
-    launch_config.configure(level=logging.INFO, log_dir=None,
-                            log_format='default', screen_format='default')
+    launch_config.configure(log_format='default', screen_format='default')
+    launch_config.level = logging.INFO
     logging.setLoggerClass(LaunchLogger)
 
 

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -37,7 +37,7 @@ def test_bad_logging_launch_config():
         launch.logging.launch_config.log_dir = 'not/a/real/dir'
 
     with pytest.raises(ValueError):
-        launch.logging.launch_config.set_screen_format('default', '%')
+        launch.logging.launch_config.set_screen_format('default', screen_style='%')
 
     with pytest.raises(ValueError):
         launch.logging.launch_config.set_log_format(log_format='default', log_style='%')
@@ -84,10 +84,7 @@ def test_output_loggers_bad_configuration(log_dir):
 def test_output_loggers_configuration(capsys, log_dir, config, checks):
     checks = {'stdout': set(), 'stderr': set(), 'both': set(), **checks}
     launch.logging.reset()
-    launch.logging.launch_config.set_log_format('default', None)
-    launch.logging.launch_config.level = logging.INFO
     launch.logging.launch_config.log_dir = log_dir
-    launch.logging.launch_config.set_screen_format('default', None)
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
@@ -168,7 +165,7 @@ def test_screen_default_format_with_timestamps(capsys, log_dir):
     launch.logging.reset()
     launch.logging.launch_config.level = logging.DEBUG
     launch.logging.launch_config.log_dir = log_dir
-    launch.logging.launch_config.set_screen_format('default_with_timestamp', None)
+    launch.logging.launch_config.set_screen_format('default_with_timestamp')
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     assert logger.getEffectiveLevel() == logging.DEBUG
@@ -185,8 +182,6 @@ def test_screen_default_format_with_timestamps(capsys, log_dir):
 def test_screen_default_format(capsys):
     """Test screen logging when using the default logs format."""
     launch.logging.reset()
-    launch.logging.launch_config.level = logging.INFO
-    launch.logging.launch_config.set_screen_format('default', None)
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
@@ -205,7 +200,6 @@ def test_log_default_format(log_dir):
     launch.logging.reset()
     launch.logging.launch_config.level = logging.WARN
     launch.logging.launch_config.log_dir = log_dir
-    launch.logging.launch_config.set_log_format('default', None)
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
     assert logger.getEffectiveLevel() == logging.WARN
@@ -244,7 +238,6 @@ def test_log_handler_factory(log_dir):
             output=outputs[path]
         )
     )
-    launch.logging.launch_config.set_log_format('default', None)
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -34,20 +34,20 @@ def test_bad_logging_launch_config():
     launch.logging.reset()
 
     with pytest.raises(ValueError):
-        launch.logging.launch_config(log_dir='not/a/real/dir')
+        launch.logging.launch_config.configure(log_dir='not/a/real/dir')
 
     with pytest.raises(ValueError):
-        launch.logging.launch_config(screen_format='default', screen_style='%')
+        launch.logging.launch_config.configure(screen_format='default', screen_style='%')
 
     with pytest.raises(ValueError):
-        launch.logging.launch_config(log_format='default', log_style='%')
+        launch.logging.launch_config.configure(log_format='default', log_style='%')
 
 
 def test_output_loggers_bad_configuration(log_dir):
     """Tests that output loggers setup throws at bad configuration."""
-    launch.logging.reset()
+    launch.logging.launch_config.reset()
 
-    launch.logging.launch_config(log_dir=log_dir)
+    launch.logging.launch_config.configure(log_dir=log_dir)
 
     with pytest.raises(ValueError):
         launch.logging.get_output_loggers('some-proc', 'not_an_alias')
@@ -84,15 +84,15 @@ def test_output_loggers_bad_configuration(log_dir):
 def test_output_loggers_configuration(capsys, log_dir, config, checks):
     checks = {'stdout': set(), 'stderr': set(), 'both': set(), **checks}
     launch.logging.reset()
-    launch.logging.launch_config(
+    launch.logging.launch_config.configure(
         level=logging.INFO,
         log_dir=log_dir,
         screen_format='default',
         log_format='default'
     )
     logger = launch.logging.get_logger('some-proc')
-    logger.addHandler(launch.logging.get_screen_handler())
-    logger.addHandler(launch.logging.get_log_file_handler())
+    logger.addHandler(launch.logging.launch_config.get_screen_handler())
+    logger.addHandler(launch.logging.launch_config.get_log_file_handler())
     logger.setLevel(logging.ERROR)
     stdout_logger, stderr_logger = launch.logging.get_output_loggers('some-proc', config)
 
@@ -111,8 +111,8 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
     assert 0 == len(lines)
     assert 0 == len(capture.err)
 
-    launch.logging.get_log_file_handler().flush()
-    main_log_path = launch.logging.get_log_file_path()
+    launch.logging.launch_config.get_log_file_handler().flush()
+    main_log_path = launch.logging.launch_config.get_log_file_path()
     assert os.path.exists(main_log_path)
     assert 0 != os.stat(main_log_path).st_size
     with open(main_log_path, 'r') as f:
@@ -125,8 +125,8 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
         assert 0 == len(lines)
 
     if 'own_log' in (checks['stdout'] | checks['both']):
-        launch.logging.get_log_file_handler('some-proc-stdout.log').flush()
-        own_log_path = launch.logging.get_log_file_path('some-proc-stdout.log')
+        launch.logging.launch_config.get_log_file_handler('some-proc-stdout.log').flush()
+        own_log_path = launch.logging.launch_config.get_log_file_path('some-proc-stdout.log')
         assert os.path.exists(own_log_path)
         assert 0 != os.stat(own_log_path).st_size
         with open(own_log_path, 'r') as f:
@@ -134,12 +134,12 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
             assert 1 == len(lines)
             assert 'foo' == lines[0]
     else:
-        own_log_path = launch.logging.get_log_file_path('some-proc-stdout.log')
+        own_log_path = launch.logging.launch_config.get_log_file_path('some-proc-stdout.log')
         assert (not os.path.exists(own_log_path) or 0 == os.stat(own_log_path).st_size)
 
     if 'own_log' in (checks['stderr'] | checks['both']):
-        launch.logging.get_log_file_handler('some-proc-stderr.log').flush()
-        own_log_path = launch.logging.get_log_file_path('some-proc-stderr.log')
+        launch.logging.launch_config.get_log_file_handler('some-proc-stderr.log').flush()
+        own_log_path = launch.logging.launch_config.get_log_file_path('some-proc-stderr.log')
         assert os.path.exists(own_log_path)
         assert 0 != os.stat(own_log_path).st_size
         with open(own_log_path, 'r') as f:
@@ -147,12 +147,12 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
             assert 1 == len(lines)
             assert 'bar' == lines[0]
     else:
-        own_log_path = launch.logging.get_log_file_path('some-proc-stderr.log')
+        own_log_path = launch.logging.launch_config.get_log_file_path('some-proc-stderr.log')
         assert (not os.path.exists(own_log_path) or 0 == os.stat(own_log_path).st_size)
 
     if 'own_log' in checks['both']:
-        launch.logging.get_log_file_handler('some-proc.log').flush()
-        own_log_path = launch.logging.get_log_file_path('some-proc.log')
+        launch.logging.launch_config.get_log_file_handler('some-proc.log').flush()
+        own_log_path = launch.logging.launch_config.get_log_file_path('some-proc.log')
         assert os.path.exists(own_log_path)
         assert 0 != os.stat(own_log_path).st_size
         with open(own_log_path, 'r') as f:
@@ -161,20 +161,20 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
             assert 'foo' == lines[0]
             assert 'bar' == lines[1]
     else:
-        own_log_path = launch.logging.get_log_file_path('some-proc.log')
+        own_log_path = launch.logging.launch_config.get_log_file_path('some-proc.log')
         assert (not os.path.exists(own_log_path) or 0 == os.stat(own_log_path).st_size)
 
 
 def test_screen_default_format_with_timestamps(capsys, log_dir):
     """Test screen logging when using the default logs format with timestamps."""
     launch.logging.reset()
-    launch.logging.launch_config(
+    launch.logging.launch_config.configure(
         level=logging.DEBUG,
         log_dir=log_dir,
         screen_format='default_with_timestamp',
     )
     logger = launch.logging.get_logger('some-proc')
-    logger.addHandler(launch.logging.get_screen_handler())
+    logger.addHandler(launch.logging.launch_config.get_screen_handler())
     assert logger.getEffectiveLevel() == logging.DEBUG
 
     logger.debug('foo')
@@ -189,13 +189,13 @@ def test_screen_default_format_with_timestamps(capsys, log_dir):
 def test_screen_default_format(capsys):
     """Test screen logging when using the default logs format."""
     launch.logging.reset()
-    launch.logging.launch_config(
+    launch.logging.launch_config.configure(
         level=logging.INFO,
         screen_format='default'
     )
 
     logger = launch.logging.get_logger('some-proc')
-    logger.addHandler(launch.logging.get_screen_handler())
+    logger.addHandler(launch.logging.launch_config.get_screen_handler())
     assert logger.getEffectiveLevel() == logging.INFO
 
     logger.info('bar')
@@ -209,22 +209,22 @@ def test_screen_default_format(capsys):
 def test_log_default_format(log_dir):
     """Test logging to the main log file when using the default logs format."""
     launch.logging.reset()
-    launch.logging.launch_config(
+    launch.logging.launch_config.configure(
         level=logging.WARN,
         log_dir=log_dir,
         log_format='default'
     )
     logger = launch.logging.get_logger('some-proc')
-    logger.addHandler(launch.logging.get_log_file_handler())
+    logger.addHandler(launch.logging.launch_config.get_log_file_handler())
     assert logger.getEffectiveLevel() == logging.WARN
 
     logger.error('baz')
 
-    launch.logging.get_log_file_handler().flush()
-    assert os.path.exists(launch.logging.get_log_file_path())
-    assert 0 != os.stat(launch.logging.get_log_file_path()).st_size
+    launch.logging.launch_config.get_log_file_handler().flush()
+    assert os.path.exists(launch.logging.launch_config.get_log_file_path())
+    assert 0 != os.stat(launch.logging.launch_config.get_log_file_path()).st_size
 
-    with open(launch.logging.get_log_file_path(), 'r') as f:
+    with open(launch.logging.launch_config.get_log_file_path(), 'r') as f:
         lines = f.readlines()
         assert 1 == len(lines)
         assert re.match(r'[0-9]+\.[0-9]+ \[ERROR\] \[some-proc\]: baz', lines[0]) is not None
@@ -245,7 +245,7 @@ def test_log_handler_factory(log_dir):
     outputs = collections.defaultdict(list)
 
     launch.logging.reset()
-    launch.logging.launch_config(
+    launch.logging.launch_config.configure(
         level=logging.WARN,
         log_dir=log_dir,
         log_format='default',
@@ -257,12 +257,12 @@ def test_log_handler_factory(log_dir):
     )
 
     logger = launch.logging.get_logger('some-proc')
-    logger.addHandler(launch.logging.get_log_file_handler())
+    logger.addHandler(launch.logging.launch_config.get_log_file_handler())
 
     logger.debug('foo')
     logger.error('baz')
 
-    path = launch.logging.get_log_file_path()
+    path = launch.logging.launch_config.get_log_file_path()
     assert path in outputs
     assert len(outputs[path]) == 1
     assert outputs[path][0].endswith('baz')

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -85,11 +85,11 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
     checks = {'stdout': set(), 'stderr': set(), 'both': set(), **checks}
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        level=logging.INFO,
         log_dir=log_dir,
         screen_format='default',
         log_format='default'
     )
+    launch.logging.launch_config.level = logging.INFO
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
@@ -169,10 +169,10 @@ def test_screen_default_format_with_timestamps(capsys, log_dir):
     """Test screen logging when using the default logs format with timestamps."""
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        level=logging.DEBUG,
         log_dir=log_dir,
         screen_format='default_with_timestamp',
     )
+    launch.logging.launch_config.level = logging.DEBUG
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     assert logger.getEffectiveLevel() == logging.DEBUG
@@ -190,9 +190,9 @@ def test_screen_default_format(capsys):
     """Test screen logging when using the default logs format."""
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        level=logging.INFO,
         screen_format='default'
     )
+    launch.logging.launch_config.level = logging.INFO
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
@@ -210,10 +210,10 @@ def test_log_default_format(log_dir):
     """Test logging to the main log file when using the default logs format."""
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        level=logging.WARN,
         log_dir=log_dir,
         log_format='default'
     )
+    launch.logging.launch_config.level = logging.WARN
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
     assert logger.getEffectiveLevel() == logging.WARN
@@ -246,7 +246,6 @@ def test_log_handler_factory(log_dir):
 
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        level=logging.WARN,
         log_dir=log_dir,
         log_format='default',
         log_handler_factory=(
@@ -255,6 +254,7 @@ def test_log_handler_factory(log_dir):
             )
         )
     )
+    launch.logging.launch_config.level = logging.WARN
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -247,14 +247,14 @@ def test_log_handler_factory(log_dir):
     launch.logging.reset()
     launch.logging.launch_config.configure(
         log_format='default',
-        log_handler_factory=(
-            lambda path, encoding=None: TestStreamHandler(
-                output=outputs[path]
-            )
-        )
     )
     launch.logging.launch_config.level = logging.WARN
     launch.logging.launch_config.log_dir = log_dir
+    launch.logging.launch_config.log_handler_factory = (
+        lambda path, encoding=None: TestStreamHandler(
+            output=outputs[path]
+        )
+    )
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -40,7 +40,7 @@ def test_bad_logging_launch_config():
         launch.logging.launch_config.set_screen_format('default', '%')
 
     with pytest.raises(ValueError):
-        launch.logging.launch_config.configure(log_format='default', log_style='%')
+        launch.logging.launch_config.set_log_format(log_format='default', log_style='%')
 
 
 def test_output_loggers_bad_configuration(log_dir):
@@ -84,9 +84,7 @@ def test_output_loggers_bad_configuration(log_dir):
 def test_output_loggers_configuration(capsys, log_dir, config, checks):
     checks = {'stdout': set(), 'stderr': set(), 'both': set(), **checks}
     launch.logging.reset()
-    launch.logging.launch_config.configure(
-        log_format='default'
-    )
+    launch.logging.launch_config.set_log_format('default', None)
     launch.logging.launch_config.level = logging.INFO
     launch.logging.launch_config.log_dir = log_dir
     launch.logging.launch_config.set_screen_format('default', None)
@@ -205,11 +203,9 @@ def test_screen_default_format(capsys):
 def test_log_default_format(log_dir):
     """Test logging to the main log file when using the default logs format."""
     launch.logging.reset()
-    launch.logging.launch_config.configure(
-        log_format='default'
-    )
     launch.logging.launch_config.level = logging.WARN
     launch.logging.launch_config.log_dir = log_dir
+    launch.logging.launch_config.set_log_format('default', None)
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
     assert logger.getEffectiveLevel() == logging.WARN
@@ -241,9 +237,6 @@ def test_log_handler_factory(log_dir):
     outputs = collections.defaultdict(list)
 
     launch.logging.reset()
-    launch.logging.launch_config.configure(
-        log_format='default',
-    )
     launch.logging.launch_config.level = logging.WARN
     launch.logging.launch_config.log_dir = log_dir
     launch.logging.launch_config.log_handler_factory = (
@@ -251,6 +244,7 @@ def test_log_handler_factory(log_dir):
             output=outputs[path]
         )
     )
+    launch.logging.launch_config.set_log_format('default', None)
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -37,7 +37,7 @@ def test_bad_logging_launch_config():
         launch.logging.launch_config.log_dir = 'not/a/real/dir'
 
     with pytest.raises(ValueError):
-        launch.logging.launch_config.configure(screen_format='default', screen_style='%')
+        launch.logging.launch_config.set_screen_format('default', '%')
 
     with pytest.raises(ValueError):
         launch.logging.launch_config.configure(log_format='default', log_style='%')
@@ -85,11 +85,11 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
     checks = {'stdout': set(), 'stderr': set(), 'both': set(), **checks}
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        screen_format='default',
         log_format='default'
     )
     launch.logging.launch_config.level = logging.INFO
     launch.logging.launch_config.log_dir = log_dir
+    launch.logging.launch_config.set_screen_format('default', None)
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
@@ -168,11 +168,9 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
 def test_screen_default_format_with_timestamps(capsys, log_dir):
     """Test screen logging when using the default logs format with timestamps."""
     launch.logging.reset()
-    launch.logging.launch_config.configure(
-        screen_format='default_with_timestamp',
-    )
     launch.logging.launch_config.level = logging.DEBUG
     launch.logging.launch_config.log_dir = log_dir
+    launch.logging.launch_config.set_screen_format('default_with_timestamp', None)
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     assert logger.getEffectiveLevel() == logging.DEBUG
@@ -189,10 +187,8 @@ def test_screen_default_format_with_timestamps(capsys, log_dir):
 def test_screen_default_format(capsys):
     """Test screen logging when using the default logs format."""
     launch.logging.reset()
-    launch.logging.launch_config.configure(
-        screen_format='default'
-    )
     launch.logging.launch_config.level = logging.INFO
+    launch.logging.launch_config.set_screen_format('default', None)
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -34,7 +34,7 @@ def test_bad_logging_launch_config():
     launch.logging.reset()
 
     with pytest.raises(ValueError):
-        launch.logging.launch_config.configure(log_dir='not/a/real/dir')
+        launch.logging.launch_config.log_dir = 'not/a/real/dir'
 
     with pytest.raises(ValueError):
         launch.logging.launch_config.configure(screen_format='default', screen_style='%')
@@ -47,7 +47,7 @@ def test_output_loggers_bad_configuration(log_dir):
     """Tests that output loggers setup throws at bad configuration."""
     launch.logging.launch_config.reset()
 
-    launch.logging.launch_config.configure(log_dir=log_dir)
+    launch.logging.launch_config.log_dir = log_dir
 
     with pytest.raises(ValueError):
         launch.logging.get_output_loggers('some-proc', 'not_an_alias')
@@ -85,11 +85,11 @@ def test_output_loggers_configuration(capsys, log_dir, config, checks):
     checks = {'stdout': set(), 'stderr': set(), 'both': set(), **checks}
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        log_dir=log_dir,
         screen_format='default',
         log_format='default'
     )
     launch.logging.launch_config.level = logging.INFO
+    launch.logging.launch_config.log_dir = log_dir
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
@@ -169,10 +169,10 @@ def test_screen_default_format_with_timestamps(capsys, log_dir):
     """Test screen logging when using the default logs format with timestamps."""
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        log_dir=log_dir,
         screen_format='default_with_timestamp',
     )
     launch.logging.launch_config.level = logging.DEBUG
+    launch.logging.launch_config.log_dir = log_dir
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_screen_handler())
     assert logger.getEffectiveLevel() == logging.DEBUG
@@ -210,10 +210,10 @@ def test_log_default_format(log_dir):
     """Test logging to the main log file when using the default logs format."""
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        log_dir=log_dir,
         log_format='default'
     )
     launch.logging.launch_config.level = logging.WARN
+    launch.logging.launch_config.log_dir = log_dir
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())
     assert logger.getEffectiveLevel() == logging.WARN
@@ -246,7 +246,6 @@ def test_log_handler_factory(log_dir):
 
     launch.logging.reset()
     launch.logging.launch_config.configure(
-        log_dir=log_dir,
         log_format='default',
         log_handler_factory=(
             lambda path, encoding=None: TestStreamHandler(
@@ -255,6 +254,7 @@ def test_log_handler_factory(log_dir):
         )
     )
     launch.logging.launch_config.level = logging.WARN
+    launch.logging.launch_config.log_dir = log_dir
 
     logger = launch.logging.get_logger('some-proc')
     logger.addHandler(launch.logging.launch_config.get_log_file_handler())


### PR DESCRIPTION
To do this, we revamp the launch_config() function into a class
with member variables and methods.  We then make the 'log_dir'
a property, and if it is None when it is accessed, we create
the directory then.  This ensures that we will not create the
directory until someone actually wants to use it.

The design of this class makes it so that we can no longer call `configure` to do partial configuration.  However, this isn't something we currently use, and if we want to do partial configuration in the future we can add more methods to the `LaunchConfig` class to do so.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7842)](http://ci.ros2.org/job/ci_linux/7842/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3910)](http://ci.ros2.org/job/ci_linux-aarch64/3910/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6399)](http://ci.ros2.org/job/ci_osx/6399/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7680)](http://ci.ros2.org/job/ci_windows/7680/)

Fixes #293 