### PR TITLE
Handle case where output buffer is closed during shutdown

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -426,40 +426,58 @@ class ExecuteProcess(Action):
     def __on_process_stdout(
         self, event: ProcessIO
     ) -> Optional[SomeActionsType]:
-        self.__stdout_buffer.write(event.text.decode(errors='replace'))
-        self.__stdout_buffer.seek(0)
-        last_line = None
-        for line in self.__stdout_buffer:
-            if line.endswith(os.linesep):
-                self.__stdout_logger.info(
-                    self.__output_format.format(line=line[:-len(os.linesep)], this=self)
-                )
-            else:
-                last_line = line
-                break
-        self.__stdout_buffer.seek(0)
-        self.__stdout_buffer.truncate(0)
-        if last_line is not None:
-            self.__stdout_buffer.write(last_line)
+        to_write = event.text.decode(errors='replace')
+        try:
+            self.__stdout_buffer.write(to_write)
+            self.__stdout_buffer.seek(0)
+            last_line = None
+            for line in self.__stdout_buffer:
+                if line.endswith(os.linesep):
+                    self.__stdout_logger.info(
+                        self.__output_format.format(line=line[:-len(os.linesep)], this=self)
+                    )
+                else:
+                    last_line = line
+                    break
+            self.__stdout_buffer.seek(0)
+            self.__stdout_buffer.truncate(0)
+            if last_line is not None:
+                self.__stdout_buffer.write(last_line)
+        except ValueError:
+            # __stdout_buffer was probably closed by __flush_buffers on shutdown.  Output without
+            # buffering.
+            self.__stdout_logger.info(
+                self.__output_format.format(line=to_write, this=self)
+            )
+
 
     def __on_process_stderr(
         self, event: ProcessIO
     ) -> Optional[SomeActionsType]:
-        self.__stderr_buffer.write(event.text.decode(errors='replace'))
-        self.__stderr_buffer.seek(0)
-        last_line = None
-        for line in self.__stderr_buffer:
-            if line.endswith(os.linesep):
-                self.__stderr_logger.info(
-                    self.__output_format.format(line=line[:-len(os.linesep)], this=self)
-                )
-            else:
-                last_line = line
-                break
-        self.__stderr_buffer.seek(0)
-        self.__stderr_buffer.truncate(0)
-        if last_line is not None:
-            self.__stderr_buffer.write(last_line)
+        to_write = event.text.decode(errors='replace')
+        try:
+            self.__stderr_buffer.write(to_write)
+            self.__stderr_buffer.seek(0)
+            last_line = None
+            for line in self.__stderr_buffer:
+                if line.endswith(os.linesep):
+                    self.__stderr_logger.info(
+                        self.__output_format.format(line=line[:-len(os.linesep)], this=self)
+                    )
+                else:
+                    last_line = line
+                    break
+            self.__stderr_buffer.seek(0)
+            self.__stderr_buffer.truncate(0)
+            if last_line is not None:
+                self.__stderr_buffer.write(last_line)
+        except ValueError:
+            # __stderr buffer was probably closed by __flush_buffers on shutdown.  Output without
+            # buffering.
+            self.__stderr_logger.info(
+                self.__output_format.format(line=to_write, this=self)
+            )
+
 
     def __flush_buffers(self, event, context):
         with self.__stdout_buffer as buf:


### PR DESCRIPTION
  - Prevent crash during launch shutdown when a process IO event happens
    after the buffers have been closed

  - Use unbuffered output in that case so IO still has a chance of being seen

Fixes #364 

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>