### PR TITLE
Fix the XML frontend for command substitution.

### DIFF
--- a/launch/launch/substitutions/command.py
+++ b/launch/launch/substitutions/command.py
@@ -71,7 +71,7 @@ class Command(Substitution):
         kwargs = {'command': data[0]}
         if len(data) == 2:
             kwargs['on_stderr'] = data[1]
-        return cls, data
+        return cls, kwargs
 
     @property
     def command(self) -> List[Substitution]:


### PR DESCRIPTION
While trying to use the XML frontend, I was getting:

type object argument after ** must be a mapping, not list

We need to return the created kwargs, not data, from the
parse() method.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>