### PR TITLE
Use unittest.TestCase.id() to put together jUnit XML output.

### DIFF
--- a/launch_testing/launch_testing/junitxml.py
+++ b/launch_testing/launch_testing/junitxml.py
@@ -83,9 +83,10 @@ def unittestCaseToXml(test_result, test_case):
     class needs to be a launch_testing.TestResult class
     """
     case_xml = ET.Element('testcase')
-    full_classname = type(test_case).__module__ + '.' + type(test_case).__name__
+    full_methodname, _, qualifiers = test_case.id().partition(' ')
+    full_classname, _, methodname = full_methodname.rpartition('.')
     case_xml.set('classname', full_classname)
-    case_xml.set('name', test_case._testMethodName)
+    case_xml.set('name', (methodname + ' ' + qualifiers).strip())
     case_xml.set('time', str(round(test_result.testTimes[test_case], 3)))
 
     for failure in test_result.failures:

--- a/launch_testing/test/launch_testing/test_xml_output.py
+++ b/launch_testing/test/launch_testing/test_xml_output.py
@@ -86,6 +86,8 @@ class TestXmlFunctions(unittest.TestCase):
         class TestHost(unittest.TestCase):
             pass
 
+        TestHost.__qualname__ = 'TestHost'  # as if it was defined in global scope
+
         for n, test_case in enumerate(test_case_list):
             setattr(TestHost, 'test_{}'.format(n), test_case)
 


### PR DESCRIPTION
Precisely what the title says. This is particularly important if using `unittest.TestCase.subTest()` or otherwise a generic name is all you get (see [an example](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/1602/testReport/junit/ros2topic.ros2topic.test/test_echo_pub/test_echo_pub/)).