### PR TITLE
Optionally remove ready fn arg from generate_test_description

### DIFF
--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -23,6 +23,27 @@ launch_test launch_testing/examples/good_proc.test.py
 
 #### The Launch Description
 
+```python
+def generate_test_description():
+
+    return launch.LaunchDescription([
+        launch.actions.ExecuteProcess(
+            cmd=[path_to_process],
+        ),
+
+        # Start tests right away - no need to wait for anything in this example.
+        # In a more complicated launch description, we might want this action happen
+        # once some process starts or once some other event happens
+        launch_testing.actions.ReadyToTest()
+    ])
+```
+The `generate_test_description` function should return a `launch.LaunchDescription` object that launches the system to be tested.
+
+The launch description needs to include a ReadyToTest action to signal to the test framework that it's safe to start the active tests.
+
+In the above example, there is no need to delay the start of the tests so the ReadyToTest action is a peer to the process under test and will signal to the framework that it's safe to start around the same time the ExecuteProcess action is run.
+
+In older style tests, a function called `ready_fn` is declared as an argument to `generate_test_description` and must be plumbed into the launch description with an `OpaqueFunction`.
 
 ```python
 def generate_test_description(ready_fn):
@@ -36,9 +57,6 @@ def generate_test_description(ready_fn):
         launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
     ])
 ```
-
-The `generate_test_description` function should return a `launch.LaunchDescription` object that launches the system to be tested.
-It should also call the `ready_fn` that is passed in to signal when the tests should start.  In the `good_proc.test.py` example, there is no need to delay the start of the tests so the `ready_fn` is called concurrently when the launching of the process under test.
 
 #### Active Tests
 

--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -42,7 +42,7 @@ The `generate_test_description` function should return a `launch.LaunchDescripti
 
 The launch description needs to include a `ReadyToTest` action to signal to the test framework that it's safe to start the active tests.
 
-In the above example, there is no need to delay the start of the tests so the ReadyToTest action is a peer to the process under test and will signal to the framework that it's safe to start around the same time the ExecuteProcess action is run.
+In the above example, there is no need to delay the start of the tests so the `ReadyToTest` action is a peer to the process under test and will signal to the framework that it's safe to start around the same time the `ExecuteProcess` action is run.
 
 In older style tests, a function called `ready_fn` is declared as an argument to `generate_test_description` and must be plumbed into the launch description with an `OpaqueFunction`.
 

--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -40,7 +40,7 @@ def generate_test_description():
 
 The `generate_test_description` function should return a `launch.LaunchDescription` object that launches the system to be tested.
 
-The launch description needs to include a ReadyToTest action to signal to the test framework that it's safe to start the active tests.
+The launch description needs to include a `ReadyToTest` action to signal to the test framework that it's safe to start the active tests.
 
 In the above example, there is no need to delay the start of the tests so the ReadyToTest action is a peer to the process under test and will signal to the framework that it's safe to start around the same time the ExecuteProcess action is run.
 

--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -37,6 +37,7 @@ def generate_test_description():
         launch_testing.actions.ReadyToTest()
     ])
 ```
+
 The `generate_test_description` function should return a `launch.LaunchDescription` object that launches the system to be tested.
 
 The launch description needs to include a ReadyToTest action to signal to the test framework that it's safe to start the active tests.

--- a/launch_testing/launch_testing/actions/__init__.py
+++ b/launch_testing/launch_testing/actions/__init__.py
@@ -16,8 +16,10 @@
 
 from .gtest import GTest
 from .pytest import PyTest
+from .ready import ReadyToTest
 
 __all__ = [
     'GTest',
     'PyTest',
+    'ReadyToTest',
 ]

--- a/launch_testing/launch_testing/actions/ready.py
+++ b/launch_testing/launch_testing/actions/ready.py
@@ -1,0 +1,42 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import List
+from typing import Optional
+
+from launch.action import Action
+from launch.launch_context import LaunchContext
+from launch.launch_description_entity import LaunchDescriptionEntity
+
+_logger_ = logging.getLogger(__name__)
+
+
+class ReadyToTest(Action):
+    """Action that signals to launch_test that it's safe to start the tests."""
+
+    def __init__(self):
+        super().__init__()
+        self._cb_list = []
+
+    def _add_callback(self, callback):
+        self._cb_list.append(callback)
+
+    def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
+        """Execute the action."""
+        for cb in self._cb_list:
+            try:
+                cb()
+            except Exception as e:
+                _logger_.error(e)

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -17,17 +17,36 @@ import inspect
 import itertools
 import unittest
 
+from .actions import ReadyToTest
+
 
 def _normalize_ld(launch_description_fn):
     # A launch description fn can return just a launch description, or a tuple of
     # (launch_description, test_context).  This wrapper function normalizes things
     # so we always get a tuple, sometimes with an empty dictionary for the test_context
-    def wrapper(*args, **kwargs):
-        result = launch_description_fn(*args, **kwargs)
+    def normalize(result):
         if isinstance(result, tuple):
             return result
         else:
             return result, {}
+
+    def wrapper(**kwargs):
+
+        fn_args = inspect.getfullargspec(launch_description_fn)
+
+        if 'ready_fn' in fn_args.args + fn_args.kwonlyargs:
+            # This is an old-style launch_description function which epects ready_fn to be passed
+            # in to the function
+            return normalize(launch_description_fn(**kwargs))
+        else:
+            # This is a new-style launch_description which should contain a ReadyToTest action
+            ready_fn = kwargs.pop('ready_fn')
+            result = normalize(launch_description_fn(**kwargs))
+            # Fish the ReadyToTest action out of the launch description and plumb our
+            # ready_fn to it
+            ready_action = next(e for e in result[0].entities if isinstance(e, ReadyToTest))
+            ready_action._add_callback(ready_fn)
+            return result
 
     return wrapper
 

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -80,7 +80,7 @@ class TestRun:
                  pre_shutdown_tests,
                  post_shutdown_tests):
         self.name = name
-        self.test_description_function = test_description_function
+        self._test_description_function = test_description_function
         self.normalized_test_description = _normalize_ld(test_description_function)
 
         self.param_args = param_args
@@ -127,7 +127,7 @@ class TestRun:
         This should only be used for the purposes of introspecting the launch description.  The
         returned launch description is not meant to be launched
         """
-        return self.test_description_function(lambda: None)
+        return self.normalized_test_description(ready_fn=lambda: None)[0]
 
     def all_cases(self):
         yield from _iterate_tests_in_test_suite(self.pre_shutdown_tests)

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -266,7 +266,7 @@ class LaunchTestRunner(object):
             # Drill down into any parametrized test descriptions and make sure the argument names
             # are correct.  A simpler check can use getcallargs, but then you won't get a very
             # helpful message.
-            base_fn = inspect.unwrap(run.test_description_function)
+            base_fn = inspect.unwrap(run._test_description_function)
             base_args = inspect.getfullargspec(base_fn)
             base_args = base_args.args + base_args.kwonlyargs
 
@@ -291,7 +291,7 @@ class LaunchTestRunner(object):
 
             # This is a double-check
             try:
-                inspect.getcallargs(run.test_description_function, ready_fn=lambda: None)
+                inspect.getcallargs(run._test_description_function, ready_fn=lambda: None)
             except TypeError:
                 # We also support generate_test_description functions without a ready_fn
-                inspect.getcallargs(run.test_description_function)
+                inspect.getcallargs(run._test_description_function)

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -290,4 +290,8 @@ class LaunchTestRunner(object):
                     )
 
             # This is a double-check
-            inspect.getcallargs(run.test_description_function, ready_fn=lambda: None)
+            try:
+                inspect.getcallargs(run.test_description_function, ready_fn=lambda: None)
+            except TypeError:
+                # We also support generate_test_description functions without a ready_fn
+                inspect.getcallargs(run.test_description_function)

--- a/launch_testing/test/launch_testing/examples/ready_action_test.py
+++ b/launch_testing/test/launch_testing/examples/ready_action_test.py
@@ -1,0 +1,97 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+import ament_index_python
+
+import launch
+import launch.actions
+
+import launch_testing
+import launch_testing.actions
+from launch_testing.asserts import assertSequentialStdout
+
+import pytest
+
+
+TEST_PROC_PATH = os.path.join(
+    ament_index_python.get_package_prefix('launch_testing'),
+    'lib/launch_testing',
+    'good_proc'
+)
+
+# This is necessary to get unbuffered output from the process under test
+proc_env = os.environ.copy()
+proc_env['PYTHONUNBUFFERED'] = '1'
+
+dut_process = launch.actions.ExecuteProcess(
+    cmd=[sys.executable, TEST_PROC_PATH],
+    env=proc_env,
+)
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+
+    return launch.LaunchDescription([
+        dut_process,
+
+        # Start tests right away - no need to wait for anything
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+# These tests will run concurrently with the dut process.  After all these tests are done,
+# the launch system will shut down the processes that it started up
+class TestGoodProcess(unittest.TestCase):
+
+    def test_count_to_four(self):
+        # This will match stdout from any process.  In this example there is only one process
+        # running
+        self.proc_output.assertWaitFor('Loop 1', timeout=10)
+        self.proc_output.assertWaitFor('Loop 2', timeout=10)
+        self.proc_output.assertWaitFor('Loop 3', timeout=10)
+        self.proc_output.assertWaitFor('Loop 4', timeout=10)
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+
+    def test_exit_code(self):
+        # Check that all processes in the launch (in this case, there's just one) exit
+        # with code 0
+        launch_testing.asserts.assertExitCodes(self.proc_info)
+
+    def test_full_output(self):
+        # Using the SequentialStdout context manager asserts that the following stdout
+        # happened in the same order that it's checked
+        with assertSequentialStdout(self.proc_output, dut_process) as cm:
+            cm.assertInStdout('Starting Up')
+            for n in range(4):
+                cm.assertInStdout('Loop {}'.format(n))
+            if os.name != 'nt':
+                # On Windows, process termination is always forced
+                # and thus the last print in good_proc never makes it.
+                cm.assertInStdout('Shutting Down')
+
+    def test_out_of_order(self):
+        # This demonstrates that we notice out-of-order IO
+        with self.assertRaisesRegex(AssertionError, "'Loop 2' not found"):
+            with assertSequentialStdout(self.proc_output, dut_process) as cm:
+                cm.assertInStdout('Loop 1')
+                cm.assertInStdout('Loop 3')
+                cm.assertInStdout('Loop 2')  # This should raise

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -15,7 +15,10 @@
 import imp
 import unittest
 
+import launch
+import launch.actions
 import launch_testing
+from launch_testing.actions import ReadyToTest
 from launch_testing.loader import LoadTestsFromPythonModule
 from launch_testing.test_runner import LaunchTestRunner
 
@@ -30,13 +33,20 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
 
     def test_catches_bad_signature(self):
 
+        # A `generate_test_description` function without a ready_fn argument is allowed because
+        # it might be a new style function that uses a ReadyToTest action to signal when it's time
+        # for tests to start.
+        # If there's no ReadyToTest action, we won't catch that until later because dut.validate()
+        # doesn't actually invoke the function.
+        # We will still expect to reject functions with wrong name arguments
+
         dut = LaunchTestRunner(
             make_test_run_for_dut(
-                lambda: None
+                lambda misspelled_ready_fn: None
             )
         )
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(Exception, "unexpected extra argument 'misspelled_ready_fn'"):
             dut.validate()
 
         dut = LaunchTestRunner(
@@ -69,3 +79,57 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
         with self.assertRaisesRegex(Exception, 'Could not find an argument') as cm:
             dut.validate()
         self.assertIn('bad_argument', str(cm.exception))
+
+
+class TestNewStyleTestDescriptions(unittest.TestCase):
+    # Tests for `generate_test_description` functions that include a ReadyToTest action in
+    # the test description
+
+    def test_good_launch_description(self):
+
+        def generate_test_description():
+            return launch.LaunchDescription([
+                ReadyToTest()
+            ])
+
+        runs = make_test_run_for_dut(generate_test_description)
+        dut = LaunchTestRunner(
+            runs
+        )
+
+        dut.validate()  # Make sure this passes initial validation (probably redundant with above)
+        runs[0].normalized_test_description(ready_fn=lambda: None)
+
+    def test_launch_description_with_missing_ready_action(self):
+
+        def generate_test_description():
+            return launch.LaunchDescription([
+            ])
+
+        runs = make_test_run_for_dut(generate_test_description)
+        dut = LaunchTestRunner(
+            runs
+        )
+
+        dut.validate()  # Make sure this passes initial validation (probably redundant with above)
+
+        with self.assertRaisesRegex(Exception, 'containing a ReadyToTest action'):
+            runs[0].normalized_test_description(ready_fn=lambda: None)
+
+    def test_launch_description_with_conditional_ready_action(self):
+
+        def generate_test_description():
+            return launch.LaunchDescription([
+                launch.actions.TimerAction(
+                    period=10.0,
+                    actions=[ReadyToTest()]
+                )
+            ])
+
+        runs = make_test_run_for_dut(generate_test_description)
+        dut = LaunchTestRunner(
+            runs
+        )
+
+        dut.validate()  # Make sure this passes initial validation (probably redundant with above)
+        runs[0].normalized_test_description(ready_fn=lambda: None)

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -134,6 +134,34 @@ class TestNewStyleTestDescriptions(unittest.TestCase):
         dut.validate()  # Make sure this passes initial validation (probably redundant with above)
         runs[0].normalized_test_description(ready_fn=lambda: None)
 
+    def test_launch_description_with_multiple_conditionals_and_deeper_nesting(self):
+
+        def generate_test_description():
+            return launch.LaunchDescription([
+                launch.actions.LogInfo(msg='Dummy Action'),
+                launch.actions.TimerAction(
+                    period=10.0,
+                    actions=[
+                        launch.actions.OpaqueFunction(function=lambda context: None),
+                        launch.actions.TimerAction(
+                            period=5.0,
+                            actions=[
+                                launch.actions.LogInfo(msg='Deeply Nested Action'),
+                                ReadyToTest()
+                            ]
+                        )
+                    ]
+                )
+            ])
+
+        runs = make_test_run_for_dut(generate_test_description)
+        dut = LaunchTestRunner(
+            runs
+        )
+
+        dut.validate()  # Make sure this passes initial validation (probably redundant with above)
+        runs[0].normalized_test_description(ready_fn=lambda: None)
+
     def test_parametrized_launch_description(self):
 
         @launch_testing.parametrize('my_param', [1, 2, 3])

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -133,3 +133,19 @@ class TestNewStyleTestDescriptions(unittest.TestCase):
 
         dut.validate()  # Make sure this passes initial validation (probably redundant with above)
         runs[0].normalized_test_description(ready_fn=lambda: None)
+
+    def test_parametrized_launch_description(self):
+
+        @launch_testing.parametrize('my_param', [1, 2, 3])
+        def generate_test_description(my_param):
+            return launch.LaunchDescription([
+                ReadyToTest()
+            ])
+
+        runs = make_test_run_for_dut(generate_test_description)
+        dut = LaunchTestRunner(
+            runs
+        )
+
+        dut.validate()  # Make sure this passes initial validation (probably redundant with above)
+        runs[0].normalized_test_description(ready_fn=lambda: None)


### PR DESCRIPTION
Resolves #305

This change lets test launch descriptions include a launch_testing.actions.ReadyToTest action to signal when it's safe for tests to start.

This is intended to be used instead of passing a ready_fn into the generate_test_description function which then has to be plumbed into the launch description with an launch.actions.OpaqueFunction

Longer term, I would like to deprecate the use of the ready_fn in favor of the ReadyToTest action.  The former is annoying to plumb especially in tests where the test launch description is generated by many nested functions.  I feel the latter is easier to understand and will also be easier to improve the behavior of in the future - for example we could support multiple ReadyToTest actions instead of using the somewhat silly [ready aggregator](https://github.com/ros2/launch/blob/master/launch_testing/launch_testing/ready_aggregator.py)