### PR TITLE
Add support for anon substitution

### DIFF
--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -14,6 +14,7 @@
 
 """Package for substitutions."""
 
+from .anon_name import AnonName
 from .command import Command
 from .environment_variable import EnvironmentVariable
 from .find_executable import FindExecutable
@@ -27,6 +28,7 @@ from .this_launch_file import ThisLaunchFile
 from .this_launch_file_dir import ThisLaunchFileDir
 
 __all__ = [
+    'AnonName',
     'Command',
     'EnvironmentVariable',
     'FindExecutable',

--- a/launch/launch/substitutions/anon_name.py
+++ b/launch/launch/substitutions/anon_name.py
@@ -34,7 +34,7 @@ class AnonName(Substitution):
     """
 
     def __init__(self, name: SomeSubstitutionsType) -> None:
-        """Create a PythonExpression substitution."""
+        """Create a AnonName substitution."""
         super().__init__()
 
         from ..utilities import normalize_to_list_of_substitutions
@@ -61,16 +61,15 @@ class AnonName(Substitution):
         from ..utilities import perform_substitutions
         name = perform_substitutions(context, self.name)
 
-        if('anon' not in context.launch_configurations):
+        if 'anon' not in context.launch_configurations:
             context.launch_configurations['anon'] = {}
         anon_context = context.launch_configurations['anon']
 
-        if(name in anon_context):
+        if name in anon_context:
             return anon_context[name]
 
-        value = self.anonymous_name(name)
-        context.launch_configurations['anon'][name] = value
-        return value
+        anon_context[name] = self.anonymous_name(name)
+        return anon_context[name]
 
     def anonymous_name(self, id_value: Text) -> Text:
         """Get anonymous name based on id value."""

--- a/launch/launch/substitutions/anon_name.py
+++ b/launch/launch/substitutions/anon_name.py
@@ -66,11 +66,11 @@ class AnonName(Substitution):
         anon_context = context.launch_configurations['anon']
 
         if name not in anon_context:
-            anon_context[name] = self.anonymous_name(name)
+            anon_context[name] = self.compute_name(name)
 
         return anon_context[name]
 
-    def anonymous_name(self, id_value: Text) -> Text:
+    def compute_name(self, id_value: Text) -> Text:
         """Get anonymous name based on id value."""
         import os
         import random

--- a/launch/launch/substitutions/anon_name.py
+++ b/launch/launch/substitutions/anon_name.py
@@ -29,12 +29,12 @@ class AnonName(Substitution):
     """
     Generates an anonymous id based on name.
 
-    Name itself is a unique identifier: multiple uses of $(anon foo)
-    will create the same "anonymized" name
+    Name itself is a unique identifier: multiple uses of anon with
+    the same parameter name will create the same "anonymized" name
     """
 
     def __init__(self, name: SomeSubstitutionsType) -> None:
-        """Create a AnonName substitution."""
+        """Construct an `AnonName` substitution."""
         super().__init__()
 
         from ..utilities import normalize_to_list_of_substitutions
@@ -65,16 +65,18 @@ class AnonName(Substitution):
             context.launch_configurations['anon'] = {}
         anon_context = context.launch_configurations['anon']
 
-        if name in anon_context:
-            return anon_context[name]
+        if name not in anon_context:
+            anon_context[name] = self.anonymous_name(name)
 
-        anon_context[name] = self.anonymous_name(name)
         return anon_context[name]
 
     def anonymous_name(self, id_value: Text) -> Text:
         """Get anonymous name based on id value."""
         import os
         import random
+        import socket
         import sys
-        name = f'{id_value}_{os.getpid()}_{random.randint(0, sys.maxsize)}'
-        return name
+        name = f'{id_value}_{socket.gethostname()}_{os.getpid()}_{random.randint(0, sys.maxsize)}'
+        name = name.replace('.', '_')
+        name = name.replace('-', '_')
+        return name.replace(':', '_')

--- a/launch/launch/substitutions/anon_name.py
+++ b/launch/launch/substitutions/anon_name.py
@@ -1,0 +1,81 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the anonymous name substitution."""
+
+from typing import Iterable
+from typing import List
+from typing import Text
+
+from ..frontend import expose_substitution
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+
+
+@expose_substitution('anon')
+class AnonName(Substitution):
+    """
+    Generates an anonymous id based on name.
+
+    Name itself is a unique identifier: multiple uses of $(anon foo)
+    will create the same "anonymized" name
+    """
+
+    def __init__(self, name: SomeSubstitutionsType) -> None:
+        """Create a PythonExpression substitution."""
+        super().__init__()
+
+        from ..utilities import normalize_to_list_of_substitutions
+        self.__name = normalize_to_list_of_substitutions(name)
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `AnonName` substitution."""
+        if len(data) != 1:
+            raise TypeError('anon substitution expects 1 argument')
+        return cls, {'name': data[0]}
+
+    @property
+    def name(self) -> List[Substitution]:
+        """Getter for name."""
+        return self.__name
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return 'AnonName({})'.format(' + '.join([sub.describe() for sub in self.name]))
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution by creating/getting the anonymous name."""
+        from ..utilities import perform_substitutions
+        name = perform_substitutions(context, self.name)
+
+        if('anon' not in context.launch_configurations):
+            context.launch_configurations['anon'] = {}
+        anon_context = context.launch_configurations['anon']
+
+        if(name in anon_context):
+            return anon_context[name]
+
+        value = self.anonymous_name(name)
+        context.launch_configurations['anon'][name] = value
+        return value
+
+    def anonymous_name(self, id_value: Text) -> Text:
+        """Get anonymous name based on id value."""
+        import os
+        import random
+        import sys
+        name = f'{id_value}_{os.getpid()}_{random.randint(0, sys.maxsize)}'
+        return name

--- a/launch/test/launch/substitutions/test_anon_name.py
+++ b/launch/test/launch/substitutions/test_anon_name.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the AnonName substitution class."""
+
+import re
+
+from launch import LaunchContext
+from launch.substitutions import AnonName
+
+# import pytest
+
+
+def test_this_launch_file_path():
+    anon_regex = re.compile(r'.+_[0-9]+_[0-9]+')
+
+    lc = LaunchContext()
+    sub1 = AnonName('foo')
+    result1 = sub1.perform(lc)
+    assert result1
+    assert anon_regex.match(result1)
+
+    sub2 = AnonName('foo')
+    result2 = sub2.perform(lc)
+    assert result2
+    assert result1 == result2
+    assert anon_regex.match(result2)
+
+    sub3 = AnonName('car')
+    result3 = sub3.perform(lc)
+    assert result3
+    assert anon_regex.match(result3)
+    assert result1 != result3

--- a/launch/test/launch/substitutions/test_anon_name.py
+++ b/launch/test/launch/substitutions/test_anon_name.py
@@ -25,7 +25,7 @@ def test_this_launch_file_path():
     sub1 = AnonName('foo')
     result1 = sub1.perform(lc)
     assert result1
-    assert re.compile(r'foo_[0-9]+_[0-9]+').match(result1)
+    assert re.match(r'foo_[a-zA-Z0-9_]+_[0-9]+_[0-9]+', result1)
 
     sub2 = AnonName('foo')
     result2 = sub2.perform(lc)
@@ -35,4 +35,4 @@ def test_this_launch_file_path():
     sub3 = AnonName('car')
     result3 = sub3.perform(lc)
     assert result3
-    assert re.compile(r'car_[0-9]+_[0-9]+').match(result3)
+    assert re.match(r'car_[a-zA-Z0-9_]+_[0-9]+_[0-9]+', result3)

--- a/launch/test/launch/substitutions/test_anon_name.py
+++ b/launch/test/launch/substitutions/test_anon_name.py
@@ -19,26 +19,20 @@ import re
 from launch import LaunchContext
 from launch.substitutions import AnonName
 
-# import pytest
-
 
 def test_this_launch_file_path():
-    anon_regex = re.compile(r'.+_[0-9]+_[0-9]+')
-
     lc = LaunchContext()
     sub1 = AnonName('foo')
     result1 = sub1.perform(lc)
     assert result1
-    assert anon_regex.match(result1)
+    assert re.compile(r'foo_[0-9]+_[0-9]+').match(result1)
 
     sub2 = AnonName('foo')
     result2 = sub2.perform(lc)
     assert result2
     assert result1 == result2
-    assert anon_regex.match(result2)
 
     sub3 = AnonName('car')
     result3 = sub3.perform(lc)
     assert result3
-    assert anon_regex.match(result3)
-    assert result1 != result3
+    assert re.compile(r'car_[0-9]+_[0-9]+').match(result3)


### PR DESCRIPTION
This commit adds the anonymous name substitution, similar to the one provided in [ROS1](http://wiki.ros.org/roslaunch/XML).

Includes as well testing for the perform function of the substitution. This PR will close #289.

Signed-off-by: Jorge J. Perez <jjperez@ekumenlabs.com>