### PR TITLE
Delete unnecessary loading of 'launch.frontend.interpolate_substitution_method' entry point that was never used

### DIFF
--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -40,12 +40,6 @@ from ..utilities.typing_file_path import FilePath
 if TYPE_CHECKING:
     from ..launch_description import LaunchDescription
 
-interpolation_functions = {
-    entry_point.name: entry_point.load()
-    for entry_point in importlib_metadata.entry_points().get(
-            'launch.frontend.interpolate_substitution_method', [])
-}
-
 
 class InvalidFrontendLaunchFileError(InvalidLaunchFileError):
     """Exception raised when the given frontend launch file is not valid."""


### PR DESCRIPTION
I think the original idea was to have a way of overloading the default substitution interpolation method (i.e. use sth different than `$()` notation), but custom parsers can already override `parse_substitution` method:

https://github.com/ros2/launch/blob/db2a421710a3d830674257dc222def241b656754/launch/launch/frontend/parser.py#L92
https://github.com/ros2/launch/blob/db2a421710a3d830674257dc222def241b656754/launch/launch/frontend/parser.py#L78-L85

I think I forgot deleting the loading of this entry points of the original code, because it doesn't make sense.