### PR TITLE
Skip launch tests entirely on Windows.

### DIFF
--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import os
 import threading
 import unittest
 
@@ -41,6 +42,10 @@ class _RunnerWorker():
                  test_run_preamble,
                  launch_file_arguments=[],
                  debug=False):
+
+        if os.name == 'nt':
+            raise unittest.SkipTest('launch tests often hang on Windows')
+
         self._test_run = test_run
         self._test_run_preamble = test_run_preamble
         self._launch_service = LaunchService(debug=debug)


### PR DESCRIPTION
This is somewhat excessively harsh, but an easy option to get the job queue unstuck.

CI on usually hanging ros2cli packages: 
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9127)](http://ci.ros2.org/job/ci_windows/9127/)