### PR TITLE
find Python debug interpreter on Windows

### DIFF
--- a/launch_testing_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ament_cmake/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(launch_testing_ament_cmake NONE)
+project(launch_testing_ament_cmake)
 
 find_package(ament_cmake REQUIRED)
 
@@ -23,6 +23,10 @@ if(BUILD_TESTING)
   if(NOT LAUNCH_TESTING_INSTALL_PREFIX)
       message(FATAL_ERROR "launch_testing package not found")
   endif()
+
+  # Provides PYTHON_EXECUTABLE_DEBUG
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
 
   # Test argument passing.  This test won't pass unless you give it an argument
   add_launch_test(

--- a/launch_testing_ament_cmake/package.xml
+++ b/launch_testing_ament_cmake/package.xml
@@ -15,6 +15,7 @@
 
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>launch_testing</test_depend>
+  <test_depend>python_cmake_module</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Fix a test which has been failing on Windows debug since it was added in #236: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11275)](https://ci.ros2.org/job/ci_windows/11275/)

The same logic already happens in the CMake extra file of the package (https://github.com/ros2/launch/blob/a489de4b890bb2f479fa9a924580d93a8cbce060/launch_testing_ament_cmake/launch_testing_ament_cmake-extras.cmake#L16-L18) but isn't available when the test within the package is run.

Windows debug build testing `launch_testing_ament_cmake`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11284)](https://ci.ros2.org/job/ci_windows/11284/)