### PR TITLE
Fix up parser.py

### DIFF
--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Rover Robotics, c/o Dan Rose
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +15,16 @@
 
 """Module for Parser class and parsing methods."""
 
-import io
-import os
+import os.path
 from typing import Any
 from typing import List
 from typing import Optional
 from typing import Text
+from typing import TextIO
 from typing import Tuple
 from typing import Type
 from typing import Union
+from typing import TYPE_CHECKING
 
 from pkg_resources import iter_entry_points
 
@@ -33,21 +35,21 @@ from .parse_substitution import replace_escaped_characters
 from ..action import Action
 from ..invalid_launch_file_error import InvalidLaunchFileError
 from ..some_substitutions_type import SomeSubstitutionsType
-from ..utilities import is_a
 
 interpolation_fuctions = {
     entry_point.name: entry_point.load()
     for entry_point in iter_entry_points('launch.frontend.interpolate_substitution_method')
 }
 
-if False:
-    from ..launch_description import LaunchDescription  # noqa: F401
+
+if TYPE_CHECKING:
+    from ..launch_description import LaunchDescription
 
 
 class InvalidFrontendLaunchFileError(InvalidLaunchFileError):
     """Exception raised when the given frontend launch file is not valid."""
 
-    ...
+    pass
 
 
 class Parser:
@@ -132,7 +134,7 @@ class Parser:
     @classmethod
     def load(
         cls,
-        file: Union[str, io.TextIOBase],
+        file: Union[Text, TextIO],
     ) -> (Entity, 'Parser'):
         """
         Parse an Entity from a markup language-based launch file.
@@ -145,28 +147,33 @@ class Parser:
         # Imported here, to avoid recursive import.
         cls.load_parser_implementations()
 
-        def get_key(extension):
-            def key(x):
-                return x[0] != extension
-            return key
-        exceptions = []
-        extension = ''
-        if is_a(file, str):
-            extension = file
-        elif hasattr(file, 'name'):
-            extension = file.name
-        extension = os.path.splitext(extension)[1]
-        if extension:
-            extension = extension[1:]
-        for (frontend_name, implementation) in sorted(
-            cls.frontend_parsers.items(), key=get_key(extension)
-        ):
-            try:
-                return implementation.load(file)
-            except Exception as ex:
-                if is_a(file, io.TextIOBase):
-                    file.seek(0)
+        try:
+            fileobj = open(file, 'r')
+            didopen = True
+        except TypeError:
+            fileobj = file
+            didopen = False
+
+        try:
+            # file extension without leading '.'
+            extension = os.path.splitext(fileobj.name)[1][1:]
+
+            implementations = []
+            for k, v in sorted(cls.frontend_parsers.items()):
+                if k == extension:
+                    implementations.insert(0, v)
                 else:
+                    implementations.append(v)
+
+            exceptions = []
+            for implementation in implementations:
+                try:
+                    return implementation.load(fileobj)
+                except Exception as ex:
                     exceptions.append(ex)
-        extension = '' if not cls.is_extension_valid(extension) else extension
-        raise InvalidFrontendLaunchFileError(extension, likely_errors=exceptions)
+                    fileobj.seek(0)
+            extension = '' if not cls.is_extension_valid(extension) else extension
+            raise InvalidFrontendLaunchFileError(extension, likely_errors=exceptions)
+        finally:
+            if didopen:
+                fileobj.close()

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -1,5 +1,5 @@
 # Copyright 2019 Open Source Robotics Foundation, Inc.
-# Copyright 2020 Rover Robotics, c/o Dan Rose
+# Copyright 2020 Open Avatar Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -155,8 +155,9 @@ class Parser:
             didopen = False
 
         try:
+            filename = get_attr(fileobj, 'name', '')
             # file extension without leading '.'
-            extension = os.path.splitext(fileobj.name)[1][1:]
+            extension = os.path.splitext(filename)[1][1:]
 
             implementations = []
             for k, v in sorted(cls.frontend_parsers.items()):

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -155,7 +155,7 @@ class Parser:
             didopen = False
 
         try:
-            filename = get_attr(fileobj, 'name', '')
+            filename = getattr(fileobj, 'name', '')
             # file extension without leading '.'
             extension = os.path.splitext(filename)[1][1:]
 

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -1,5 +1,5 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
 # Copyright 2020 Rover Robotics, c/o Dan Rose
+# Copyright 2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,16 +35,15 @@ from .parse_substitution import replace_escaped_characters
 from ..action import Action
 from ..invalid_launch_file_error import InvalidLaunchFileError
 from ..some_substitutions_type import SomeSubstitutionsType
-from ..utilities.file_path import FilePath
+from ..utilities.typing_file_path import FilePath
+
+if TYPE_CHECKING:
+    from ..launch_description import LaunchDescription
 
 interpolation_fuctions = {
     entry_point.name: entry_point.load()
     for entry_point in iter_entry_points('launch.frontend.interpolate_substitution_method')
 }
-
-
-if TYPE_CHECKING:
-    from ..launch_description import LaunchDescription
 
 
 class InvalidFrontendLaunchFileError(InvalidLaunchFileError):
@@ -160,12 +159,10 @@ class Parser:
             # file extension without leading '.'
             extension = os.path.splitext(filename)[1][1:]
 
-            implementations = []
-            for k, v in sorted(cls.frontend_parsers.items()):
-                if k == extension:
-                    implementations.insert(0, v)
-                else:
-                    implementations.append(v)
+            sorted_parsers = sorted(cls.frontend_parsers.items())
+            implementations = [v for k, v in sorted_parsers if k == extension] + [
+                v for k, v in sorted_parsers if k != extension
+            ]
 
             exceptions = []
             for implementation in implementations:

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -1,5 +1,5 @@
-# Copyright 2020 Rover Robotics, c/o Dan Rose
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Rover Robotics, c/o Dan Rose
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -35,6 +35,7 @@ from .parse_substitution import replace_escaped_characters
 from ..action import Action
 from ..invalid_launch_file_error import InvalidLaunchFileError
 from ..some_substitutions_type import SomeSubstitutionsType
+from ..utilities.file_path import FilePath
 
 interpolation_fuctions = {
     entry_point.name: entry_point.load()
@@ -134,7 +135,7 @@ class Parser:
     @classmethod
     def load(
         cls,
-        file: Union[Text, TextIO],
+        file: Union[FilePath, TextIO],
     ) -> (Entity, 'Parser'):
         """
         Parse an Entity from a markup language-based launch file.

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -23,8 +23,8 @@ from typing import Text
 from typing import TextIO
 from typing import Tuple
 from typing import Type
-from typing import Union
 from typing import TYPE_CHECKING
+from typing import Union
 
 from pkg_resources import iter_entry_points
 

--- a/launch/launch/utilities/file_path.py
+++ b/launch/launch/utilities/file_path.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Rover Robotics, c/o Dan Rose
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import typing
+
+# Type of a filesystem path
+FilePath = typing.Union[str, bytes, os.PathLike]

--- a/launch/launch/utilities/typing_file_path.py
+++ b/launch/launch/utilities/typing_file_path.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Rover Robotics, c/o Dan Rose
+# Copyright 2020 Open Avatar Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/launch/utilities/typing_file_path.py
+++ b/launch/launch/utilities/typing_file_path.py
@@ -16,4 +16,4 @@ import os
 import typing
 
 # Type of a filesystem path
-FilePath = typing.Union[str, bytes, os.PathLike]
+FilePath = typing.TypeVar('FilePath', str, bytes, os.PathLike)


### PR DESCRIPTION
1. *always* pass a file object to parser implementation. Passing a string introduces no extra expressiveness and the file is not guaranteed to be properly closed.
2. Use more Pythonic type detection for whether passed object is a string or a file.
3. Clean up type declarations
4. Clean up parser ordering logic
5. Make parser ordering deterministic
6. Remove use of Ellipsis. It makes the declaration look like a stub.
Signed-off-by: Dan Rose <dan@digilabs.io>