### PR TITLE
Fix launch argument listing/checking issues

### DIFF
--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -14,9 +14,11 @@
 
 """Module for Action class."""
 
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Text
+from typing import Tuple
 
 from .condition import Condition
 from .launch_context import LaunchContext
@@ -81,6 +83,24 @@ class Action(LaunchDescriptionEntity):
     def describe(self) -> Text:
         """Return a description of this Action."""
         return self.__repr__()
+
+    def get_sub_entities(self) -> List[LaunchDescriptionEntity]:
+        """Return subentities."""
+        return []
+
+    def describe_sub_entities(self) -> List[LaunchDescriptionEntity]:
+        """Override describe_sub_entities from LaunchDescriptionEntity."""
+        return self.get_sub_entities() if self.condition is None else []
+
+    def describe_conditional_sub_entities(self) -> List[Tuple[
+        Text,  # text description of the condition
+        Iterable[LaunchDescriptionEntity],  # list of conditional sub-entities
+    ]]:
+        """Override describe_conditional_sub_entities from LaunchDescriptionEntity."""
+        return (
+            'Conditionally included by {}'.format(self.describe()),
+            self.get_sub_entities() if self.condition is not None else []
+        )
 
     def visit(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Override visit from LaunchDescriptionEntity so that it executes."""

--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -97,10 +97,13 @@ class Action(LaunchDescriptionEntity):
         Iterable[LaunchDescriptionEntity],  # list of conditional sub-entities
     ]]:
         """Override describe_conditional_sub_entities from LaunchDescriptionEntity."""
-        return (
-            'Conditionally included by {}'.format(self.describe()),
-            self.get_sub_entities() if self.condition is not None else []
-        )
+        return [
+            (
+                'Conditionally included by {}'.format(self.describe()),
+                entity,
+            )
+            for entity in self.get_sub_entities()
+        ] if self.condition is not None else []
 
     def visit(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Override visit from LaunchDescriptionEntity so that it executes."""

--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -69,6 +69,10 @@ class GroupAction(Action):
         kwargs['actions'] = [parser.parse_action(e) for e in entity.children]
         return cls, kwargs
 
+    def get_sub_entities(self) -> List[LaunchDescriptionEntity]:
+        """Return subentities."""
+        return self.actions
+
     def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Execute the action."""
         actions = []  # type: List[Action]

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -68,12 +68,19 @@ class IncludeLaunchDescription(Action):
         launch_arguments: Optional[
             Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]
         ] = None,
+        automatically_redeclare_arguments: bool = False,
         **kwargs
     ) -> None:
         """Constructor."""
         super().__init__(**kwargs)
         self.__launch_description_source = launch_description_source
         self.__launch_arguments = launch_arguments
+        self._automatically_redeclare_arguments = automatically_redeclare_arguments
+        if automatically_redeclare_arguments is True and launch_arguments is not None:
+            raise ValueError(
+                'Cannot pass `automatically_redeclare_arguments` as `True` and'
+                ' not `None` `launch_arguments`.'
+            )
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
@@ -118,8 +125,8 @@ class IncludeLaunchDescription(Action):
             launch_file_location = self.__launch_description_source.location
         return launch_file_location
 
-    def describe_sub_entities(self) -> List[LaunchDescriptionEntity]:
-        """Override describe_sub_entities from LaunchDescriptionEntity to return sub entities."""
+    def get_sub_entities(self):
+        """Get subentities."""
         ret = self.__launch_description_source.try_get_launch_description_without_context()
         return [ret] if ret is not None else []
 

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -68,19 +68,12 @@ class IncludeLaunchDescription(Action):
         launch_arguments: Optional[
             Iterable[Tuple[SomeSubstitutionsType, SomeSubstitutionsType]]
         ] = None,
-        automatically_redeclare_arguments: bool = False,
         **kwargs
     ) -> None:
         """Constructor."""
         super().__init__(**kwargs)
         self.__launch_description_source = launch_description_source
         self.__launch_arguments = launch_arguments
-        self._automatically_redeclare_arguments = automatically_redeclare_arguments
-        if automatically_redeclare_arguments is True and launch_arguments is not None:
-            raise ValueError(
-                'Cannot pass `automatically_redeclare_arguments` as `True` and'
-                ' not `None` `launch_arguments`.'
-            )
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):

--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -72,11 +72,7 @@ class LaunchDescription(LaunchDescriptionEntity):
         """Override describe_sub_entities from LaunchDescriptionEntity to return sub entities."""
         return self.__entities
 
-    def get_launch_arguments(
-        self,
-        conditional_inclusion=False,
-        get_nested=True
-    ) -> List[DeclareLaunchArgument]:
+    def get_launch_arguments(self, conditional_inclusion=False) -> List[DeclareLaunchArgument]:
         """
         Return a list of :py:class:`launch.actions.DeclareLaunchArgument` actions.
 
@@ -118,9 +114,8 @@ class LaunchDescription(LaunchDescriptionEntity):
                 else:
                     from .actions import IncludeLaunchDescription
                     if isinstance(entity, IncludeLaunchDescription):
-                        if not entity._automatically_redeclare_arguments or not get_nested:
-                            # Do not check launch arguments of included descriptions.
-                            continue
+                        # Do not check launch arguments of included descriptions.
+                        continue
                     process_entities(
                         entity.describe_sub_entities(), _conditional_inclusion=False)
                     for conditional_sub_entity in entity.describe_conditional_sub_entities():

--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -72,7 +72,11 @@ class LaunchDescription(LaunchDescriptionEntity):
         """Override describe_sub_entities from LaunchDescriptionEntity to return sub entities."""
         return self.__entities
 
-    def get_launch_arguments(self, conditional_inclusion=False) -> List[DeclareLaunchArgument]:
+    def get_launch_arguments(
+        self,
+        conditional_inclusion=False,
+        get_nested=True
+    ) -> List[DeclareLaunchArgument]:
         """
         Return a list of :py:class:`launch.actions.DeclareLaunchArgument` actions.
 
@@ -113,12 +117,10 @@ class LaunchDescription(LaunchDescriptionEntity):
                     declared_launch_arguments.append(entity)
                 else:
                     from .actions import IncludeLaunchDescription
-                    if (
-                        isinstance(entity, IncludeLaunchDescription)
-                        and not entity._automatically_redeclare_arguments
-                    ):
-                        # Do not check launch arguments of included descriptions.
-                        continue
+                    if isinstance(entity, IncludeLaunchDescription):
+                        if not entity._automatically_redeclare_arguments or not get_nested:
+                            # Do not check launch arguments of included descriptions.
+                            continue
                     process_entities(
                         entity.describe_sub_entities(), _conditional_inclusion=False)
                     for conditional_sub_entity in entity.describe_conditional_sub_entities():

--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -113,7 +113,10 @@ class LaunchDescription(LaunchDescriptionEntity):
                     declared_launch_arguments.append(entity)
                 else:
                     from .actions import IncludeLaunchDescription
-                    if isinstance(entity, IncludeLaunchDescription):
+                    if (
+                        isinstance(entity, IncludeLaunchDescription)
+                        and not entity._automatically_redeclare_arguments
+                    ):
                         # Do not check launch arguments of included descriptions.
                         continue
                     process_entities(


### PR DESCRIPTION
- Fixes `describe_sub_entities` `describe_conditional_sub_entities`.
- Declared launch arguments in `GroupAction` actions were ignored. Fixed that.

Both items affect the logic of checking/getting launch arguments:
https://github.com/ros2/launch/blob/89de94182947ed8fa61fbe7554866e871d8a5121/launch/launch/launch_description.py#L101-L128
https://github.com/ros2/launch/blob/89de94182947ed8fa61fbe7554866e871d8a5121/launch/launch/actions/include_launch_description.py#L139-L152