### PR TITLE
Support launch test reruns when using pytest

### DIFF
--- a/launch_testing/launch_testing/pytest/hooks.py
+++ b/launch_testing/launch_testing/pytest/hooks.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from unittest import TestCase
 
 import pytest
@@ -42,8 +43,11 @@ class LaunchTestItem(pytest.Item):
         launch_args = sum((
             args_set for args_set in self.config.getoption('--launch-args')
         ), [])
+        # Copy test runs' collection as it may be used more than
+        # once e.g. if pytest rerunfailures plugin is in use.
+        test_runs = copy.deepcopy(self.test_runs)
         runner = self.runner_cls(
-            test_runs=self.test_runs,
+            test_runs=test_runs,
             launch_file_arguments=launch_args,
             debug=self.config.getoption('verbose')
         )


### PR DESCRIPTION
Precisely what the title says. Without this patch, test failures coupled with a `--reruns` option result in:

```bash
AttributeError: 'NoneType' object has no attribute 'launch_service'
```

as it happens [here](https://ci.ros2.org/job/ci_windows/8434/testReport/junit/ros2topic.test/test_echo_pub/test_echo_pub/).