### PR TITLE
Refactor launch service run_async loop to wait on futures and queued events

### DIFF
--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -182,6 +182,7 @@ class LaunchContext:
 
     def emit_event_sync(self, event: Event) -> None:
         """Emit an event synchronously."""
+        self.__logger.debug("emitting event synchronously: '{}'".format(event.name))
         with self._event_queue_lock:
             self._event_queue.put_nowait(event)
 

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import collections
-from threading import Lock
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -43,7 +42,6 @@ class LaunchContext:
         self.__argv = argv if argv is not None else []
 
         self._event_queue = asyncio.Queue()  # type: asyncio.Queue
-        self._event_queue_lock = Lock()
         self._event_handlers = collections.deque()  # type: collections.deque
         self._completion_futures = []  # type: List[asyncio.Future]
 
@@ -75,15 +73,6 @@ class LaunchContext:
 
     def _set_asyncio_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         self.__asyncio_loop = loop
-
-    def _set_event_queue(self, new_queue: asyncio.Queue) -> None:
-        with self._event_queue_lock:
-            while True:
-                try:
-                    new_queue.put_nowait(self._event_queue.get_nowait())
-                except asyncio.QueueEmpty:
-                    break
-            self._event_queue = new_queue
 
     @property
     def asyncio_loop(self):
@@ -183,24 +172,12 @@ class LaunchContext:
     def emit_event_sync(self, event: Event) -> None:
         """Emit an event synchronously."""
         self.__logger.debug("emitting event synchronously: '{}'".format(event.name))
-        with self._event_queue_lock:
-            self._event_queue.put_nowait(event)
+        self._event_queue.put_nowait(event)
 
     async def emit_event(self, event: Event) -> None:
         """Emit an event."""
-        with self._event_queue_lock:
-            self.__logger.debug("emitting event: '{}'".format(event.name))
-            await self._event_queue.put(event)
-
-    def is_event_queue_empty(self) -> bool:
-        with self._event_queue_lock:
-            return self._event_queue.empty()
-
-    async def get_next_event(self):
-        with self._event_queue_lock:
-            if self._event_queue.empty():
-                return None
-            return await self._event_queue.get()
+        self.__logger.debug("emitting event: '{}'".format(event.name))
+        await self._event_queue.put(event)
 
     def perform_substitution(self, substitution: Substitution) -> Text:
         """Perform substitution on given Substitution."""

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -155,7 +155,7 @@ class LaunchService:
     def _is_idle(self):
         number_of_entity_future_pairs = self._prune_and_count_entity_future_pairs()
         number_of_entity_future_pairs += self._prune_and_count_context_completion_futures()
-        return number_of_entity_future_pairs == 0 and self.__context._event_queue.empty()
+        return number_of_entity_future_pairs == 0 and self.__context.is_event_queue_empty()
 
     @contextlib.contextmanager
     def _prepare_run_loop(self):
@@ -174,13 +174,7 @@ class LaunchService:
                 # Set the asyncio loop for the context.
                 self.__context._set_asyncio_loop(this_loop)
                 # Recreate the event queue to ensure the same event loop is being used.
-                new_queue = asyncio.Queue()
-                while True:
-                    try:
-                        new_queue.put_nowait(self.__context._event_queue.get_nowait())
-                    except asyncio.QueueEmpty:
-                        break
-                self.__context._event_queue = new_queue
+                self.__context._set_event_queue(asyncio.Queue())
 
                 self.__loop_from_run_thread = this_loop
 
@@ -269,8 +263,9 @@ class LaunchService:
                 self.__shutting_down = False
 
     async def _process_one_event(self) -> None:
-        next_event = await self.__context._event_queue.get()
-        await self.__process_event(next_event)
+        next_event = await self.__context.get_next_event()
+        if next_event is not None:
+            await self.__process_event(next_event)
 
     async def __process_event(self, event: Event) -> None:
         self.__logger.debug("processing event: '{}'".format(event))

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -342,6 +342,11 @@ class LaunchService:
 
                     # Stop running if we're shutting down and there's no more work
                     if self.__shutting_down and is_idle:
+                        if (
+                            process_one_event_task is not None and
+                            not process_one_event_task.done()
+                        ):
+                            process_one_event_task.cancel()
                         break
 
                     # Collect futures to wait on

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -363,9 +363,7 @@ class LaunchService:
                             timeout=1.0,
                             return_when=asyncio.FIRST_COMPLETED
                         )
-                        if process_one_event_task in done:
-                            break
-                        elif len(done) == 0:
+                        if (process_one_event_task in done) or len(done) == 0:
                             break
                         entity_futures = set(entity_futures).difference(done)
 

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -350,8 +350,11 @@ class LaunchService:
                         break
 
                     # Collect futures to wait on
-                    entity_futures = [pair[1] for pair in self._entity_future_pairs]
-                    entity_futures.extend(self.__context._completion_futures)
+                    # We only need to wait on futures if there are no events to wait on
+                    entity_futures = []
+                    if self.__context._event_queue.empty():
+                        entity_futures = [pair[1] for pair in self._entity_future_pairs]
+                        entity_futures.extend(self.__context._completion_futures)
 
                     # If the current task is done, create a new task to process any events
                     # in the queue

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -361,16 +361,11 @@ class LaunchService:
                     # Add the process event task to the list of awaitables
                     entity_futures.append(process_one_event_task)
 
-                    # Wait on events and futures until an event is processed or a timeout occurs
-                    while True:
-                        done, pending = await asyncio.wait(
-                            entity_futures,
-                            timeout=1.0,
-                            return_when=asyncio.FIRST_COMPLETED
-                        )
-                        if (process_one_event_task in done) or len(done) == 0:
-                            break
-                        entity_futures = set(entity_futures).difference(done)
+                    # Wait on events and futures
+                    await asyncio.wait(
+                        entity_futures,
+                        return_when=asyncio.FIRST_COMPLETED
+                    )
 
                 except KeyboardInterrupt:
                     continue


### PR DESCRIPTION
Fixes https://github.com/ros2/launch_ros/issues/169

Otherwise, it's possible to run into a race condition between checking for 'idle' and processing events from the queue.

**Edit:**

As described in https://github.com/ros2/launch/pull/449#issuecomment-672209093, we can **not** be idle because we're waiting for futures to complete, but if there are no more events in the queue then we end up blocking forever.

To resolve this corner-case that results in deadlock, this PR refactors the run_async loop such that we concurrently wait on futures and events in the queue.

cc/ @wjwwood 