### PR TITLE
Update launch_testing example name in launch_testing_ament_cmake

### DIFF
--- a/launch_testing_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ament_cmake/CMakeLists.txt
@@ -26,7 +26,7 @@ if(BUILD_TESTING)
 
   # Test argument passing.  This test won't pass unless you give it an argument
   add_launch_test(
-    "${LAUNCH_TESTING_INSTALL_PREFIX}/share/launch_testing/examples/args.test.py"
+    "${LAUNCH_TESTING_INSTALL_PREFIX}/share/launch_testing/examples/args_launch_test.py"
     ARGS "dut_arg:=--anything"
   )
 endif()


### PR DESCRIPTION
Precisely what the title says. Follow-up after #312, it addresses recent test failure https://ci.ros2.org/job/ci_linux/7986/testReport/(root)/projectroot/_home_jenkins_agent_workspace_ci_linux_ws_install_launch_testing_share_launch_testing_examples_args_test_py/.  