### PR TITLE
wait_for_ouput() repr includes actual text

### DIFF
--- a/launch_testing/launch_testing/tools/process.py
+++ b/launch_testing/launch_testing/tools/process.py
@@ -85,6 +85,7 @@ class ProcessProxy:
             return actual_output
 
         class BoolWithText:
+
             def __init__(self, result, output):
                 self._result = result
                 self._output = output


### PR DESCRIPTION
This makes `wait_for_output()` return an object that still evaluates as
a bool, but when `repr()`'d it includes the actual text. This will help
debug a few test failures on the build farm caused by expected output
not being seen.

@jacobperron review-requested because I would like to get this into foxy to help debug test failures on the build farm, though I could see how this could be considered changing an API. I think it's safe because the returned object still evaluates `True` as `False`. Thoughts?