### PR TITLE
Fix junit XML when launch dies early

### DIFF
--- a/launch_testing/launch_testing/test_result.py
+++ b/launch_testing/launch_testing/test_result.py
@@ -20,14 +20,20 @@ import unittest
 class FailResult(unittest.TestResult):
     """For test runs that fail when the DUT dies unexpectedly."""
 
+    def __init__(self, test_run, message):
+        super().__init__()
+        for case in test_run.all_cases():
+            self.addFailure(case, (Exception, Exception(message), None))
+            self.testsRun += 1
+
     @property
     def testCases(self):
-        return []
+        return [failure[0] for failure in self.failures]
 
     @property
     def testTimes(self):
         """Get a dict of {test_case: elapsed_time}."""
-        return {}
+        return {failure[0]: 0 for failure in self.failures}
 
     def wasSuccessful(self):
         return False

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -264,7 +264,7 @@ class LaunchTestRunner(object):
                 # The most likely cause was ctrl+c, so we'll abort the test run
                 results[run] = FailResult(
                     test_run=run,
-                    message="Launch stopped before the active tests finished."
+                    message='Launch stopped before the active tests finished.'
                 )
                 break
 

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -262,7 +262,10 @@ class LaunchTestRunner(object):
                 continue
             except _LaunchDiedException:
                 # The most likely cause was ctrl+c, so we'll abort the test run
-                results[run] = FailResult()
+                results[run] = FailResult(
+                    test_run=run,
+                    message="Launch stopped before the active tests finished."
+                )
                 break
 
         return results

--- a/launch_testing/test/launch_testing/test_xml_output.py
+++ b/launch_testing/test/launch_testing/test_xml_output.py
@@ -98,16 +98,43 @@ class TestXmlFunctions(unittest.TestCase):
             return runner.run(cases)
 
     def test_fail_results_serialize(self):
+
+        def generate_test_description(ready_fn):
+            raise Exception('This should never be invoked')  # pragma: no cover
+
+        def test_fail_always(self):
+            assert False  # pragma: no cover
+
+        def test_pass_always(self):
+            pass  # pragma: no cover
+
+        test_runs = self.source_test_loader(
+            generate_test_description,
+            pre_shutdown_tests=[
+                test_fail_always,
+            ],
+            post_shutdown_tests=[
+                test_fail_always,
+                test_pass_always
+            ]
+        )
+
+        self.assertEqual(1, len(test_runs))  # Not a parametrized launch, so only 1 run
+
         xml_tree = unittestResultsToXml(
             name='fail_xml',
             test_results={
-                'active_tests': FailResult()
+                'active_tests': FailResult(test_run=test_runs[0])
             }
         )
 
         # Simple sanity check - see that there's a child element called active_tests
         child_names = [chld.attrib['name'] for chld in xml_tree.getroot()]
         self.assertEqual(set(child_names), {'active_tests'})
+
+        # Make sure failures is non-zero, otherwise colcon test-result won't recognize this
+        # as a failure
+        self.assertGreater(int(xml_tree.getroot().get('failures')), 0)
 
     def test_skip_results_serialize(self):
         # This checks the case where all unit tests are skipped because of a skip

--- a/launch_testing/test/launch_testing/test_xml_output.py
+++ b/launch_testing/test/launch_testing/test_xml_output.py
@@ -124,7 +124,7 @@ class TestXmlFunctions(unittest.TestCase):
         xml_tree = unittestResultsToXml(
             name='fail_xml',
             test_results={
-                'active_tests': FailResult(test_run=test_runs[0])
+                'active_tests': FailResult(test_run=test_runs[0], message='Test Message')
             }
         )
 


### PR DESCRIPTION
  - old junit XML showed 0 cases, 0 failures when a test stopped early
  - Colcon test-result would not spot this as a failure
  - New method uses same logic as 'skip' when there's a skip decorator on the launch description

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>

I'm not sure how this slipped through for so long, but I just started noticing this with tests that shutdown early.  If a test [stops early](https://github.com/ros2/launch/blob/2f32b9fa94a5cd441271a9b23850db18b9c7d28e/launch_testing/launch_testing/test_runner.py#L162-L169) either because of ctrl+c or because all of the processes in the launch description stop before the active tests complete, we generate a [fail result](https://github.com/ros2/launch/blob/2f32b9fa94a5cd441271a9b23850db18b9c7d28e/launch_testing/launch_testing/test_runner.py#L263-L266)

This fail result correctly sets the exit code for launch_testing, but the generated junit XML looks something like this

```
<testsuites errors="0" failures="0" name="rcutils.test_logging_long_messages" tests="0" time="0">
  <testsuite errors="0" failures="0" name="rcutils.test_logging_long_messages.launch_tests" skipped="0" tests="0" time="0" />
</testsuites>   
```

When 'failures' and 'errors' is set to 0, colcon test-result won't pick this up as a failing result.

After this PR, the generated junit XML looks a bit like this:

```
<?xml version='1.0' encoding='utf-8'?>                                                                                                                                                     
<testsuites errors="0" failures="1" name="rcutils.test_logging_long_messages" tests="1" time="0">
    <testsuite errors="0" failures="1" name="rcutils.test_logging_long_messages.launch_tests" skipped="0" tests="1" time="0">
        <testcase classname="rcutils.TestLoggingLongMessages" name="test_logging_output" time="0"> 
             <failure message="Exception: Launch stopped before the active tests finished.&#10;" />
        </testcase>
    </testsuite>
</testsuites>         
```

Now that failures is set to a non-zero value, colcon test-result will correctly detect this failure.

The logic I'm using for the FailResult is almost exactly the same as the skip result down below.  We loop through all of the test cases in the test run and call "AddFailure" to log the failure.