### PR TITLE
Remove pkg_resources.

### DIFF
--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -26,7 +26,7 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
-from pkg_resources import iter_entry_points
+import importlib_metadata
 
 from .entity import Entity
 from .expose import instantiate_action
@@ -40,9 +40,10 @@ from ..utilities.typing_file_path import FilePath
 if TYPE_CHECKING:
     from ..launch_description import LaunchDescription
 
-interpolation_fuctions = {
+interpolation_functions = {
     entry_point.name: entry_point.load()
-    for entry_point in iter_entry_points('launch.frontend.interpolate_substitution_method')
+    for entry_point in importlib_metadata.entry_points().get(
+            'launch.frontend.interpolate_substitution_method', [])
 }
 
 
@@ -68,7 +69,8 @@ class Parser:
     def load_launch_extensions(cls):
         """Load launch extensions, in order to get all the exposed substitutions and actions."""
         if cls.extensions_loaded is False:
-            for entry_point in iter_entry_points('launch.frontend.launch_extension'):
+            for entry_point in importlib_metadata.entry_points().get(
+                    'launch.frontend.launch_extension', []):
                 entry_point.load()
             cls.extensions_loaded = True
 
@@ -78,7 +80,8 @@ class Parser:
         if cls.frontend_parsers is None:
             cls.frontend_parsers = {
                 entry_point.name: entry_point.load()
-                for entry_point in iter_entry_points('launch.frontend.parser')
+                for entry_point in importlib_metadata.entry_points().get(
+                        'launch.frontend.parser', [])
             }
 
     def parse_action(self, entity: Entity) -> (Action, Tuple[Any]):

--- a/launch/package.xml
+++ b/launch/package.xml
@@ -10,6 +10,7 @@
   <depend>osrf_pycommon</depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-lark-parser</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Replace it with the use of the more modern importlib*
libraries.  There are a couple of reasons to do this:

1.  pkg_resources is quite slow to import; on my machine,
just firing up the python interpreter takes ~35ms, while
firing up the python interpreter and importing pkg_resources
takes ~175ms.  Firing up the python interpreter and importing
importlib_metadata takes ~70ms.  Removing 100ms per invocation
of the command-line both makes it speedier for users, and
will speed up our tests (which call out to the command-line
quite a lot).

2.  pkg_resources is somewhat deprecated and being replaced
by importlib.  https://importlib-metadata.readthedocs.io/en/latest/using.html
describes some of it

Note: By itself, this change is not enough to completely remove our
dependence on pkg_resources.  We'll also have to do something about
the console_scripts that setup.py generates.  That will be
a separate effort.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

See ros2/ros2#919 for a lot more details on why we want to do this.