### PR TITLE
fix expectation for test on Windows

### DIFF
--- a/launch/test/launch/actions/test_emulate_tty.py
+++ b/launch/test/launch/actions/test_emulate_tty.py
@@ -35,8 +35,8 @@ def tty_expected_unless_windows():
 
 
 @pytest.mark.parametrize('test_input,expected', [
-    # use the default defined by ExecuteProcess
-    (None, not tty_expected_unless_windows()),
+    # use the default defined by ExecuteProcess (default is off or "false" right now)
+    (None, 0),
     # redundantly override the default via LaunchConfiguration
     ('true', tty_expected_unless_windows()),
     # override the default via LaunchConfiguration


### PR DESCRIPTION
Follow up for https://github.com/ros2/launch/pull/277 to fix CI until we can re-enable this feature.

CI (up to `launch`):

before (windows):

- [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7845)](https://ci.ros2.org/job/ci_windows/7845/)

after:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7998)](http://ci.ros2.org/job/ci_linux/7998/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4014)](http://ci.ros2.org/job/ci_linux-aarch64/4014/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6512)](http://ci.ros2.org/job/ci_osx/6512/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7846)](http://ci.ros2.org/job/ci_windows/7846/)