### PR TITLE
[foxy backport] Add pytest.ini to test_launch_testing so tests succeed locally. (#431)

### DIFF
--- a/launch/pytest.ini
+++ b/launch/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/launch_xml/pytest.ini
+++ b/launch_xml/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/launch_yaml/pytest.ini
+++ b/launch_yaml/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/test_launch_testing/pytest.ini
+++ b/test_launch_testing/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Backport #431 to Foxy.

This should help resolve one of the outstanding failures in ros2/ci#503