### PR TITLE
stop using constructors deprecated in pytest 5.4

### DIFF
--- a/launch_testing/launch_testing/pytest/hooks.py
+++ b/launch_testing/launch_testing/pytest/hooks.py
@@ -110,8 +110,16 @@ def pytest_pycollect_makemodule(path, parent):
         if module is not None:
             return module
     if path.basename == '__init__.py':
-        return pytest.Package(path, parent)
-    return pytest.Module(path, parent)
+        try:
+            # since pytest 5
+            return pytest.Package.from_parent(parent, fspath=path)
+        except AttributeError:
+            return pytest.Package(path, parent)
+    try:
+        # since pytest 5
+        return pytest.Module.from_parent(parent, fspath=path)
+    except AttributeError:
+        return pytest.Module(path, parent)
 
 
 @pytest.hookimpl(trylast=True)

--- a/launch_testing/launch_testing/pytest/hooks.py
+++ b/launch_testing/launch_testing/pytest/hooks.py
@@ -111,12 +111,14 @@ def pytest_pycollect_makemodule(path, parent):
             return module
     if path.basename == '__init__.py':
         try:
-            # since pytest 5
+            # since https://docs.pytest.org/en/latest/changelog.html#deprecations
+            # todo: remove fallback once all platforms use pytest >=5.4
             return pytest.Package.from_parent(parent, fspath=path)
         except AttributeError:
             return pytest.Package(path, parent)
     try:
-        # since pytest 5
+        # since https://docs.pytest.org/en/latest/changelog.html#deprecations
+        # todo: remove fallback once all platforms use pytest >=5.4
         return pytest.Module.from_parent(parent, fspath=path)
     except AttributeError:
         return pytest.Module(path, parent)


### PR DESCRIPTION
```
=============================== warnings summary ===============================
/opt/ros/master/install/lib/python3.8/site-packages/launch_testing/pytest/hooks.py:113
/opt/ros/master/install/lib/python3.8/site-packages/launch_testing/pytest/hooks.py:113
  /opt/ros/master/install/lib/python3.8/site-packages/launch_testing/pytest/hooks.py:113: PytestDeprecationWarning: direct construction of Package has been deprecated, please use Package.from_parent
    return pytest.Package(path, parent)

/opt/ros/master/install/lib/python3.8/site-packages/launch_testing/pytest/hooks.py:114: 37 tests with warnings
  /opt/ros/master/install/lib/python3.8/site-packages/launch_testing/pytest/hooks.py:114: PytestDeprecationWarning: direct construction of Module has been deprecated, please use Module.from_parent
    return pytest.Module(path, parent)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================= 324 passed, 39 warnings in 66.09s (0:01:06) ==================
```
