### PR TITLE
Make launch_testing.markers.retry_on_failure decorator more robust.

### DIFF
--- a/launch_testing/launch_testing/markers.py
+++ b/launch_testing/launch_testing/markers.py
@@ -41,6 +41,8 @@ def retry_on_failure(*, times):
                         assert self._outcome.success
                     return ret
                 except AssertionError:
+                    self._outcome.errors.clear()
+                    self._outcome.success = True
                     n -= 1
             return func(self, *args, **kwargs)
         return _wrapper

--- a/launch_testing/launch_testing/markers.py
+++ b/launch_testing/launch_testing/markers.py
@@ -31,6 +31,7 @@ def retry_on_failure(*, times):
 
     def _decorator(func):
         assert 'self' == list(inspect.signature(func).parameters)[0]
+
         @functools.wraps(func)
         def _wrapper(self, *args, **kwargs):
             n = times


### PR DESCRIPTION
Precisely what the title says, to help deal with `unittest.TestCase.subTest` usage correctly.