### PR TITLE
Fix ExecuteProcess.get_sub_entities()

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -335,6 +335,11 @@ class ExecuteProcess(Action):
         """Getter for the process details, e.g. name, pid, cmd, etc., or None if not started."""
         return self.__process_event_args
 
+    def get_sub_entities(self):
+        if isinstance(self.__on_exit, list):
+            return self.__on_exit
+        return []
+
     def _shutdown_process(self, context, *, send_sigint):
         if self.__shutdown_received:
             # Do not handle shutdown more than once.

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -20,6 +20,7 @@ import sys
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions.execute_process import ExecuteProcess
+from launch.actions.opaque_function import OpaqueFunction
 
 import pytest
 
@@ -50,3 +51,36 @@ def test_execute_process_with_env(test_input, expected):
     assert ('TEST_NEW_ENV' in env) is expected[1]
     if expected[1]:
         assert env['TEST_NEW_ENV'] == '2'
+
+
+def test_execute_process_with_on_exit_behavior():
+    """Test a process' on_exit callback and actions are processed."""
+    def on_exit_callback(event, context):
+        on_exit_callback.called = True
+    on_exit_callback.called = False
+
+    executable_with_on_exit_callback = ExecuteProcess(
+        cmd=[sys.executable, '-c', "print('callback')"],
+        output='screen', on_exit=on_exit_callback
+    )
+    assert len(executable_with_on_exit_callback.get_sub_entities()) == 0
+
+    def on_exit_function(context):
+        on_exit_function.called = True
+    on_exit_function.called = False
+    on_exit_action = OpaqueFunction(function=on_exit_function)
+    executable_with_on_exit_action = ExecuteProcess(
+        cmd=[sys.executable, '-c', "print('action')"],
+        output='screen', on_exit=[on_exit_action]
+    )
+    assert executable_with_on_exit_action.get_sub_entities() == [on_exit_action]
+
+    ld = LaunchDescription([
+        executable_with_on_exit_callback,
+        executable_with_on_exit_action
+    ])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+    assert on_exit_callback.called
+    assert on_exit_function.called


### PR DESCRIPTION
Precisely what the title says. This pull requests fixes said method implemnentatoin, taking into account `on_exit` actions, if any.