### PR TITLE
Fix test_expose_decorators failures

### DIFF
--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -91,7 +91,7 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
                 'Exposed {} parser for {} is not a callable or a class'
                 ' containg a parse method'.format(exposed_type, name)
             )
-        if name in parse_methods_map and found_parse_method is not parse_methods_map[name]:
+        if name in parse_methods_map and found_parse_method != parse_methods_map[name]:
             raise RuntimeError(
                 'Two {} parsing methods exposed with same name.'.format(exposed_type)
             )

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -93,7 +93,10 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
             )
         if name in parse_methods_map and found_parse_method != parse_methods_map[name]:
             raise RuntimeError(
-                'Two {} parsing methods exposed with same name.'.format(exposed_type)
+                'Two {} parsing methods exposed with the same name: [{}].'.format(
+                    exposed_type,
+                    name
+                )
             )
         parse_methods_map[name] = found_parse_method
         return exposed

--- a/launch/test/launch/frontend/test_expose_decorators.py
+++ b/launch/test/launch/frontend/test_expose_decorators.py
@@ -28,14 +28,11 @@ def to_be_exposed(entity, parser):
     return ToBeExposed(), ()
 
 
-register = dict({})
-
-
-def expose_test(name):
-    return __expose_impl(name, register, 'test')
-
-
 def test_expose_decorators():
+    register = {}
+
+    def expose_test(name):
+        return __expose_impl(name, register, 'test')
     expose_test('ToBeExposed')(ToBeExposed)
     assert 'ToBeExposed' in register
     if 'ToBeExposed' in register:

--- a/launch/test/launch/frontend/test_expose_decorators.py
+++ b/launch/test/launch/frontend/test_expose_decorators.py
@@ -43,7 +43,7 @@ def test_expose_decorators():
     expose_test('to_be_exposed')(to_be_exposed)
     assert 'to_be_exposed' in register
     if 'to_be_exposed' in register:
-        assert register['to_be_exposed'] is to_be_exposed
+        assert register['to_be_exposed'] == to_be_exposed
     NotACallable = 5
     with pytest.raises(
         RuntimeError,


### PR DESCRIPTION
I never realized, but `test_expose_decorators` is failing in some nightly jobs (since I merged launch frontend stuff):

- [nightly_win_rep](https://ci.ros2.org/view/nightly/job/nightly_win_rep/1565/#showFailuresLink)
- [nightly_linux_repeated](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/1557/testReport/junit/launch.test.launch.frontend/test_expose_decorators/test_expose_decorators_2_11_/)

I guess this will solve the issue, but I'm not sure.
Also, I don't understand the difference between this nightly jobs and manual jobs or [nightly_linux_debug](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/1283/#showFailuresLink) where this test is passing.