### PR TITLE
Improve error message when a failing to include launch file

### DIFF
--- a/launch/launch/invalid_launch_file_error.py
+++ b/launch/launch/invalid_launch_file_error.py
@@ -22,20 +22,15 @@ class InvalidLaunchFileError(Exception):
         """Constructor."""
         self._extension = extension
         self._likely_errors = likely_errors
+        if self._extension == '' or not self._likely_errors:
+            self._error_message = 'The launch file may have a syntax error, or its format is unknown'
+        else:
+            self._error_message = 'Caught exception when trying to load file of format [{}]: {}'.format(
+                self._extension,
+                self._likely_errors[0]
+            )
+            self.__cause__ = self._likely_errors[0]
 
     def __str__(self):
         """Pretty print."""
-        if self._extension == '' or not self._likely_errors:
-            return 'The launch file may have a syntax error, or its format is unknown'
-        else:
-            # If `self.likely_errors[0]` is `RuntimeError('asd')`, the following will be printed:
-            #   ```
-            #   InvalidLaunchFileError: Failed to load file of format [<extension>]:
-            #       RuntimeError: asd
-            #   ```
-            return 'Failed to load file of format [{}]:\n\t{}: {}'.format(
-                self._extension,
-                # Convert `<class 'ERROR_NAME'>` to `ERROR_NAME`
-                str(self._likely_errors[0].__class__)[8:-2],
-                str(self._likely_errors[0])
-            )
+        return self._error_message

--- a/launch/launch/invalid_launch_file_error.py
+++ b/launch/launch/invalid_launch_file_error.py
@@ -23,9 +23,11 @@ class InvalidLaunchFileError(Exception):
         self._extension = extension
         self._likely_errors = likely_errors
         if self._extension == '' or not self._likely_errors:
-            self._error_message = 'The launch file may have a syntax error, or its format is unknown'
+            self._error_message = 'The launch file may have a syntax error'
+            ', or its format is unknown'
         else:
-            self._error_message = 'Caught exception when trying to load file of format [{}]: {}'.format(
+            self._error_message = 'Caught exception when trying to load file of format [{}]:'
+            ' {}'.format(
                 self._extension,
                 self._likely_errors[0]
             )

--- a/launch/launch/launch_description_sources/any_launch_file_utilities.py
+++ b/launch/launch/launch_description_sources/any_launch_file_utilities.py
@@ -46,7 +46,7 @@ def get_launch_description_from_any_launch_file(
         loaders.insert(0, get_launch_description_from_python_launch_file)
     else:
         loaders.append(get_launch_description_from_python_launch_file)
-    extension = '' if not Parser.is_extension_valid(extension) else extension
+        extension = '' if not Parser.is_extension_valid(extension) else extension
     exceptions = []
     for loader in loaders:
         try:


### PR DESCRIPTION
Fixes https://github.com/ros2/launch/issues/314.

- The error message was better only when a `.xml` or `.yaml` file failed to be included, because an error in the logic of `any_launch_file_utilities.py`.
- I improved the message further, by using `__cause__` attribute. See https://docs.python.org/3/library/exceptions.html, https://stackoverflow.com/questions/24752395/python-raise-from-usage.