### PR TITLE
Fix a simple typo in an error message.

### DIFF
--- a/launch_testing/launch_testing/io_handler.py
+++ b/launch_testing/launch_testing/io_handler.py
@@ -174,7 +174,7 @@ class ActiveIoHandler(IoHandler):
                                        strict_proc_matching=False)
             if len(matches) == 0:
                 raise Exception(
-                    "After fimeout, found no processes matching '{}'  "
+                    "After timeout, found no processes matching '{}'  "
                     "It either doesn't exist, was never launched, "
                     "or didn't generate any output".format(
                         process


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I'm not going to run CI since it is an error message.