### PR TITLE
fixed depcrecation warning of imp to importlib (issue #387)

### DIFF
--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -24,7 +24,8 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    module = importlib.util.module_from_spec('test_module')
+    test_spec = importlib.util.spec_from_loader('test_module', loader=None)
+    module = importlib.util.module_from_spec(test_spec)
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
+import importlib
 import unittest
 
 import launch
@@ -24,7 +24,7 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    module = imp.new_module('test_module')
+    module = importlib.util.module_from_spec('test_module')
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 


### PR DESCRIPTION
This is a fix for the second deprecation warning that dirk found in issue #387 . I'm still trying to figure out the first.