### PR TITLE
Unindent setup.cfg options

### DIFF
--- a/launch_testing/setup.cfg
+++ b/launch_testing/setup.cfg
@@ -1,4 +1,4 @@
 [coverage:run]
-    # This will let coverage find files with 0% coverage (not hit by tests at all)
-    source = .
-    omit = setup.py
+# This will let coverage find files with 0% coverage (not hit by tests at all)
+source = .
+omit = setup.py


### PR DESCRIPTION
Precisely what the title says. This was causing Python 2.7-based `bloom-release` to fail on `launch_testing`.