### PR TITLE
removed deprecated loop parameter call (#387)

### DIFF
--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -81,7 +81,6 @@ class TimerAction(Action):
     async def __wait_to_fire_event(self, context):
         done, pending = await asyncio.wait(
             [self.__canceled_future],
-            loop=context.asyncio_loop,
             timeout=float(perform_substitutions(context, self.__period)),
         )
         if not self.__canceled_future.done():

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -24,7 +24,8 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    module = importlib.util.module_from_spec('test_module')
+    test_spec = importlib.util.spec_from_loader('test_module', loader=None)
+    module = importlib.util.module_from_spec(test_spec)
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
+import importlib
 import unittest
 
 import launch
@@ -24,7 +24,7 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    module = imp.new_module('test_module')
+    module = importlib.util.module_from_spec('test_module')
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 


### PR DESCRIPTION
According to the [documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait). Two things are deprecated by Python 3.10: the use of coroutines and the `loop` parameter. Since the first parameter is an `asyncio.Future`, we don't have to worry about the first one. For the second, I just removed the use of the `loop` parameter and it passed all the `pytest` unit tests. If merged, I believe this should close issue #387 .