### PR TITLE
Convert list comprehension to generator

### DIFF
--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -104,7 +104,7 @@ class LaunchDescription(LaunchDescriptionEntity):
             for entity in entities:
                 if isinstance(entity, DeclareLaunchArgument):
                     # Avoid duplicate entries with the same name.
-                    if entity.name in [e.name for e in declared_launch_arguments]:
+                    if entity.name in (e.name for e in declared_launch_arguments):
                         continue
                     # Stuff this contextual information into the class for
                     # potential use in command-line descriptions or errors.


### PR DESCRIPTION
Addresses flake8 C412 errors introduced by flake8-comprehension 2.2.0

https://github.com/adamchainz/flake8-comprehensions/blob/master/README.rst#c412-unnecessary-list-comprehension---in-can-take-a-generator

See ros2/build_cop#228

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7867)](http://ci.ros2.org/job/ci_linux/7867/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3928)](http://ci.ros2.org/job/ci_linux-aarch64/3928/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6420)](http://ci.ros2.org/job/ci_osx/6420/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7727)](http://ci.ros2.org/job/ci_windows/7727/)