### PR TITLE
Make RegisterEventHandler describe its sub-entities

### DIFF
--- a/launch/launch/actions/register_event_handler.py
+++ b/launch/launch/actions/register_event_handler.py
@@ -14,9 +14,15 @@
 
 """Module for the RegisterEventHandler action."""
 
+from typing import Iterable
+from typing import List
+from typing import Text
+from typing import Tuple
+
 from ..action import Action
 from ..event_handler import BaseEventHandler
 from ..launch_context import LaunchContext
+from ..launch_description_entity import LaunchDescriptionEntity
 
 
 class RegisterEventHandler(Action):
@@ -45,3 +51,12 @@ class RegisterEventHandler(Action):
     def execute(self, context: LaunchContext):
         """Execute the action."""
         context.register_event_handler(self.__event_handler)
+
+    def describe_conditional_sub_entities(self) -> List[Tuple[
+        Text,  # text description of the condition
+        Iterable[LaunchDescriptionEntity],  # list of conditional sub-entities
+    ]]:
+        event_handler_description = self.__event_handler.describe()
+        return [
+            (event_handler_description[0], event_handler_description[1])
+        ] if event_handler_description[1] else []

--- a/launch/test/launch/actions/test_register_unregister_event_handler.py
+++ b/launch/test/launch/actions/test_register_unregister_event_handler.py
@@ -14,6 +14,7 @@
 
 """Tests for the RegisterEventHandler and UnregisterEventHandler action classes."""
 
+from launch import Action
 from launch import EventHandler
 from launch import LaunchContext
 from launch.actions import RegisterEventHandler
@@ -56,3 +57,24 @@ def test_unregister_event_handler_constructor():
     event_handler = EventHandler(matcher=lambda: True)
     unregister_event_handler_action = UnregisterEventHandler(event_handler)
     assert event_handler == unregister_event_handler_action.event_handler
+
+
+def test_register_event_handler_description():
+    """Test that describe_sub_entities and describe_conditional_sub_entities methods behave."""
+    action = Action()
+    action2 = Action()  # Sanity Check - not part of the event handler
+    event_handler = EventHandler(
+        matcher=lambda: True,
+        entities=[action]
+    )
+    action_under_test = RegisterEventHandler(event_handler)
+    assert action_under_test.describe_sub_entities() == []
+
+    # There should be a single condition described
+    assert len(action_under_test.describe_conditional_sub_entities()) == 1
+
+    # Get the condition tuple of (Text, [LaunchDescriptionEntity])
+    condition = action_under_test.describe_conditional_sub_entities()[0]
+    assert condition[1] != []
+    assert action in condition[1]
+    assert action2 not in condition[1]

--- a/launch_testing/launch_testing/event_handlers/stdout_ready_listener.py
+++ b/launch_testing/launch_testing/event_handlers/stdout_ready_listener.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
 from typing import Optional
 from typing import Text
+from typing import Tuple
 
 from launch.actions import ExecuteProcess
 from launch.event_handlers import OnProcessIO
@@ -47,3 +49,11 @@ class StdoutReadyListener(OnProcessIO):
     def __on_stdout(self, process_io):
         if self.__ready_txt in process_io.text.decode():
             return self.__actions
+
+    def describe(self) -> Tuple[Text, List[SomeActionsType]]:
+        """Return the description list with 0 as a string, and then LaunchDescriptionEntity's."""
+        description = super().describe()[0]
+        return (
+            description,
+            self.__actions
+        )

--- a/launch_testing/test/launch_testing/test_stdout_ready_listener.py
+++ b/launch_testing/test/launch_testing/test_stdout_ready_listener.py
@@ -113,3 +113,21 @@ class TestStdoutReadyListener(unittest.TestCase):
 
         # We should not get confused by output that doesn't match the ready_txt
         self.assertNotIn('ok', data)
+
+
+def test_description():
+    target_action = launch.actions.ExecuteProcess(cmd='dummy')
+    included_action = launch.Action()
+    not_included_action = launch.Action()
+
+    dut = StdoutReadyListener(
+        target_action=target_action,
+        ready_txt='test text',
+        actions=[
+            included_action
+        ]
+    )
+
+    description = dut.describe()
+    assert description[1] == [included_action]
+    assert not_included_action not in description[1]  # Sanity check


### PR DESCRIPTION
 * Make the RegisterEventHandler action return a description of its conditional sub-entities
 * Also wire up the correct description method for the launch_testing
stdout ready listener event handler

This is needed so that launch_testing can find a ReadyToTest action that's conditional on seeing some stdout from one of the processes under test

Signed-off-by: Pete Baughman <peter.c.baughman@gmail.com>

  - Closes issue 385