### PR TITLE
Use imperative mood in docstrings.

### DIFF
--- a/launch/.eggs/README.txt
+++ b/launch/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/launch/.eggs/README.txt
+++ b/launch/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/launch/examples/counter.py
+++ b/launch/examples/counter.py
@@ -23,7 +23,7 @@ import time
 
 
 def main(argv=sys.argv[1:]):
-    """Main."""
+    """Run Counter script."""
     parser = argparse.ArgumentParser(
         description=(
             'Simple program outputting a counter. '

--- a/launch/examples/launch_counters.py
+++ b/launch/examples/launch_counters.py
@@ -37,7 +37,7 @@ import launch.substitutions
 
 
 def main(argv=sys.argv[1:]):
-    """Main."""
+    """Run Counter via launch."""
     # Configure rotating logs.
     launch.logging.launch_config.log_handler_factory = \
         lambda path, encoding=None: launch.logging.handlers.RotatingFileHandler(

--- a/launch/launch/action.py
+++ b/launch/launch/action.py
@@ -39,7 +39,7 @@ class Action(LaunchDescriptionEntity):
 
     def __init__(self, *, condition: Optional[Condition] = None) -> None:
         """
-        Constructor.
+        Create an Action.
 
         If the conditions argument is not None, the condition object will be
         evaluated while being visited and the action will only be executed if

--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -82,7 +82,7 @@ class DeclareLaunchArgument(Action):
         description: Text = 'no description given',
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create a DeclareLaunchArgument action."""
         super().__init__(**kwargs)
         self.__name = name
         if default_value is None:

--- a/launch/launch/actions/emit_event.py
+++ b/launch/launch/actions/emit_event.py
@@ -24,7 +24,7 @@ class EmitEvent(Action):
     """Action that emits an event when executed."""
 
     def __init__(self, *, event: Event, **kwargs) -> None:
-        """Constructor."""
+        """Create an EmitEvent action."""
         super().__init__(**kwargs)
         if not is_a_subclass(event, Event):
             raise RuntimeError("EmitEvent() expected an event instance, got '{}'.".format(event))

--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -50,7 +50,7 @@ class GroupAction(Action):
         launch_configurations: Optional[Dict[SomeSubstitutionsType, SomeSubstitutionsType]] = None,
         **left_over_kwargs
     ) -> None:
-        """Constructor."""
+        """Create a GroupAction."""
         super().__init__(**left_over_kwargs)
         self.__actions = actions
         self.__scoped = scoped

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -70,7 +70,7 @@ class IncludeLaunchDescription(Action):
         ] = None,
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create an IncludeLaunchDescription action."""
         super().__init__(**kwargs)
         self.__launch_description_source = launch_description_source
         self.__launch_arguments = () if launch_arguments is None else tuple(launch_arguments)

--- a/launch/launch/actions/log_info.py
+++ b/launch/launch/actions/log_info.py
@@ -41,7 +41,7 @@ class LogInfo(Action):
         ...
 
     def __init__(self, *, msg, **kwargs):  # noqa: F811
-        """Constructor."""
+        """Create a LogInfo action."""
         super().__init__(**kwargs)
 
         self.__msg = normalize_to_list_of_substitutions(msg)

--- a/launch/launch/actions/opaque_coroutine.py
+++ b/launch/launch/actions/opaque_coroutine.py
@@ -69,7 +69,7 @@ class OpaqueCoroutine(Action):
         ignore_context: bool = False,
         **left_over_kwargs
     ) -> None:
-        """Constructor."""
+        """Create an OpaqueCoroutine action."""
         super().__init__(**left_over_kwargs)
         if not asyncio.iscoroutinefunction(coroutine):
             raise TypeError(

--- a/launch/launch/actions/opaque_function.py
+++ b/launch/launch/actions/opaque_function.py
@@ -53,7 +53,7 @@ class OpaqueFunction(Action):
         kwargs: Optional[Dict[Text, Any]] = None,
         **left_over_kwargs
     ) -> None:
-        """Constructor."""
+        """Create an OpaqueFunction action."""
         super().__init__(**left_over_kwargs)
         if not callable(function):
             raise TypeError("OpaqueFunction expected a callable for 'function', got '{}'".format(

--- a/launch/launch/actions/pop_launch_configurations.py
+++ b/launch/launch/actions/pop_launch_configurations.py
@@ -27,7 +27,7 @@ class PopLaunchConfigurations(Action):
     """
 
     def __init__(self, **kwargs) -> None:
-        """Constructor."""
+        """Create a PopLaunchConfigurations action."""
         super().__init__(**kwargs)
 
     def execute(self, context: LaunchContext):

--- a/launch/launch/actions/push_launch_configurations.py
+++ b/launch/launch/actions/push_launch_configurations.py
@@ -27,7 +27,7 @@ class PushLaunchConfigurations(Action):
     """
 
     def __init__(self, **kwargs) -> None:
-        """Constructor."""
+        """Create a PushLaunchConfigurations action."""
         super().__init__(**kwargs)
 
     def execute(self, context: LaunchContext):

--- a/launch/launch/actions/register_event_handler.py
+++ b/launch/launch/actions/register_event_handler.py
@@ -33,7 +33,7 @@ class RegisterEventHandler(Action):
     """
 
     def __init__(self, event_handler: BaseEventHandler, **kwargs) -> None:
-        """Constructor."""
+        """Create a RegisterEventHandler action."""
         super().__init__(**kwargs)
         self.__event_handler = event_handler
 

--- a/launch/launch/actions/set_environment_variable.py
+++ b/launch/launch/actions/set_environment_variable.py
@@ -38,7 +38,7 @@ class SetEnvironmentVariable(Action):
         value: SomeSubstitutionsType,
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create a SetEnvironmentVariable action."""
         super().__init__(**kwargs)
         self.__name = normalize_to_list_of_substitutions(name)
         self.__value = normalize_to_list_of_substitutions(value)

--- a/launch/launch/actions/set_launch_configuration.py
+++ b/launch/launch/actions/set_launch_configuration.py
@@ -43,7 +43,7 @@ class SetLaunchConfiguration(Action):
         value: SomeSubstitutionsType,
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create a SetLaunchConfiguration action."""
         super().__init__(**kwargs)
         self.__name = normalize_to_list_of_substitutions(name)
         self.__value = normalize_to_list_of_substitutions(value)

--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -61,7 +61,7 @@ class TimerAction(Action):
         cancel_on_shutdown: bool = True,
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create a TimerAction."""
         super().__init__(**kwargs)
         period_types = list(SomeSubstitutionsType_types_tuple) + [float]
         ensure_argument_type(period, period_types, 'period', 'TimerAction')

--- a/launch/launch/actions/unregister_event_handler.py
+++ b/launch/launch/actions/unregister_event_handler.py
@@ -23,7 +23,7 @@ class UnregisterEventHandler(Action):
     """Action that unregisters an event handler."""
 
     def __init__(self, event_handler: BaseEventHandler, **kwargs) -> None:
-        """Constructor."""
+        """Create an UnregisterEventHandler action."""
         super().__init__(**kwargs)
         self.__event_handler = event_handler
 

--- a/launch/launch/actions/unset_environment_variable.py
+++ b/launch/launch/actions/unset_environment_variable.py
@@ -38,7 +38,7 @@ class UnsetEnvironmentVariable(Action):
         name: SomeSubstitutionsType,
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create an UnsetEnvironmentVariable action."""
         super().__init__(**kwargs)
         self.__name = normalize_to_list_of_substitutions(name)
 

--- a/launch/launch/actions/unset_launch_configuration.py
+++ b/launch/launch/actions/unset_launch_configuration.py
@@ -39,7 +39,7 @@ class UnsetLaunchConfiguration(Action):
         name: SomeSubstitutionsType,
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create an UnsetLaunchConfiguration action."""
         super().__init__(**kwargs)
         self.__name = normalize_to_list_of_substitutions(name)
 

--- a/launch/launch/event_handler.py
+++ b/launch/launch/event_handler.py
@@ -40,7 +40,7 @@ class BaseEventHandler:
 
     def __init__(self, *, matcher: Callable[[Event], bool], handle_once: bool = False):
         """
-        Constructor.
+        Create a BaseEventHandler.
 
         :param: matcher is a callable that takes an event and returns True if
             the event should be handled by this event handler, False otherwise.
@@ -110,7 +110,7 @@ class EventHandler(BaseEventHandler):
         handle_once: bool = False
     ) -> None:
         """
-        Constructor.
+        Create an EventHandler.
 
         :param: matcher is a callable that takes an event and returns True if
             the event should be handled by this event handler, False otherwise.

--- a/launch/launch/event_handlers/on_execution_complete.py
+++ b/launch/launch/event_handlers/on_execution_complete.py
@@ -58,7 +58,7 @@ class OnExecutionComplete(EventHandler):
         ...
 
     def __init__(self, *, target_action=None, on_completion, **kwargs) -> None:  # noqa: F811
-        """Constructor."""
+        """Create an OnExecutionComplete event handler."""
         from ..action import Action  # noqa
         if not isinstance(target_action, (Action, type(None))):
             raise ValueError("OnExecutionComplete requires an 'Action' as the target")

--- a/launch/launch/event_handlers/on_include_launch_description.py
+++ b/launch/launch/event_handlers/on_include_launch_description.py
@@ -25,7 +25,7 @@ class OnIncludeLaunchDescription(EventHandler):
     """Event handler used to handle asynchronous requests to include LaunchDescriptions."""
 
     def __init__(self, **kwargs):
-        """Constructor."""
+        """Create an OnIncludeLaunchDescription event handler."""
         from ..actions import OpaqueFunction
         super().__init__(
             matcher=lambda event: is_a_subclass(event, IncludeLaunchDescription),

--- a/launch/launch/event_handlers/on_process_exit.py
+++ b/launch/launch/event_handlers/on_process_exit.py
@@ -50,7 +50,7 @@ class OnProcessExit(BaseEventHandler):
                        Callable[[ProcessExited, LaunchContext], Optional[SomeActionsType]]],
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create an OnProcessExit event handler."""
         from ..actions import ExecuteProcess  # noqa
         if not isinstance(target_action, (ExecuteProcess, type(None))):
             raise TypeError("OnProcessExit requires an 'ExecuteProcess' action as the target")

--- a/launch/launch/event_handlers/on_process_io.py
+++ b/launch/launch/event_handlers/on_process_io.py
@@ -44,7 +44,7 @@ class OnProcessIO(BaseEventHandler):
         on_stderr: Callable[[ProcessIO], Optional[SomeActionsType]] = None,
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create an OnProcessIO event handler."""
         from ..actions import ExecuteProcess  # noqa
         if not isinstance(target_action, (ExecuteProcess, type(None))):
             raise TypeError("OnProcessIO requires an 'ExecuteProcess' action as the target")

--- a/launch/launch/event_handlers/on_process_start.py
+++ b/launch/launch/event_handlers/on_process_start.py
@@ -50,7 +50,7 @@ class OnProcessStart(BaseEventHandler):
                         Callable[[ProcessStarted, LaunchContext], Optional[SomeActionsType]]],
         **kwargs
     ) -> None:
-        """Constructor."""
+        """Create an OnProcessStart event handler."""
         from ..actions import ExecuteProcess  # noqa
         if not isinstance(target_action, (ExecuteProcess, type(None))):
             raise TypeError("OnProcessStart requires an 'ExecuteProcess' action as the target")

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -50,7 +50,7 @@ class OnShutdown(BaseEventHandler):
         ...
 
     def __init__(self, *, on_shutdown, **kwargs):  # noqa: F811
-        """Constructor."""
+        """Create an OnShutdown event handler."""
         super().__init__(
             matcher=lambda event: is_a_subclass(event, Shutdown),
             **kwargs,

--- a/launch/launch/events/execution_complete.py
+++ b/launch/launch/events/execution_complete.py
@@ -24,7 +24,7 @@ class ExecutionComplete(Event):
     name = 'launch.events.ExecutionComplete'
 
     def __init__(self, *, action: Action) -> None:
-        """Constructor."""
+        """Create an ExecutionComplete event."""
         self.__action = action
 
     @property

--- a/launch/launch/events/include_launch_description.py
+++ b/launch/launch/events/include_launch_description.py
@@ -24,7 +24,7 @@ class IncludeLaunchDescription(Event):
     name = 'launch.events.IncludeLaunchDescription'
 
     def __init__(self, launch_description: LaunchDescription) -> None:
-        """Constructor."""
+        """Create an IncludeLaunchDescription event."""
         self.__launch_description = launch_description
 
     @property

--- a/launch/launch/events/process/process_exited.py
+++ b/launch/launch/events/process/process_exited.py
@@ -29,7 +29,7 @@ class ProcessExited(RunningProcessEvent):
         **kwargs
     ) -> None:
         """
-        Constructor.
+        Create a ProcessExited event.
 
         Unmatched keyword arguments are passed to RunningProcessEvent, see it
         for details on those arguments.

--- a/launch/launch/events/process/process_io.py
+++ b/launch/launch/events/process/process_io.py
@@ -24,7 +24,7 @@ class ProcessIO(RunningProcessEvent):
 
     def __init__(self, *, text: bytes, fd: int, **kwargs) -> None:
         """
-        Constructor.
+        Create a ProcessIO event.
 
         Unmatched keyword arguments are passed to RunningProcessEvent, see it
         for details on those arguments.

--- a/launch/launch/events/process/process_started.py
+++ b/launch/launch/events/process/process_started.py
@@ -24,7 +24,7 @@ class ProcessStarted(RunningProcessEvent):
 
     def __init__(self, **kwargs):
         """
-        Constructor.
+        Create a ProcessStarted event.
 
         Unmatched keyword arguments are passed to RunningProcessEvent, see it
         for details on those arguments.

--- a/launch/launch/events/process/process_stderr.py
+++ b/launch/launch/events/process/process_stderr.py
@@ -24,7 +24,7 @@ class ProcessStderr(ProcessIO):
 
     def __init__(self, *, text: bytes, **kwargs) -> None:
         """
-        Constructor.
+        Create a ProcessStderr event.
 
         Unmatched keyword arguments are passed to ProcessEvent, see it for
         details on those arguments.

--- a/launch/launch/events/process/process_stdin.py
+++ b/launch/launch/events/process/process_stdin.py
@@ -24,7 +24,7 @@ class ProcessStdin(ProcessIO):
 
     def __init__(self, *, text: bytes, **kwargs) -> None:
         """
-        Constructor.
+        Create a ProcessStdin event.
 
         Unmatched keyword arguments are passed to ProcessEvent, see it for
         details on those arguments.

--- a/launch/launch/events/process/process_stdout.py
+++ b/launch/launch/events/process/process_stdout.py
@@ -24,7 +24,7 @@ class ProcessStdout(ProcessIO):
 
     def __init__(self, *, text: bytes, **kwargs) -> None:
         """
-        Constructor.
+        Create a ProcessStdout event.
 
         Unmatched keyword arguments are passed to ProcessEvent, see it for
         details on those arguments.

--- a/launch/launch/events/process/process_targeted_event.py
+++ b/launch/launch/events/process/process_targeted_event.py
@@ -30,7 +30,7 @@ class ProcessTargetedEvent(Event):
 
     def __init__(self, *, process_matcher: Callable[['ExecuteProcess'], bool]) -> None:
         """
-        Constructor.
+        Create a ProcessTargetedEvent.
 
         Some standard matchers are also available, like:
 

--- a/launch/launch/events/process/running_process_event.py
+++ b/launch/launch/events/process/running_process_event.py
@@ -42,7 +42,7 @@ class RunningProcessEvent(Event):
         pid: int
     ) -> None:
         """
-        Constructor.
+        Create a RunningProcessEvent.
 
         :param: action is the ExecuteProcess action associated with the event
         :param: name is the final name of the process instance, which is unique

--- a/launch/launch/events/process/shutdown_process.py
+++ b/launch/launch/events/process/shutdown_process.py
@@ -37,5 +37,5 @@ class ShutdownProcess(ProcessTargetedEvent):
     name = 'launch.events.process.ShutdownProcess'
 
     def __init__(self, *, process_matcher: Callable[['ExecuteProcess'], bool]) -> None:
-        """Constructor."""
+        """Create a ShutdownProcess event."""
         super().__init__(process_matcher=process_matcher)

--- a/launch/launch/events/process/signal_process.py
+++ b/launch/launch/events/process/signal_process.py
@@ -38,7 +38,7 @@ class SignalProcess(ProcessTargetedEvent):
         process_matcher: Callable[['ExecuteProcess'], bool]
     ) -> None:
         """
-        Constructor.
+        Create a SignalProcess event.
 
         Takes an optional process matcher, which can be used to match the
         signal to a process.

--- a/launch/launch/events/shutdown.py
+++ b/launch/launch/events/shutdown.py
@@ -25,7 +25,7 @@ class Shutdown(Event):
     name = 'launch.events.Shutdown'
 
     def __init__(self, *, reason: Text = 'reason not given', due_to_sigint: bool = False) -> None:
-        """Constructor."""
+        """Create a Shutdown event."""
         self.__reason = reason
         self.__due_to_sigint = due_to_sigint
 

--- a/launch/launch/events/timer_event.py
+++ b/launch/launch/events/timer_event.py
@@ -28,7 +28,7 @@ class TimerEvent(Event):
     name = 'launch.events.TimerEvent'
 
     def __init__(self, *, timer_action: 'TimerAction') -> None:
-        """Constructor."""
+        """Create a TimerEvent."""
         self.__timer_action = timer_action
 
     @property

--- a/launch/launch/invalid_launch_file_error.py
+++ b/launch/launch/invalid_launch_file_error.py
@@ -19,7 +19,7 @@ class InvalidLaunchFileError(Exception):
     """Exception raised when the given launch file is not valid."""
 
     def __init__(self, extension='', *, likely_errors=None):
-        """Constructor."""
+        """Create an InvalidLaunchFileError."""
         self._extension = extension
         self._likely_errors = likely_errors
         if self._extension == '' or not self._likely_errors:

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -35,7 +35,7 @@ class LaunchContext:
 
     def __init__(self, *, argv: Optional[Iterable[Text]] = None) -> None:
         """
-        Constructor.
+        Create a LaunchContext.
 
         :param: argv stored in the context for access by the entities, None results in []
         """

--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -51,7 +51,7 @@ class LaunchDescription(LaunchDescriptionEntity):
         *,
         deprecated_reason: Optional[Text] = None
     ) -> None:
-        """Constructor."""
+        """Create a LaunchDescription."""
         self.__entities = list(initial_entities) if initial_entities is not None else []
         self.__deprecated_reason = deprecated_reason
 

--- a/launch/launch/launch_description_source.py
+++ b/launch/launch/launch_description_source.py
@@ -37,7 +37,7 @@ class LaunchDescriptionSource:
         method: str = 'unspecified mechanism from a script',
     ) -> None:
         """
-        Constructor.
+        Create a LaunchDescriptionSource.
 
         For example, loading a file called ``example.launch.py`` for inclusion
         might end up setting `location` to ``/path/to/example.launch.py`` and

--- a/launch/launch/launch_description_sources/any_launch_description_source.py
+++ b/launch/launch/launch_description_sources/any_launch_description_source.py
@@ -34,7 +34,7 @@ class AnyLaunchDescriptionSource(LaunchDescriptionSource):
         launch_file_path: SomeSubstitutionsType,
     ) -> None:
         """
-        Constructor.
+        Create an AnyLaunchDescriptionSource.
 
         If a relative path is passed, it will be relative to the current working
         directory wherever the launch file was run from.

--- a/launch/launch/launch_description_sources/frontend_launch_description_source.py
+++ b/launch/launch/launch_description_sources/frontend_launch_description_source.py
@@ -37,7 +37,7 @@ class FrontendLaunchDescriptionSource(LaunchDescriptionSource):
         parser: Type[Parser] = Parser
     ) -> None:
         """
-        Constructor.
+        Create a FrontendLaunchDescriptionSource.
 
         The given file path should be to a launch frontend style file (like xml or yaml).
         If a relative path is passed, it will be relative to the current working

--- a/launch/launch/launch_description_sources/python_launch_description_source.py
+++ b/launch/launch/launch_description_sources/python_launch_description_source.py
@@ -27,7 +27,7 @@ class PythonLaunchDescriptionSource(LaunchDescriptionSource):
         launch_file_path: SomeSubstitutionsType,
     ) -> None:
         """
-        Constructor.
+        Create a PythonLaunchDescriptionSource.
 
         The given file path should be to a ``.launch.py`` style file.
         The path should probably be absolute, since the current working

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -78,7 +78,7 @@ class LaunchService:
         debug: bool = False
     ) -> None:
         """
-        Constructor.
+        Create a LaunchService.
 
         If called outside of the main-thread before the function
         :func:`launch.utilities.install_signal_handlers()` has been called,

--- a/launch/launch/substitutions/find_executable.py
+++ b/launch/launch/substitutions/find_executable.py
@@ -36,7 +36,7 @@ class FindExecutable(Substitution):
     """
 
     def __init__(self, *, name: SomeSubstitutionsType) -> None:
-        """Constructor."""
+        """Create a FindExecutable substitution."""
         super().__init__()
 
         from ..utilities import normalize_to_list_of_substitutions  # import here to avoid loop

--- a/launch/launch/substitutions/launch_configuration.py
+++ b/launch/launch/substitutions/launch_configuration.py
@@ -39,7 +39,7 @@ class LaunchConfiguration(Substitution):
         *,
         default: Optional[Union[Any, Iterable[Any]]] = None
     ) -> None:
-        """Constructor."""
+        """Create a LaunchConfiguration substitution."""
         super().__init__()
 
         from ..utilities import normalize_to_list_of_substitutions

--- a/launch/launch/substitutions/local_substitution.py
+++ b/launch/launch/substitutions/local_substitution.py
@@ -26,7 +26,7 @@ class LocalSubstitution(Substitution):
     """Substitution that can access contextual local variables."""
 
     def __init__(self, expression: Text, description: Optional[Text] = None) -> None:
-        """Constructor."""
+        """Create a LocalSubstitution."""
         super().__init__()
 
         ensure_argument_type(expression, str, 'expression', 'LocalSubstitution')

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -27,7 +27,7 @@ class PathJoinSubstitution(Substitution):
     """Substitution that join paths, in a platform independent way."""
 
     def __init__(self, substitutions: Iterable[SomeSubstitutionsType]) -> None:
-        """Constructor."""
+        """Create a PathJoinSubstitution."""
         from ..utilities import normalize_to_list_of_substitutions
         self.__substitutions = normalize_to_list_of_substitutions(substitutions)
 

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -36,7 +36,7 @@ class PythonExpression(Substitution):
     """
 
     def __init__(self, expression: SomeSubstitutionsType) -> None:
-        """Constructor."""
+        """Create a PythonExpression substitution."""
         super().__init__()
 
         ensure_argument_type(

--- a/launch/launch/substitutions/substitution_failure.py
+++ b/launch/launch/substitutions/substitution_failure.py
@@ -19,5 +19,5 @@ class SubstitutionFailure(RuntimeError):
     """Raised when a Substitution fails."""
 
     def __init__(self, msg):
-        """Constructor."""
+        """Create a SubstitutionFailure error."""
         super().__init__(msg)

--- a/launch/launch/substitutions/text_substitution.py
+++ b/launch/launch/substitutions/text_substitution.py
@@ -24,7 +24,7 @@ class TextSubstitution(Substitution):
     """Substitution that wraps a single string text."""
 
     def __init__(self, *, text: Text) -> None:
-        """Constructor."""
+        """Create a TextSubstitution."""
         super().__init__()
 
         if not isinstance(text, Text):

--- a/launch/launch/substitutions/this_launch_file.py
+++ b/launch/launch/substitutions/this_launch_file.py
@@ -29,7 +29,7 @@ class ThisLaunchFile(Substitution):
     """Substitution that returns the absolute path to the current launch file."""
 
     def __init__(self) -> None:
-        """Constructor."""
+        """Create a ThisLaunchFile substitution."""
         super().__init__()
 
     @classmethod

--- a/launch/launch/substitutions/this_launch_file_dir.py
+++ b/launch/launch/substitutions/this_launch_file_dir.py
@@ -29,7 +29,7 @@ class ThisLaunchFileDir(Substitution):
     """Substitution that returns the absolute path to the current launch file."""
 
     def __init__(self) -> None:
-        """Constructor."""
+        """Create a ThisLaunchFileDir substitution."""
         super().__init__()
 
     @classmethod

--- a/launch_testing/launch_testing/actions/gtest.py
+++ b/launch_testing/launch_testing/actions/gtest.py
@@ -29,7 +29,7 @@ class GTest(Test):
         **kwargs
     ) -> None:
         """
-        Constructor.
+        Create a Gtest test action.
 
         timeout argument is passed to :class:`launch_testing.Test`.
         The other arguments are passed to :class:`launch.ExecuteProcess`, so

--- a/launch_testing/launch_testing/actions/pytest.py
+++ b/launch_testing/launch_testing/actions/pytest.py
@@ -31,7 +31,7 @@ class PyTest(Test):
         **kwargs
     ) -> None:
         """
-        Constructor.
+        Create a PyTest test action.
 
         timeout argument is passed to :class:`launch_testing.Test`.
         The other arguments are passed to :class:`launch.ExecuteProcess`, so

--- a/launch_testing/launch_testing/actions/test.py
+++ b/launch_testing/launch_testing/actions/test.py
@@ -40,7 +40,7 @@ class Test(ExecuteProcess):
         **kwargs
     ) -> None:
         """
-        Constructor.
+        Create a Test action.
 
         Many arguments are passed to :class:`launch.ExecuteProcess`, so
         see the documentation for the class for additional details.

--- a/launch_xml/launch_xml/launch_description_sources/xml_launch_description_source.py
+++ b/launch_xml/launch_xml/launch_description_sources/xml_launch_description_source.py
@@ -28,7 +28,7 @@ class XMLLaunchDescriptionSource(FrontendLaunchDescriptionSource):
         launch_file_path: SomeSubstitutionsType,
     ) -> None:
         """
-        Constructor.
+        Create an XMLLaunchDescriptionSource.
 
         The given file path should be to a launch XML style file (`.launch.xml`).
         If a relative path is passed, it will be relative to the current working

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -35,7 +35,7 @@ class Entity(BaseEntity):
         *,
         parent: 'Entity' = None
     ) -> Text:
-        """Constructor."""
+        """Create an Entity."""
         self.__type_name = type_name
         self.__element = element
         self.__parent = parent

--- a/launch_yaml/launch_yaml/launch_description_sources/yaml_launch_description_source.py
+++ b/launch_yaml/launch_yaml/launch_description_sources/yaml_launch_description_source.py
@@ -28,7 +28,7 @@ class YAMLLaunchDescriptionSource(FrontendLaunchDescriptionSource):
         launch_file_path: SomeSubstitutionsType,
     ) -> None:
         """
-        Constructor.
+        Create a YAMLLaunchDescriptionSource.
 
         The given file path should be to a launch YAML style file (`.launch.yaml`).
         If a relative path is passed, it will be relative to the current working


### PR DESCRIPTION
Where class names alone were not grammatical I elaborated with
superclass names to get a valid imperative sentence.

Fixes D401 in pydocstyle and flake8.

Contributes to closing ros2/build_cop#255

Signed-off-by: Steven! Ragnarök <steven@nuclearsandwich.com>