### PR TITLE
Suppress flake8 A003 warning

### DIFF
--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -121,7 +121,7 @@ class LaunchContext:
         return self._get_combined_locals()
 
     @property  # noqa: A003
-    def locals(self):
+    def locals(self):  # noqa: A003
         """Getter for the locals."""
         class AttributeDict:
 


### PR DESCRIPTION
The warning was previously being suppressed at the decorator line, but it
appears an update to one of the flake8 dependencies now requires a
suppression comment to be on the same line as the violation.