### PR TITLE
Fix default Action describe_conditional_sub_entities() implementation.

### DIFF
--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -97,13 +97,7 @@ class Action(LaunchDescriptionEntity):
         Iterable[LaunchDescriptionEntity],  # list of conditional sub-entities
     ]]:
         """Override describe_conditional_sub_entities from LaunchDescriptionEntity."""
-        return [
-            (
-                'Conditionally included by {}'.format(self.describe()),
-                entity,
-            )
-            for entity in self.get_sub_entities()
-        ] if self.condition is not None else []
+        return [('Conditionally included by {}'.format(self.describe()), self.get_sub_entities())]
 
     def visit(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Override visit from LaunchDescriptionEntity so that it executes."""

--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -97,7 +97,7 @@ class Action(LaunchDescriptionEntity):
         Iterable[LaunchDescriptionEntity],  # list of conditional sub-entities
     ]]:
         """Override describe_conditional_sub_entities from LaunchDescriptionEntity."""
-        return [('Conditionally included by {}'.format(self.describe()), self.get_sub_entities())]
+        return [('Conditionally included by {}'.format(self.describe()), self.get_sub_entities())] if self.condition is not None else []
 
     def visit(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Override visit from LaunchDescriptionEntity so that it executes."""

--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -97,7 +97,9 @@ class Action(LaunchDescriptionEntity):
         Iterable[LaunchDescriptionEntity],  # list of conditional sub-entities
     ]]:
         """Override describe_conditional_sub_entities from LaunchDescriptionEntity."""
-        return [('Conditionally included by {}'.format(self.describe()), self.get_sub_entities())] if self.condition is not None else []
+        return [
+            ('Conditionally included by {}'.format(self.describe()), self.get_sub_entities())
+        ] if self.condition is not None else []
 
     def visit(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         """Override visit from LaunchDescriptionEntity so that it executes."""


### PR DESCRIPTION
Precisely what the title says. Current implementation does not seem to match the documentation in `LaunchDescriptionEntity` nor the mock used to test `get_launch_arguments`. It also fails on conditional `GroupAction`s.