### PR TITLE
Add the ability to assert in stdout or stderr.

### DIFF
--- a/launch_testing/launch_testing/asserts/__init__.py
+++ b/launch_testing/launch_testing/asserts/__init__.py
@@ -18,7 +18,9 @@ from .assert_exit_codes import EXIT_SIGINT
 from .assert_exit_codes import EXIT_SIGKILL
 from .assert_exit_codes import EXIT_SIGQUIT
 from .assert_exit_codes import EXIT_SIGSEGV
+from .assert_output import assertInStderr
 from .assert_output import assertInStdout
+from .assert_output import assertInStream
 from .assert_sequential_output import assertSequentialStdout
 from .assert_sequential_output import SequentialTextChecker
 
@@ -26,7 +28,9 @@ from ..util.proc_lookup import NO_CMD_ARGS
 
 __all__ = [
     'assertExitCodes',
+    'assertInStderr',
     'assertInStdout',
+    'assertInStream',
     'assertSequentialStdout',
 
     'SequentialTextChecker',

--- a/launch_testing/launch_testing/asserts/__init__.py
+++ b/launch_testing/launch_testing/asserts/__init__.py
@@ -18,6 +18,7 @@ from .assert_exit_codes import EXIT_SIGINT
 from .assert_exit_codes import EXIT_SIGKILL
 from .assert_exit_codes import EXIT_SIGQUIT
 from .assert_exit_codes import EXIT_SIGSEGV
+from .assert_output import assertDefaultStream
 from .assert_output import assertInStderr
 from .assert_output import assertInStdout
 from .assert_output import assertInStream
@@ -27,6 +28,7 @@ from .assert_sequential_output import SequentialTextChecker
 from ..util.proc_lookup import NO_CMD_ARGS
 
 __all__ = [
+    'assertDefaultStream',
     'assertExitCodes',
     'assertInStderr',
     'assertInStdout',

--- a/launch_testing/launch_testing/asserts/assert_output.py
+++ b/launch_testing/launch_testing/asserts/assert_output.py
@@ -26,6 +26,84 @@ from ..tools.text import build_text_match
 from ..util import resolveProcesses
 
 
+def assertInStream(proc_output,
+                   expected_output,
+                   process,
+                   cmd_args=None,
+                   *,
+                   output_filter=None,
+                   strict_proc_matching=True,
+                   strip_ansi_escape_sequences=True,
+                   stream='stderr'):
+    """
+    Assert that 'output' was found in a stream of a process.
+
+    :param proc_output: The process output captured by launch_test.  This is usually injected
+    into test cases as self._proc_output
+    :type proc_output: An launch_testing.IoHandler
+
+    :param expected_output: The output to search for
+    :type expected_output: string or regex pattern or a list of the aforementioned types
+
+    :param process: The process whose output will be searched
+    :type process: A string (search by process name) or a launch.actions.ExecuteProcess object
+
+    :param cmd_args: Optional.  If 'process' is a string, cmd_args will be used to disambiguate
+    processes with the same name.  Pass launch_testing.asserts.NO_CMD_ARGS to match a proc without
+    command arguments
+    :type cmd_args: string
+
+    :param output_filter: Optional. A function to filter output before attempting any assertion.
+    :type output_filter: callable
+
+    :param strict_proc_matching: Optional (default True), If proc is a string and the combination
+    of proc and cmd_args matches multiple processes, then strict_proc_matching=True will raise
+    an error.
+    :type strict_proc_matching: bool
+
+    :param strip_ansi_escape_sequences: If True (default), strip ansi escape
+    sequences from actual output before comparing with the output filter or
+    expected output.
+    :type strip_ansi_escape_sequences: bool
+
+    :param stream: Which stream to examine.  This must be one of 'stderr' or 'stdout'.
+    :type stream: string
+    """
+    resolved_procs = resolveProcesses(
+        info_obj=proc_output,
+        process=process,
+        cmd_args=cmd_args,
+        strict_proc_matching=strict_proc_matching
+    )
+    if output_filter is not None:
+        if not callable(output_filter):
+            raise ValueError('output_filter is not callable')
+    output_match = build_text_match(expected_output)
+
+    for proc in resolved_procs:  # Nominally just one matching proc
+        if stream == 'stdout':
+            full_output = ''.join(
+                output.text.decode() for output in proc_output[proc] if output.from_stdout
+            )
+        elif stream == 'stderr':
+            full_output = ''.join(
+                output.text.decode() for output in proc_output[proc] if output.from_stderr
+            )
+        else:
+            raise ValueError("Invalid value for stream; must be 'stout' or 'stderr'")
+
+        if strip_ansi_escape_sequences:
+            full_output = remove_ansi_escape_sequences(full_output)
+        if output_filter is not None:
+            full_output = output_filter(full_output)
+        if output_match(full_output) is not None:
+            break
+    else:
+        names = ', '.join(sorted(p.process_details['name'] for p in resolved_procs))
+        assert False, "Did not find '{}' in output for any of the matching processes: {}".format(
+            expected_output, names
+        )
+
 def assertInStdout(proc_output,
                    expected_output,
                    process,
@@ -35,7 +113,7 @@ def assertInStdout(proc_output,
                    strict_proc_matching=True,
                    strip_ansi_escape_sequences=True):
     """
-    Assert that 'output' was found in the standard out of a process.
+    Assert that 'output' was found in the standard output of a process.
 
     :param proc_output: The process output captured by launch_test.  This is usually injected
     into test cases as self._proc_output
@@ -65,29 +143,45 @@ def assertInStdout(proc_output,
     expected output.
     :type strip_ansi_escape_sequences: bool
     """
-    resolved_procs = resolveProcesses(
-        info_obj=proc_output,
-        process=process,
-        cmd_args=cmd_args,
-        strict_proc_matching=strict_proc_matching
-    )
-    if output_filter is not None:
-        if not callable(output_filter):
-            raise ValueError('output_filter is not callable')
-    output_match = build_text_match(expected_output)
+    assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter, strict_proc_matching=strict_proc_matching, strip_ansi_escape_sequences=strip_ansi_escape_sequences, stream='stdout')
 
-    for proc in resolved_procs:  # Nominally just one matching proc
-        full_output = ''.join(
-            output.text.decode() for output in proc_output[proc] if output.from_stdout
-        )
-        if strip_ansi_escape_sequences:
-            full_output = remove_ansi_escape_sequences(full_output)
-        if output_filter is not None:
-            full_output = output_filter(full_output)
-        if output_match(full_output) is not None:
-            break
-    else:
-        names = ', '.join(sorted(p.process_details['name'] for p in resolved_procs))
-        assert False, "Did not find '{}' in output for any of the matching processes: {}".format(
-            expected_output, names
-        )
+def assertInStderr(proc_output,
+                   expected_output,
+                   process,
+                   cmd_args=None,
+                   *,
+                   output_filter=None,
+                   strict_proc_matching=True,
+                   strip_ansi_escape_sequences=True):
+    """
+    Assert that 'output' was found in the standard error of a process.
+
+    :param proc_output: The process output captured by launch_test.  This is usually injected
+    into test cases as self._proc_output
+    :type proc_output: An launch_testing.IoHandler
+
+    :param expected_output: The output to search for
+    :type expected_output: string or regex pattern or a list of the aforementioned types
+
+    :param process: The process whose output will be searched
+    :type process: A string (search by process name) or a launch.actions.ExecuteProcess object
+
+    :param cmd_args: Optional.  If 'process' is a string, cmd_args will be used to disambiguate
+    processes with the same name.  Pass launch_testing.asserts.NO_CMD_ARGS to match a proc without
+    command arguments
+    :type cmd_args: string
+
+    :param output_filter: Optional. A function to filter output before attempting any assertion.
+    :type output_filter: callable
+
+    :param strict_proc_matching: Optional (default True), If proc is a string and the combination
+    of proc and cmd_args matches multiple processes, then strict_proc_matching=True will raise
+    an error.
+    :type strict_proc_matching: bool
+
+    :param strip_ansi_escape_sequences: If True (default), strip ansi escape
+    sequences from actual output before comparing with the output filter or
+    expected output.
+    :type strip_ansi_escape_sequences: bool
+    """
+    assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter, strict_proc_matching=strict_proc_matching, strip_ansi_escape_sequences=strip_ansi_escape_sequences, stream='stderr')

--- a/launch_testing/launch_testing/asserts/assert_output.py
+++ b/launch_testing/launch_testing/asserts/assert_output.py
@@ -104,6 +104,7 @@ def assertInStream(proc_output,
             expected_output, names
         )
 
+
 def assertInStdout(proc_output,
                    expected_output,
                    process,
@@ -143,7 +144,10 @@ def assertInStdout(proc_output,
     expected output.
     :type strip_ansi_escape_sequences: bool
     """
-    assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter, strict_proc_matching=strict_proc_matching, strip_ansi_escape_sequences=strip_ansi_escape_sequences, stream='stdout')
+    assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter,
+                   strict_proc_matching=strict_proc_matching,
+                   strip_ansi_escape_sequences=strip_ansi_escape_sequences, stream='stdout')
+
 
 def assertInStderr(proc_output,
                    expected_output,
@@ -184,4 +188,6 @@ def assertInStderr(proc_output,
     expected output.
     :type strip_ansi_escape_sequences: bool
     """
-    assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter, strict_proc_matching=strict_proc_matching, strip_ansi_escape_sequences=strip_ansi_escape_sequences, stream='stderr')
+    assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter,
+                   strict_proc_matching=strict_proc_matching,
+                   strip_ansi_escape_sequences=strip_ansi_escape_sequences, stream='stderr')

--- a/launch_testing/launch_testing/asserts/assert_output.py
+++ b/launch_testing/launch_testing/asserts/assert_output.py
@@ -90,7 +90,7 @@ def assertInStream(proc_output,
                 output.text.decode() for output in proc_output[proc] if output.from_stderr
             )
         else:
-            raise ValueError("Invalid value for stream; must be 'stout' or 'stderr'")
+            raise ValueError("Invalid value for stream; must be 'stdout' or 'stderr'")
 
         if strip_ansi_escape_sequences:
             full_output = remove_ansi_escape_sequences(full_output)
@@ -116,33 +116,7 @@ def assertInStdout(proc_output,
     """
     Assert that 'output' was found in the standard output of a process.
 
-    :param proc_output: The process output captured by launch_test.  This is usually injected
-    into test cases as self._proc_output
-    :type proc_output: An launch_testing.IoHandler
-
-    :param expected_output: The output to search for
-    :type expected_output: string or regex pattern or a list of the aforementioned types
-
-    :param process: The process whose output will be searched
-    :type process: A string (search by process name) or a launch.actions.ExecuteProcess object
-
-    :param cmd_args: Optional.  If 'process' is a string, cmd_args will be used to disambiguate
-    processes with the same name.  Pass launch_testing.asserts.NO_CMD_ARGS to match a proc without
-    command arguments
-    :type cmd_args: string
-
-    :param output_filter: Optional. A function to filter output before attempting any assertion.
-    :type output_filter: callable
-
-    :param strict_proc_matching: Optional (default True), If proc is a string and the combination
-    of proc and cmd_args matches multiple processes, then strict_proc_matching=True will raise
-    an error.
-    :type strict_proc_matching: bool
-
-    :param strip_ansi_escape_sequences: If True (default), strip ansi escape
-    sequences from actual output before comparing with the output filter or
-    expected output.
-    :type strip_ansi_escape_sequences: bool
+    See the documentation for 'assertInStream' for full details.
     """
     assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter,
                    strict_proc_matching=strict_proc_matching,
@@ -160,33 +134,7 @@ def assertInStderr(proc_output,
     """
     Assert that 'output' was found in the standard error of a process.
 
-    :param proc_output: The process output captured by launch_test.  This is usually injected
-    into test cases as self._proc_output
-    :type proc_output: An launch_testing.IoHandler
-
-    :param expected_output: The output to search for
-    :type expected_output: string or regex pattern or a list of the aforementioned types
-
-    :param process: The process whose output will be searched
-    :type process: A string (search by process name) or a launch.actions.ExecuteProcess object
-
-    :param cmd_args: Optional.  If 'process' is a string, cmd_args will be used to disambiguate
-    processes with the same name.  Pass launch_testing.asserts.NO_CMD_ARGS to match a proc without
-    command arguments
-    :type cmd_args: string
-
-    :param output_filter: Optional. A function to filter output before attempting any assertion.
-    :type output_filter: callable
-
-    :param strict_proc_matching: Optional (default True), If proc is a string and the combination
-    of proc and cmd_args matches multiple processes, then strict_proc_matching=True will raise
-    an error.
-    :type strict_proc_matching: bool
-
-    :param strip_ansi_escape_sequences: If True (default), strip ansi escape
-    sequences from actual output before comparing with the output filter or
-    expected output.
-    :type strip_ansi_escape_sequences: bool
+    See the documentation for 'assertInStream' for full details.
     """
     assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter,
                    strict_proc_matching=strict_proc_matching,

--- a/launch_testing/launch_testing/asserts/assert_output.py
+++ b/launch_testing/launch_testing/asserts/assert_output.py
@@ -139,3 +139,12 @@ def assertInStderr(proc_output,
     assertInStream(proc_output, expected_output, process, cmd_args, output_filter=output_filter,
                    strict_proc_matching=strict_proc_matching,
                    strip_ansi_escape_sequences=strip_ansi_escape_sequences, stream='stderr')
+
+
+def assertDefaultStream():
+    """
+    Return the stream that is used by default for 'assertInStream'.
+
+    This is useful for writing tests that are compatible with both Eloquent and newer releases.
+    """
+    return 'stderr'

--- a/launch_testing/launch_testing/io_handler.py
+++ b/launch_testing/launch_testing/io_handler.py
@@ -23,7 +23,7 @@ further reference.
 
 import threading
 
-from .asserts.assert_output import assertInStdout
+from .asserts.assert_output import assertInStream
 from .util import NoMatchingProcessException
 from .util import resolveProcesses
 
@@ -154,13 +154,14 @@ class ActiveIoHandler:
         strict_proc_matching=True,
         output_filter=None,
         timeout=10,
-        strip_ansi_escape_sequences=True
+        strip_ansi_escape_sequences=True,
+        stream='stderr',
     ):
         success = False
 
         def msg_found():
             try:
-                assertInStdout(
+                assertInStream(
                     self._io_handler,  # Use unsynchronized, since this is called from a lock
                     expected_output=expected_output,
                     process=process,
@@ -168,6 +169,7 @@ class ActiveIoHandler:
                     output_filter=output_filter,
                     strict_proc_matching=strict_proc_matching,
                     strip_ansi_escape_sequences=strip_ansi_escape_sequences,
+                    stream=stream,
                 )
                 return True
             except NoMatchingProcessException:

--- a/launch_testing/test/launch_testing/examples/context_launch_test.py
+++ b/launch_testing/test/launch_testing/examples/context_launch_test.py
@@ -71,7 +71,7 @@ class TestProcOutput(unittest.TestCase):
         # We can use the 'dut' argument here because it's part of the test context
         # returned by `generate_test_description`  It's not necessary for every
         # test to use every piece of the context
-        self.proc_output.assertWaitFor('Loop 1', process=dut, timeout=10)
+        self.proc_output.assertWaitFor('Loop 1', process=dut, timeout=10, stream='stdout')
 
 
 @launch_testing.post_shutdown_test()

--- a/launch_testing/test/launch_testing/examples/good_proc_launch_test.py
+++ b/launch_testing/test/launch_testing/examples/good_proc_launch_test.py
@@ -61,10 +61,10 @@ class TestGoodProcess(unittest.TestCase):
     def test_count_to_four(self):
         # This will match stdout from any process.  In this example there is only one process
         # running
-        self.proc_output.assertWaitFor('Loop 1', timeout=10)
-        self.proc_output.assertWaitFor('Loop 2', timeout=10)
-        self.proc_output.assertWaitFor('Loop 3', timeout=10)
-        self.proc_output.assertWaitFor('Loop 4', timeout=10)
+        self.proc_output.assertWaitFor('Loop 1', timeout=10, stream='stdout')
+        self.proc_output.assertWaitFor('Loop 2', timeout=10, stream='stdout')
+        self.proc_output.assertWaitFor('Loop 3', timeout=10, stream='stdout')
+        self.proc_output.assertWaitFor('Loop 4', timeout=10, stream='stdout')
 
 
 @launch_testing.post_shutdown_test()

--- a/launch_testing/test/launch_testing/examples/parameters_launch_test.py
+++ b/launch_testing/test/launch_testing/examples/parameters_launch_test.py
@@ -59,4 +59,4 @@ class TestProcessOutput(unittest.TestCase):
     # Note that 'arg_param' is automatically given to the test case, even though it was not
     # part of the test context.
     def test_process_outputs_expectd_value(self, proc_output, arg_param):
-        proc_output.assertWaitFor('--' + arg_param, timeout=10)
+        proc_output.assertWaitFor('--' + arg_param, timeout=10, stream='stdout')

--- a/launch_testing/test/launch_testing/examples/parameters_launch_test.py
+++ b/launch_testing/test/launch_testing/examples/parameters_launch_test.py
@@ -58,5 +58,5 @@ class TestProcessOutput(unittest.TestCase):
 
     # Note that 'arg_param' is automatically given to the test case, even though it was not
     # part of the test context.
-    def test_process_outputs_expectd_value(self, proc_output, arg_param):
+    def test_process_outputs_expected_value(self, proc_output, arg_param):
         proc_output.assertWaitFor('--' + arg_param, timeout=10, stream='stdout')

--- a/launch_testing/test/launch_testing/examples/ready_action_test.py
+++ b/launch_testing/test/launch_testing/examples/ready_action_test.py
@@ -60,10 +60,10 @@ class TestGoodProcess(unittest.TestCase):
     def test_count_to_four(self):
         # This will match stdout from any process.  In this example there is only one process
         # running
-        self.proc_output.assertWaitFor('Loop 1', timeout=10)
-        self.proc_output.assertWaitFor('Loop 2', timeout=10)
-        self.proc_output.assertWaitFor('Loop 3', timeout=10)
-        self.proc_output.assertWaitFor('Loop 4', timeout=10)
+        self.proc_output.assertWaitFor('Loop 1', timeout=10, stream='stdout')
+        self.proc_output.assertWaitFor('Loop 2', timeout=10, stream='stdout')
+        self.proc_output.assertWaitFor('Loop 3', timeout=10, stream='stdout')
+        self.proc_output.assertWaitFor('Loop 4', timeout=10, stream='stdout')
 
 
 @launch_testing.post_shutdown_test()

--- a/launch_testing/test/launch_testing/examples/terminating_proc_launch_test.py
+++ b/launch_testing/test/launch_testing/examples/terminating_proc_launch_test.py
@@ -61,10 +61,16 @@ class TestTerminatingProc(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForStartup(process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Starting Up', process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Emulating Work', process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Done', process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Shutting Down', process=proc_action, timeout=2)
+            proc_output.assertWaitFor(
+                'Starting Up', process=proc_action, timeout=2, stream='stdout'
+            )
+            proc_output.assertWaitFor(
+                'Emulating Work', process=proc_action, timeout=2, stream='stdout'
+            )
+            proc_output.assertWaitFor('Done', process=proc_action, timeout=2, stream='stdout')
+            proc_output.assertWaitFor(
+                'Shutting Down', process=proc_action, timeout=2, stream='stdout'
+            )
             proc_info.assertWaitForShutdown(process=proc_action, timeout=4)
         launch_testing.asserts.assertExitCodes(proc_info, process=proc_action)
 
@@ -75,13 +81,20 @@ class TestTerminatingProc(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForStartup(process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Starting Up', process=proc_action, timeout=2)
             proc_output.assertWaitFor(
-                "Called with arguments ['--foo', 'bar']", process=proc_action, timeout=2
+                'Starting Up', process=proc_action, timeout=2, stream='stdout'
             )
-            proc_output.assertWaitFor('Emulating Work', process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Done', process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Shutting Down', process=proc_action, timeout=2)
+            proc_output.assertWaitFor(
+                "Called with arguments ['--foo', 'bar']", process=proc_action, timeout=2,
+                stream='stdout'
+            )
+            proc_output.assertWaitFor(
+                'Emulating Work', process=proc_action, timeout=2, stream='stdout'
+            )
+            proc_output.assertWaitFor('Done', process=proc_action, timeout=2, stream='stdout')
+            proc_output.assertWaitFor(
+                'Shutting Down', process=proc_action, timeout=2, stream='stdout'
+            )
             proc_info.assertWaitForShutdown(process=proc_action, timeout=4)
         launch_testing.asserts.assertExitCodes(proc_info, process=proc_action)
 
@@ -92,9 +105,12 @@ class TestTerminatingProc(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForStartup(process=proc_action, timeout=2)
-            proc_output.assertWaitFor('Starting Up', process=proc_action, timeout=2)
             proc_output.assertWaitFor(
-                "Called with arguments ['--exception']", process=proc_action, timeout=2
+                'Starting Up', process=proc_action, timeout=2, stream='stdout'
+            )
+            proc_output.assertWaitFor(
+                "Called with arguments ['--exception']", process=proc_action, timeout=2,
+                stream='stdout'
             )
             proc_info.assertWaitForShutdown(process=proc_action, timeout=4)
         launch_testing.asserts.assertExitCodes(

--- a/launch_testing/test/launch_testing/test_io_handler_and_assertions.py
+++ b/launch_testing/test/launch_testing/test_io_handler_and_assertions.py
@@ -117,7 +117,7 @@ class TestIoHandlerAndAssertions(unittest.TestCase):
 
     def test_assert_wait_for_returns_immediately(self):
         # If the output has already been seen, ensure that assertWaitsFor returns right away
-        self.proc_output.assertWaitFor('Starting Up', timeout=1)
+        self.proc_output.assertWaitFor('Starting Up', timeout=1, stream='stdout')
 
     def test_EXPECTED_TEXT_is_present(self):
         # Sanity check - makes sure the EXPECTED_TEXT is somewhere in the test run

--- a/launch_testing/test/launch_testing/test_resolve_process.py
+++ b/launch_testing/test/launch_testing/test_resolve_process.py
@@ -121,9 +121,9 @@ class TestStringProcessResolution(unittest.TestCase):
                                no_arg_proc,
                                one_arg_proc,
                                two_arg_proc):
-                proc_output.assertWaitFor('--one-arg')
-                proc_output.assertWaitFor('--two-arg')
-                proc_output.assertWaitFor('arg_two')
+                proc_output.assertWaitFor('--one-arg', stream='stdout')
+                proc_output.assertWaitFor('--two-arg', stream='stdout')
+                proc_output.assertWaitFor('arg_two', stream='stdout')
 
                 arr.append(proc_info)
 

--- a/launch_testing/test/launch_testing/test_runner_results.py
+++ b/launch_testing/test/launch_testing/test_runner_results.py
@@ -166,7 +166,7 @@ def test_parametrized_run_with_one_failure(source_test_loader):
         ])
 
     def test_fail_on_two(self, proc_output, arg_val):
-        proc_output.assertWaitFor('Starting Up')
+        proc_output.assertWaitFor('Starting Up', stream='stdout')
         assert arg_val != 2
 
     def test_fail_on_three(self, arg_val):


### PR DESCRIPTION
Since we are switching the underlying logging to be stderr,
this is going to be important for tests.  This commit
refactors assertInStdout() to be assertInStream(), which
takes in the stream to be asserted on.  It then recreates
assertInStdout() on top of that, and adds in assertInStderr().

It also changes assertWaitFor() to wait on the stderr stream
by default.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This goes along with https://github.com/ros2/rcutils/pull/196