### PR TITLE
import collections.abc

### DIFF
--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -15,7 +15,7 @@
 """Module for the TimerAction action."""
 
 import asyncio
-import collections
+import collections.abc
 from typing import Any  # noqa: F401
 from typing import cast
 from typing import Dict  # noqa: F401


### PR DESCRIPTION
Since the file only uses `collections.abc.Iterable` it should import `collections.abc`.