### PR TITLE
add missing test dependency

### DIFF
--- a/launch_testing_ament_cmake/package.xml
+++ b/launch_testing_ament_cmake/package.xml
@@ -14,6 +14,7 @@
   <buildtool_export_depend>launch_testing</buildtool_export_depend>
 
   <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>launch_testing</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Failing the recently released version: http://build.ros2.org/view/Ebin_uB64/job/Ebin_uB64__launch_testing_ament_cmake__ubuntu_bionic_amd64__binary/21/