### PR TITLE
Fix parsing of cmd line arguments in XML and yaml file

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -262,7 +262,7 @@ class ExecuteProcess(Action):
         def _append_arg():
             nonlocal arg
             result_args.append(arg)
-            arg= []
+            arg = []
         for sub in parser.parse_substitution(cmd):
             if isinstance(sub, TextSubstitution):
                 tokens = shlex.split(sub.text)

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -26,7 +26,6 @@ from launch.frontend.parse_substitution import parse_substitution
 from launch.substitutions import EnvironmentVariable
 from launch.substitutions import PythonExpression
 from launch.substitutions import ThisLaunchFileDir
-from launch.substitutions import TextSubstitution
 
 
 def test_no_text():
@@ -201,6 +200,7 @@ class MockedParser:
 
     def parse_substitution(self, value: Text) -> SomeSubstitutionsType:
         return parse_substitution(value)
+
 
 def test_execute_process_parse_cmd_line():
     """Test ExecuteProcess._parse_cmd_line."""

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -196,7 +196,7 @@ def expand_cmd_subs(cmd_subs: List[SomeSubstitutionsType]):
     return [perform_substitutions_without_context(x) for x in cmd_subs]
 
 
-class MockedParser:
+class MockParser:
 
     def parse_substitution(self, value: Text) -> SomeSubstitutionsType:
         return parse_substitution(value)
@@ -204,7 +204,7 @@ class MockedParser:
 
 def test_execute_process_parse_cmd_line():
     """Test ExecuteProcess._parse_cmd_line."""
-    parser = MockedParser()
+    parser = MockParser()
 
     cmd_text: Text = '$(test path)/a/b/c asd csd $(test asd)/bsd/csd'
     cmd_subs: List[SomeSubstitutionsType] = ExecuteProcess._parse_cmdline(cmd_text, parser)
@@ -235,3 +235,13 @@ def test_execute_process_parse_cmd_line():
     cmd_subs = ExecuteProcess._parse_cmdline(cmd_text, parser)
     cmd_performed = expand_cmd_subs(cmd_subs)
     assert cmd_performed == ['exec', 'asd', 'prefix/bsd']
+
+    cmd_text = '$(test foo)$(test bar)'
+    cmd_subs = ExecuteProcess._parse_cmdline(cmd_text, parser)
+    cmd_performed = expand_cmd_subs(cmd_subs)
+    assert cmd_performed == ['foobar']
+
+    cmd_text = '$(test that) $(test this)'
+    cmd_subs = ExecuteProcess._parse_cmdline(cmd_text, parser)
+    cmd_performed = expand_cmd_subs(cmd_subs)
+    assert cmd_performed == ['that', 'this']

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -19,8 +19,10 @@ import sys
 
 from launch import LaunchDescription
 from launch import LaunchService
+from launch import Substitution
 from launch.actions.execute_process import ExecuteProcess
 from launch.actions.opaque_function import OpaqueFunction
+from launch.substitutions import TextSubstitution
 
 import pytest
 

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -19,10 +19,8 @@ import sys
 
 from launch import LaunchDescription
 from launch import LaunchService
-from launch import Substitution
 from launch.actions.execute_process import ExecuteProcess
 from launch.actions.opaque_function import OpaqueFunction
-from launch.substitutions import TextSubstitution
 
 import pytest
 


### PR DESCRIPTION
Fixes https://github.com/ros2/launch/issues/337.

The rules are a bit tricky, but I added a bunch of test cases. I will add any other suggested test case if needed.

I first though about solving the problem by addressing https://github.com/ros2/launch/issues/263.
But I later realized that:
- That change breaks API and it's not backportable. This fixes #337 in a backportable way.
- Using a string (`SomeSubstitutionsType`) for specifying commands, instead of a list (`List[SomeSubstitutionsType]`), makes concatenation of arguments more complex (e.g.: when passing args from `Node` to `ExecuteProcess`).