### PR TITLE
Make parse_substitution handle zero-width text.

### DIFF
--- a/launch/launch/frontend/parse_substitution.py
+++ b/launch/launch/frontend/parse_substitution.py
@@ -99,5 +99,8 @@ transformer = ExtractSubstitution()
 
 
 def parse_substitution(string_value):
+    if not string_value:
+        # Grammar cannot deal with zero-width expressions.
+        return [TextSubstitution(text=string_value)]
     tree = parser.parse(string_value)
     return transformer.transform(tree)

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -23,6 +23,12 @@ from launch.substitutions import TextSubstitution
 from launch.substitutions import ThisLaunchFileDir
 
 
+def test_no_text():
+    subst = parse_substitution('')
+    assert len(subst) == 1
+    assert subst[0].perform(None) == ''
+
+
 def test_text_only():
     subst = parse_substitution("'yes'")
     assert len(subst) == 1


### PR DESCRIPTION
Precisely what the title says. Substitutions' grammer nor `lark` itself seem to be able to cope with zero-width text. 