### PR TITLE
Use signal.CTRL_C_EVENT on windows instead of signal.SIGINT

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -354,12 +354,8 @@ class ExecuteProcess(Action):
             return None
         if platform.system() == 'Windows' and typed_event.signal_name == 'SIGINT':
             # TODO(wjwwood): remove this when/if SIGINT is fixed on Windows
-            self.__logger.warning(
-                "'SIGINT' sent to process[{}] not supported on Windows, escalating to 'SIGTERM'"
-                .format(self.process_details['name']),
-            )
             typed_event = SignalProcess(
-                signal_number=signal.SIGTERM,
+                signal_number=signal.CTRL_C_EVENT,
                 process_matcher=lambda process: True)
         self.__logger.info("sending signal '{}' to process[{}]".format(
             typed_event.signal_name, self.process_details['name']


### PR DESCRIPTION
We were using `signal.SIGTERM` on windows instead of `signal.SIGINT`.
I think that `signal.CTRL_C_EVENT` is the correct signal to be send in replacement of `signal.SIGINT`, which is not supported in [SubprocessTransport.send_signal](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.send_signal).

Related with https://github.com/ros2/ros2cli/pull/315.
See https://github.com/pypa/setuptools/issues/1818.