### PR TITLE
Remove the asyncio.wait loop parameter.

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -772,7 +772,6 @@ class ExecuteProcess(Action):
                 # to make sure `ros2 launch` exit in time
                 await asyncio.wait(
                     [asyncio.sleep(self.__respawn_delay), self.__shutdown_future],
-                    loop=context.asyncio_loop,
                     return_when=asyncio.FIRST_COMPLETED
                 )
             if not self.__shutdown_future.done():


### PR DESCRIPTION
This has been deprecated for quite a long time, but Python 3.8
is now showing warnings about it.  Just remove it here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

The warning that this gets rid of looks like:

```
  /home/ubuntu/ros2_ws/src/ros2/launch/launch/launch/actions/execute_process.py:758: DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
    await asyncio.wait(

```

One thing I'll point out is that I don't know if this is *exactly* the same as what was there before.  Looking into the Python code, if the loop parameter is None (the default), then it just gets the currently running loop and adds this `wait` to that.  But its not entirely clear to me that the currently running loop is `context.asyncio_loop`.  The tests pass, but I'm not sure if that is enough.  Looking for review from people with more expertise in this to say for sure.