### PR TITLE
removed deprecated loop parameter call (#387)

### DIFF
--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -81,7 +81,6 @@ class TimerAction(Action):
     async def __wait_to_fire_event(self, context):
         done, pending = await asyncio.wait(
             [self.__canceled_future],
-            loop=context.asyncio_loop,
             timeout=float(perform_substitutions(context, self.__period)),
         )
         if not self.__canceled_future.done():

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -174,7 +174,7 @@ class LaunchService:
                 # Set the asyncio loop for the context.
                 self.__context._set_asyncio_loop(this_loop)
                 # Recreate the event queue to ensure the same event loop is being used.
-                new_queue = asyncio.Queue(loop=this_loop)
+                new_queue = asyncio.Queue()
                 while True:
                     try:
                         new_queue.put_nowait(self.__context._event_queue.get_nowait())
@@ -351,7 +351,6 @@ class LaunchService:
                         while not done:
                             done, pending = await asyncio.wait(
                                 entity_futures,
-                                loop=this_loop,
                                 timeout=1.0,
                                 return_when=asyncio.FIRST_COMPLETED
                             )

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -158,7 +158,7 @@ class LaunchService:
         return number_of_entity_future_pairs == 0 and self.__context._event_queue.empty()
 
     @contextlib.contextmanager
-    def _prepare_run_loop(self, loop):
+    def _prepare_run_loop(self):
         try:
             # Acquire the lock and initialize the loop.
             with self.__loop_from_run_thread_lock:
@@ -166,7 +166,7 @@ class LaunchService:
                     raise RuntimeError(
                         'LaunchService cannot be run multiple times concurrently.'
                     )
-                this_loop = asyncio.get_event_loop() if loop is None else loop
+                this_loop = asyncio.get_event_loop()
 
                 if self.__debug:
                     this_loop.set_debug(True)
@@ -299,7 +299,7 @@ class LaunchService:
                 #     'launch.LaunchService',
                 #     "processing event: '{}' x '{}'".format(event, event_handler))
 
-    async def run_async(self, *, shutdown_when_idle=True, loop=None) -> int:
+    async def run_async(self, *, shutdown_when_idle=True) -> int:
         """
         Visit all entities of all included LaunchDescription instances asynchronously.
 
@@ -318,7 +318,7 @@ class LaunchService:
             )
 
         return_code = 0
-        with self._prepare_run_loop(loop) as (this_loop, this_task):
+        with self._prepare_run_loop() as (this_loop, this_task):
             # Log logging configuration details.
             launch.logging.log_launch_config(logger=self.__logger)
 
@@ -388,7 +388,7 @@ class LaunchService:
         """
         loop = osrf_pycommon.process_utils.get_loop()
         run_async_task = loop.create_task(self.run_async(
-            shutdown_when_idle=shutdown_when_idle, loop=loop
+            shutdown_when_idle=shutdown_when_idle
         ))
         loop.run_until_complete(run_async_task)
         return run_async_task.result()

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -24,7 +24,8 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    module = importlib.util.module_from_spec('test_module')
+    test_spec = importlib.util.spec_from_loader('test_module', loader=None)
+    module = importlib.util.module_from_spec(test_spec)
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -24,8 +24,7 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    test_spec = importlib.util.spec_from_loader('test_module', loader=None)
-    module = importlib.util.module_from_spec(test_spec)
+    module = importlib.util.module_from_spec('test_module')
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
+import importlib
 import unittest
 
 import launch
@@ -24,7 +24,7 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    module = imp.new_module('test_module')
+    module = importlib.util.module_from_spec('test_module')
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
+import imp
 import unittest
 
 import launch
@@ -24,7 +24,7 @@ from launch_testing.test_runner import LaunchTestRunner
 
 
 def make_test_run_for_dut(generate_test_description_function):
-    module = importlib.util.module_from_spec('test_module')
+    module = imp.new_module('test_module')
     module.generate_test_description = generate_test_description_function
     return LoadTestsFromPythonModule(module)
 


### PR DESCRIPTION
According to the [documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait). Two things are deprecated by Python 3.10: the use of coroutines and the `loop` parameter. Since the first parameter is an `asyncio.Future`, we don't have to worry about the first one. For the second, I just removed the use of the `loop` parameter.

The other deprecation warning raised during testing comes from the use of `asyncio.Queue()`. The [docs](https://docs.python.org/3/library/asyncio-queue.html#asyncio.Queue) state that the loop parameter is deprecated, so it can be removed without issue. Finally, the last deprecation warning came from the use of `asyncio.wait()` that tried to use `loop=` parameter and was simply removed.

Removing these still had `launch` pass all unit testing with `pytest`. If merged, I believe this should close issue #387 .
