### PR TITLE
Add pytest.ini so local tests don't display warning (#428)

### DIFF
--- a/launch/pytest.ini
+++ b/launch/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/launch_xml/pytest.ini
+++ b/launch_xml/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/launch_yaml/pytest.ini
+++ b/launch_yaml/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
This should help resolve one of the outstanding failures in ros2/ci#503