### PR TITLE
fix max() with empty sequence

### DIFF
--- a/launch_testing/launch_testing/pytest/hooks.py
+++ b/launch_testing/launch_testing/pytest/hooks.py
@@ -38,11 +38,12 @@ class LaunchTestFailureRepr:
     """A `_pytest._code.code.ExceptionReprChain`-like object."""
 
     def __init__(self, failures):
-        max_length = max(
-            len(line)
+        lines = [
+            line
             for _, error_description in failures
             for line in error_description.splitlines()
-        )
+        ]
+        max_length = max(len(line) for line in lines) if lines else 3
         thick_sep_line = '=' * max_length
         thin_sep_line = '-' * max_length
         self._fulldescr = '\n' + '\n\n'.join([


### PR DESCRIPTION
The nightly Windows builds are failing during the tests of `ros2bag` with the following internal error in `pytest`:

```
INTERNALERROR> Traceback (most recent call last):
...
INTERNALERROR>   File "C:\ci\ws\install\Lib\site-packages\launch_testing\pytest\hooks.py", line 41, in __init__
INTERNALERROR>     max_length = max(
INTERNALERROR> ValueError: max() arg is an empty sequence
```

I can't say *why* the sequence is empty in this case, But this patch fixes the logic to handle that case.

Windows build: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11393)](https://ci.ros2.org/job/ci_windows/11393/)