### PR TITLE
Add OnProcessStart callback to defer shutdown when not ready

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -389,7 +389,7 @@ class ExecuteProcess(Action):
 
         if self.process_details is None or self._subprocess_transport is None:
             # Skip shutting down if the process is not ready
-            context.register_event_handler(OnProcessStart(on_start=self.__deferred_shutdown ))
+            context.register_event_handler(OnProcessStart(on_start=self.__deferred_shutdown))
             return None
 
         self.__shutdown_received = True

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -379,9 +379,6 @@ class ExecuteProcess(Action):
             return self.__on_exit
         return []
 
-    def __deferred_shutdown(self, event, context):
-        return self._shutdown_process(context, send_sigint=True)
-
     def _shutdown_process(self, context, *, send_sigint):
         if self.__shutdown_received:
             # Do not handle shutdown more than once.
@@ -389,7 +386,10 @@ class ExecuteProcess(Action):
 
         if self.process_details is None or self._subprocess_transport is None:
             # Skip shutting down if the process is not ready
-            context.register_event_handler(OnProcessStart(on_start=self.__deferred_shutdown))
+            context.register_event_handler(
+                OnProcessStart(
+                    on_start=lambda event, context:
+                    self._shutdown_process(context, send_sigint=send_sigint)))
             return None
 
         self.__shutdown_received = True


### PR DESCRIPTION
Should close #418 and [demos#438](https://github.com/ros2/demos/issues/438).

The problem is generated when a shutdown condition reaches a process started by launch, that doesn't have its transport available. The exception is generated in the `execute_process.py` file:
https://github.com/ros2/launch/blob/3a6bde714a402121aeb64147ac3b2c8a172af79c/launch/launch/actions/execute_process.py#L421

As the processes are not available to receive the `shutdown` event, my proposed solution is to add a handler to call the shutdown procedure when the process(es) start executing. 

The exceptions generated there are not catched by the launch system, which might require further addressing.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>