### PR TITLE
avoid side effect, defer until needed

### DIFF
--- a/launch/launch/frontend/parse_substitution.py
+++ b/launch/launch/frontend/parse_substitution.py
@@ -107,7 +107,8 @@ def parse_substitution(string_value):
         # Grammar cannot deal with zero-width expressions.
         return [TextSubstitution(text=string_value)]
     if _parser is None:
-        _parser = Lark.open(get_grammar_path(), start='template')
+        with open(get_grammar_path(), 'r') as h:
+            _parser = Lark(h, start='template')
     tree = _parser.parse(string_value)
     transformer = ExtractSubstitution()
     return transformer.transform(tree)

--- a/launch/launch/frontend/parse_substitution.py
+++ b/launch/launch/frontend/parse_substitution.py
@@ -93,14 +93,21 @@ class ExtractSubstitution(Transformer):
     double_quoted_template = template
 
 
-grammar_file = os.path.join(get_package_share_directory('launch'), 'frontend', 'grammar.lark')
-parser = Lark.open(grammar_file, start='template')
-transformer = ExtractSubstitution()
+def get_grammar_path():
+    return os.path.join(
+        get_package_share_directory('launch'), 'frontend', 'grammar.lark')
+
+
+_parser = None
 
 
 def parse_substitution(string_value):
+    global _parser
     if not string_value:
         # Grammar cannot deal with zero-width expressions.
         return [TextSubstitution(text=string_value)]
-    tree = parser.parse(string_value)
+    if _parser is None:
+        _parser = Lark.open(get_grammar_path(), start='template')
+    tree = _parser.parse(string_value)
+    transformer = ExtractSubstitution()
     return transformer.transform(tree)


### PR DESCRIPTION
This avoids looking for and parsing the grammar on module load time. Instead it is deferred until when the parser is needed the first time.

As a side effect (pun intended) this fixes ros-visualization/rqt#230: https://ci.ros2.org/view/nightly/job/nightly_win_rel/1591/testReport/(root)/projectroot/rqt_py_common/

CI builds testing `launch` and above:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11285)](http://ci.ros2.org/job/ci_linux/11285/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6534)](http://ci.ros2.org/job/ci_linux-aarch64/6534/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9235)](http://ci.ros2.org/job/ci_osx/9235/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11190)](http://ci.ros2.org/job/ci_windows/11190/) (unrelated test failures)