### PR TITLE
[Dashing] Address additional syntax issues with Python 3.5.

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -56,7 +56,7 @@ def launch_config(
     screen_style=None,
     log_format=None,
     log_style=None,
-    log_handler_factory=None,
+    log_handler_factory=None
 ):
     """
     Set up launch logging.


### PR DESCRIPTION
Some Python 3.5 syntax errors were missed on the first pass.
Using a variant of @sloretz's Dockerfile this PR is now clean against `flake8 --select=E999` on Debian Stretch.