### PR TITLE
Add delay parameter to retry_on_failure decorator

### DIFF
--- a/launch_testing/launch_testing/markers.py
+++ b/launch_testing/launch_testing/markers.py
@@ -26,12 +26,13 @@ def keep_alive(test_description):
     return test_description
 
 
-def retry_on_failure(*, times, delay=0.0):
+def retry_on_failure(*, times, delay=None):
     """
     Mark a test case to be retried up to `times` on AssertionError.
 
     :param times: The number of times to rety the test.
     :param delay: The time to wait between retries, in seconds.
+      A value of None will result in zero delay.
     """
     assert times > 0
 
@@ -51,7 +52,8 @@ def retry_on_failure(*, times, delay=0.0):
                     self._outcome.errors.clear()
                     self._outcome.success = True
                     n -= 1
-                time.sleep(delay)
+                if delay is not None:
+                    time.sleep(delay)
             return func(self, *args, **kwargs)
         return _wrapper
     return _decorator

--- a/launch_testing/launch_testing/markers.py
+++ b/launch_testing/launch_testing/markers.py
@@ -26,7 +26,7 @@ def keep_alive(test_description):
     return test_description
 
 
-def retry_on_failure(*, times, delay=0.1):
+def retry_on_failure(*, times, delay=0.0):
     """
     Mark a test case to be retried up to `times` on AssertionError.
 

--- a/launch_testing/launch_testing/markers.py
+++ b/launch_testing/launch_testing/markers.py
@@ -14,6 +14,7 @@
 
 import functools
 import inspect
+import time
 import unittest
 
 
@@ -25,8 +26,13 @@ def keep_alive(test_description):
     return test_description
 
 
-def retry_on_failure(*, times):
-    """Mark a test case to be retried up to `times` on AssertionError."""
+def retry_on_failure(*, times, delay=0.1):
+    """
+    Mark a test case to be retried up to `times` on AssertionError.
+
+    :param times: The number of times to rety the test.
+    :param delay: The time to wait between retries, in seconds.
+    """
     assert times > 0
 
     def _decorator(func):
@@ -45,6 +51,7 @@ def retry_on_failure(*, times):
                     self._outcome.errors.clear()
                     self._outcome.success = True
                     n -= 1
+                time.sleep(delay)
             return func(self, *args, **kwargs)
         return _wrapper
     return _decorator


### PR DESCRIPTION
Also added documentation for the parameters to the docstring.

Motivated by flaky tests in ros2action: https://github.com/ros2/ros2cli/pull/454