### PR TITLE
 Remove unnecessary overloads 

### DIFF
--- a/launch/launch/event_handlers/on_execution_complete.py
+++ b/launch/launch/event_handlers/on_execution_complete.py
@@ -17,8 +17,8 @@ from typing import Callable
 from typing import cast
 from typing import List  # noqa
 from typing import Optional
-from typing import overload
 from typing import Text
+from typing import Union
 
 from ..event import Event
 from ..event_handler import EventHandler
@@ -36,28 +36,13 @@ class OnExecutionComplete(EventHandler):
     or to handle them all.
     """
 
-    @overload
-    def __init__(
-        self, *,
-        target_action: Optional['Action'] = None,
-        on_completion: SomeActionsType,
-        **kwargs
-    ) -> None:
-        """Overload which takes just actions."""
-        ...
-
-    @overload  # noqa: F811
     def __init__(
         self,
         *,
         target_action: Optional['Action'] = None,
-        on_completion: Callable[[int], Optional[SomeActionsType]],
+        on_completion: Union[SomeActionsType, Callable[[int], Optional[SomeActionsType]]],
         **kwargs
     ) -> None:
-        """Overload which takes a callable to handle completion."""
-        ...
-
-    def __init__(self, *, target_action=None, on_completion, **kwargs) -> None:  # noqa: F811
         """Create an OnExecutionComplete event handler."""
         from ..action import Action  # noqa
         if not isinstance(target_action, (Action, type(None))):

--- a/launch/launch/event_handlers/on_shutdown.py
+++ b/launch/launch/event_handlers/on_shutdown.py
@@ -17,9 +17,9 @@
 from typing import Callable
 from typing import cast
 from typing import Optional
-from typing import overload
 from typing import Text
 from typing import TYPE_CHECKING
+from typing import Union
 
 from ..event import Event
 from ..event_handler import BaseEventHandler
@@ -34,22 +34,13 @@ if TYPE_CHECKING:
 class OnShutdown(BaseEventHandler):
     """Convenience class for handling the launch shutdown event."""
 
-    @overload
-    def __init__(self, *, on_shutdown: SomeActionsType, **kwargs) -> None:
-        """Overload which takes just actions."""
-        ...
-
-    @overload  # noqa: F811
     def __init__(
         self,
         *,
-        on_shutdown: Callable[[Shutdown, 'LaunchContext'], Optional[SomeActionsType]],
+        on_shutdown: Union[SomeActionsType,
+                           Callable[[Shutdown, 'LaunchContext'], Optional[SomeActionsType]]],
         **kwargs
     ) -> None:
-        """Overload which takes a callable to handle the shutdown."""
-        ...
-
-    def __init__(self, *, on_shutdown, **kwargs):  # noqa: F811
         """Create an OnShutdown event handler."""
         super().__init__(
             matcher=lambda event: is_a_subclass(event, Shutdown),


### PR DESCRIPTION
For some reason, overloaded methods should also have a noqa comment on first line of the method in
addition to the overload decorator.