### PR TITLE
Release loop lock before waiting for it to do work

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -127,6 +127,7 @@ class LaunchService:
 
         If the LaunchService is not running, the event is queued until it is.
         """
+        future = None
         with self.__loop_from_run_thread_lock:
             if self.__loop_from_run_thread is not None:
                 # loop is in use, asynchronously emit the event
@@ -134,10 +135,13 @@ class LaunchService:
                     self.__context.emit_event(event),
                     self.__loop_from_run_thread
                 )
-                future.result()
             else:
                 # loop is not in use, synchronously emit the event, and it will be processed later
                 self.__context.emit_event_sync(event)
+
+        if future is not None:
+            # Block until asynchronously emitted event is emitted by loop
+            future.result()
 
     def include_launch_description(self, launch_description: LaunchDescription) -> None:
         """


### PR DESCRIPTION
The main thread can be blocked [trying to acquire `__loop_from_run_thread_lock`](https://github.com/ros2/launch/blob/0822c9711e7d6543a8ba3361e3b5a8db41268c44/launch/launch/launch_service.py#L284), but `emit_event()` [holds that lock while waiting for a future](https://github.com/ros2/launch/blob/0822c9711e7d6543a8ba3361e3b5a8db41268c44/launch/launch/launch_service.py#L130-L137) that can only be completed by the main thread. This change releases the lock before blocking when emitting an event.

I expect this to fix ros2/build_cop#248 . This is the situation in the `python3 setup.py pytest` process that is hung on [this CI job](https://ci.ros2.org/job/ci_linux/9046/). There are 5 threads. The main thread is blocked as above, and four threads are all simultaneously trying to call `emit_event()`. One of them is holding the lock and blocked wating for the future, while the other 3 are blocked trying to acquire `__loop_from_run_thread_lock`. I have no idea why the hang started occurring so regularly since it looks like it's a race condition. The fact that the CI job seems to require the December 10th fastrtps and rmw_connext changes plus all other tests to be run beforehand seems to be coincidence.


**edit:** gdb `py-bt` output from all threads https://gist.github.com/sloretz/6091ef621b9244579ec557ecb95b7a39