### PR TITLE
Add support for conditions in IncludeLaunchDescription actions

### DIFF
--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -14,7 +14,6 @@
 
 """Module for Action class."""
 
-from typing import cast
 from typing import List
 from typing import Optional
 from typing import Text
@@ -87,7 +86,7 @@ class Action(LaunchDescriptionEntity):
         """Override visit from LaunchDescriptionEntity so that it executes."""
         if self.__condition is None or self.__condition.evaluate(context):
             try:
-                return cast(Optional[List[LaunchDescriptionEntity]], self.execute(context))
+                return self.execute(context)
             finally:
                 from .events import ExecutionComplete  # noqa
                 event = ExecutionComplete(action=self)
@@ -101,7 +100,7 @@ class Action(LaunchDescriptionEntity):
                         context.emit_event_sync(event)
         return None
 
-    def execute(self, context: LaunchContext) -> Optional[List['Action']]:
+    def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """
         Execute the action.
 

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -64,6 +64,7 @@ from ..frontend import expose_action
 from ..frontend import Parser
 from ..launch_context import LaunchContext
 from ..launch_description import LaunchDescription
+from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution  # noqa: F401
@@ -629,7 +630,7 @@ class ExecuteProcess(Action):
         await context.emit_event(ProcessExited(returncode=returncode, **process_event_args))
         self.__cleanup()
 
-    def execute(self, context: LaunchContext) -> Optional[List['Action']]:
+    def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """
         Execute the action.
 

--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -27,6 +27,7 @@ from ..frontend import Entity
 from ..frontend import expose_action
 from ..frontend import Parser
 from ..launch_context import LaunchContext
+from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_substitutions_type import SomeSubstitutionsType
 
 
@@ -68,7 +69,7 @@ class GroupAction(Action):
         kwargs['actions'] = [parser.parse_action(e) for e in entity.children]
         return cls, kwargs
 
-    def execute(self, context: LaunchContext) -> Optional[List[Action]]:
+    def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Execute the action."""
         actions = []  # type: List[Action]
         actions += [SetLaunchConfiguration(k, v) for k, v in self.__launch_configurations.items()]

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -122,8 +122,8 @@ class IncludeLaunchDescription(Action):
         ret = self.__launch_description_source.try_get_launch_description_without_context()
         return [ret] if ret is not None else []
 
-    def visit(self, context: LaunchContext) -> List[LaunchDescriptionEntity]:
-        """Override visit to return an Entity rather than an action."""
+    def execute(self, context: LaunchContext) -> List[LaunchDescriptionEntity]:
+        """Execute the action."""
         launch_description = self.__launch_description_source.get_launch_description(context)
         # If the location does not exist, then it's likely set to '<script>' or something.
         context.extend_locals({

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -67,10 +67,11 @@ class IncludeLaunchDescription(Action):
         *,
         launch_arguments: Optional[
             Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]
-        ] = None
+        ] = None,
+        **kwargs
     ) -> None:
         """Constructor."""
-        super().__init__()
+        super().__init__(**kwargs)
         self.__launch_description_source = launch_description_source
         self.__launch_arguments = launch_arguments
 

--- a/launch/launch/actions/opaque_coroutine.py
+++ b/launch/launch/actions/opaque_coroutine.py
@@ -28,6 +28,7 @@ from ..action import Action
 from ..event import Event
 from ..event_handlers import OnShutdown
 from ..launch_context import LaunchContext
+from ..launch_description_entity import LaunchDescriptionEntity
 from ..some_actions_type import SomeActionsType
 from ..utilities import ensure_argument_type
 
@@ -97,7 +98,7 @@ class OpaqueCoroutine(Action):
             self.__future.cancel()
         return None
 
-    def execute(self, context: LaunchContext) -> Optional[List[Action]]:
+    def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Execute the action."""
         args = self.__args
         if not self.__ignore_context:

--- a/launch/launch/actions/opaque_function.py
+++ b/launch/launch/actions/opaque_function.py
@@ -25,6 +25,7 @@ from typing import Text
 
 from ..action import Action
 from ..launch_context import LaunchContext
+from ..launch_description_entity import LaunchDescriptionEntity
 from ..utilities import ensure_argument_type
 
 
@@ -69,6 +70,6 @@ class OpaqueFunction(Action):
         if kwargs is not None:
             self.__kwargs = kwargs
 
-    def execute(self, context: LaunchContext) -> Optional[List[Action]]:
+    def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Execute the action."""
         return self.__function(context, *self.__args, **self.__kwargs)


### PR DESCRIPTION
Fixes https://github.com/ros2/launch/issues/303. I couldn't find a rationale anywhere as to why an `Action` `execute(...)` should return a `List[Action]` as opposed to the more general `List[LaunchDescriptionEntity]`, and we have clear use case at hand here where that is not true i.e. for `IncludeLaunchDescription`. 