### PR TITLE
Allow configuring logging directory through environment variables

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -43,16 +43,16 @@ def _get_logging_directory():
 
     Uses various environment variables to construct a logging directory path.
 
-    Use $ROS2_LOG_DIR if ROS2_LOG_DIR is set and not empty.
-    Otherwise, use $ROS2_HOME/log, using ~/.ros for ROS2_HOME if not set or if empty.
+    Use $ROS_LOG_DIR if ROS_LOG_DIR is set and not empty.
+    Otherwise, use $ROS_HOME/log, using ~/.ros for ROS_HOME if not set or if empty.
 
     It also expands '~' to the current user's home directory.
 
     :return: the path to the logging directory
     """
-    log_dir = os.environ.get('ROS2_LOG_DIR')
+    log_dir = os.environ.get('ROS_LOG_DIR')
     if not log_dir:
-        log_dir = os.environ.get('ROS2_HOME')
+        log_dir = os.environ.get('ROS_HOME')
         if not log_dir:
             log_dir = os.path.join('~', '.ros')
         log_dir = os.path.join(log_dir, 'log')

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -37,6 +37,28 @@ __all__ = [
 ]
 
 
+def _get_logging_directory():
+    """
+    Get logging directory path.
+
+    Uses various environment variables to construct a logging directory path.
+
+    Use $ROS2_LOG_DIR if ROS2_LOG_DIR is set and not empty.
+    Otherwise, use $ROS2_HOME/log, using ~/.ros for ROS2_HOME if not set or if empty.
+
+    It also expands '~' to the current user's home directory.
+
+    :return: the path to the logging directory
+    """
+    log_dir = os.environ.get('ROS2_LOG_DIR')
+    if not log_dir:
+        log_dir = os.environ.get('ROS2_HOME')
+        if not log_dir:
+            log_dir = os.path.join('~', '.ros')
+        log_dir = os.path.join(log_dir, 'log')
+    return os.path.expanduser(log_dir)
+
+
 def _make_unique_log_dir(*, base_path):
     """
     Make a unique directory for logging.
@@ -93,7 +115,7 @@ class LaunchConfig:
         """Get the current log directory, generating it if necessary."""
         if self._log_dir is None:
             self._log_dir = _make_unique_log_dir(
-                base_path=os.path.join(os.path.expanduser('~'), '.ros/log')
+                base_path=_get_logging_directory()
             )
 
         return self._log_dir

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -46,7 +46,8 @@ def _get_logging_directory():
     Use $ROS_LOG_DIR if ROS_LOG_DIR is set and not empty.
     Otherwise, use $ROS_HOME/log, using ~/.ros for ROS_HOME if not set or if empty.
 
-    It also expands '~' to the current user's home directory.
+    It also expands '~' to the current user's home directory,
+    and normalizes the path, converting the path separator if necessary.
 
     :return: the path to the logging directory
     """
@@ -56,7 +57,7 @@ def _get_logging_directory():
         if not log_dir:
             log_dir = os.path.join('~', '.ros')
         log_dir = os.path.join(log_dir, 'log')
-    return os.path.expanduser(log_dir)
+    return os.path.normpath(os.path.expanduser(log_dir))
 
 
 def _make_unique_log_dir(*, base_path):

--- a/launch/package.xml
+++ b/launch/package.xml
@@ -17,7 +17,6 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>python3-mock</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/launch/package.xml
+++ b/launch/package.xml
@@ -17,6 +17,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-mock</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -304,6 +304,12 @@ def test_get_logging_directory():
     os.environ['ROS_HOME'] = str(fake_ros_home)
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == fake_ros_home_log_dir
+    # Make sure it converts path separators when necessary
+    my_ros_home_raw = '/my/ros/home'
+    my_ros_home_log_dir = str(pathlib.Path(my_ros_home_raw) / 'log')
+    os.environ['ROS_HOME'] = my_ros_home_raw
+    launch.logging.launch_config.log_dir = None
+    assert launch.logging.launch_config.log_dir == my_ros_home_log_dir
     # Empty is considered unset
     os.environ['ROS_HOME'] = ''
     launch.logging.launch_config.log_dir = None

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -275,6 +275,11 @@ def test_get_logging_directory():
     os.environ['ROS_LOG_DIR'] = my_log_dir
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == my_log_dir
+    # Setting ROS_HOME won't change anything since ROS_LOG_DIR is used first
+    os.environ['ROS_HOME'] = '/this/wont/be/used'
+    launch.logging.launch_config.log_dir = None
+    assert launch.logging.launch_config.log_dir == my_log_dir
+    os.environ.pop('ROS_HOME', None)
     # Empty is considered unset
     os.environ['ROS_LOG_DIR'] = ''
     launch.logging.launch_config.log_dir = None

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -267,6 +267,7 @@ def test_get_logging_directory():
 
     # Default case without ROS_LOG_DIR or ROS_HOME being set (but with HOME)
     default_dir = os.path.join(home, '.ros/log')
+    # This ensures that the launch config will check the environment again
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == default_dir
 

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -267,7 +267,7 @@ def test_get_logging_directory():
     assert str(home)
 
     # Default case without ROS_LOG_DIR or ROS_HOME being set (but with HOME)
-    default_dir = str(home.joinpath('.ros/log'))
+    default_dir = str(home / '.ros/log')
     # This ensures that the launch config will check the environment again
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == default_dir
@@ -289,13 +289,13 @@ def test_get_logging_directory():
     # Make sure '~' is expanded to the home directory
     os.environ['ROS_LOG_DIR'] = '~/logdir'
     launch.logging.launch_config.log_dir = None
-    assert launch.logging.launch_config.log_dir == str(home.joinpath('logdir'))
+    assert launch.logging.launch_config.log_dir == str(home / 'logdir')
 
     os.environ.pop('ROS_LOG_DIR', None)
 
     # Without ROS_LOG_DIR, use $ROS_HOME/log
-    fake_ros_home = home.joinpath('.fakeroshome')
-    fake_ros_home_log_dir = str(fake_ros_home.joinpath('log'))
+    fake_ros_home = home / '.fakeroshome'
+    fake_ros_home_log_dir = str(fake_ros_home / 'log')
     os.environ['ROS_HOME'] = str(fake_ros_home)
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == fake_ros_home_log_dir

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -260,46 +260,46 @@ def fake_make_unique_log_dir(*, base_path):
 @mock.patch('launch.logging._make_unique_log_dir', mock.MagicMock(wraps=fake_make_unique_log_dir))
 def test_get_logging_directory():
     launch.logging.launch_config.reset()
-    os.environ.pop('ROS2_LOG_DIR', None)
-    os.environ.pop('ROS2_HOME', None)
+    os.environ.pop('ROS_LOG_DIR', None)
+    os.environ.pop('ROS_HOME', None)
     home = os.environ.get('HOME', None)
     assert home
 
-    # Default case without ROS2_LOG_DIR or ROS2_HOME being set (but with HOME)
+    # Default case without ROS_LOG_DIR or ROS_HOME being set (but with HOME)
     default_dir = os.path.join(home, '.ros/log')
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == default_dir
 
-    # Use $ROS2_LOG_DIR if it is set
-    my_log_dir = '/my/ros2_log_dir'
-    os.environ['ROS2_LOG_DIR'] = my_log_dir
+    # Use $ROS_LOG_DIR if it is set
+    my_log_dir = '/my/ros_log_dir'
+    os.environ['ROS_LOG_DIR'] = my_log_dir
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == my_log_dir
     # Empty is considered unset
-    os.environ['ROS2_LOG_DIR'] = ''
+    os.environ['ROS_LOG_DIR'] = ''
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == default_dir
     # Make sure '~' is expanded to the home directory
-    os.environ['ROS2_LOG_DIR'] = '~/logdir'
+    os.environ['ROS_LOG_DIR'] = '~/logdir'
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == os.path.join(home, 'logdir')
 
-    os.environ.pop('ROS2_LOG_DIR', None)
+    os.environ.pop('ROS_LOG_DIR', None)
 
-    # Without ROS2_LOG_DIR, use $ROS2_HOME/log
+    # Without ROS_LOG_DIR, use $ROS_HOME/log
     fake_ros_home = os.path.join(home, '.fakeroshome')
     fake_ros_home_log_dir = os.path.join(fake_ros_home, 'log')
-    os.environ['ROS2_HOME'] = fake_ros_home
+    os.environ['ROS_HOME'] = fake_ros_home
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == fake_ros_home_log_dir
     # Empty is considered unset
-    os.environ['ROS2_HOME'] = ''
+    os.environ['ROS_HOME'] = ''
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == default_dir
     # Make sure '~' is expanded to the home directory
-    os.environ['ROS2_HOME'] = '~/.fakeroshome'
+    os.environ['ROS_HOME'] = '~/.fakeroshome'
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == fake_ros_home_log_dir
 
-    os.environ.pop('ROS2_HOME', None)
+    os.environ.pop('ROS_HOME', None)
     launch.logging.launch_config.reset()

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -263,11 +263,11 @@ def test_get_logging_directory():
     launch.logging.launch_config.reset()
     os.environ.pop('ROS_LOG_DIR', None)
     os.environ.pop('ROS_HOME', None)
-    home = str(pathlib.Path.home())
-    assert home
+    home = pathlib.Path.home()
+    assert str(home)
 
     # Default case without ROS_LOG_DIR or ROS_HOME being set (but with HOME)
-    default_dir = os.path.join(home, '.ros/log')
+    default_dir = str(home.joinpath('.ros/log'))
     # This ensures that the launch config will check the environment again
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == default_dir
@@ -289,14 +289,14 @@ def test_get_logging_directory():
     # Make sure '~' is expanded to the home directory
     os.environ['ROS_LOG_DIR'] = '~/logdir'
     launch.logging.launch_config.log_dir = None
-    assert launch.logging.launch_config.log_dir == os.path.join(home, 'logdir')
+    assert launch.logging.launch_config.log_dir == str(home.joinpath('logdir'))
 
     os.environ.pop('ROS_LOG_DIR', None)
 
     # Without ROS_LOG_DIR, use $ROS_HOME/log
-    fake_ros_home = os.path.join(home, '.fakeroshome')
-    fake_ros_home_log_dir = os.path.join(fake_ros_home, 'log')
-    os.environ['ROS_HOME'] = fake_ros_home
+    fake_ros_home = home.joinpath('.fakeroshome')
+    fake_ros_home_log_dir = str(fake_ros_home.joinpath('log'))
+    os.environ['ROS_HOME'] = str(fake_ros_home)
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == fake_ros_home_log_dir
     # Empty is considered unset

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import pathlib
 import re
 
 import launch.logging
@@ -262,7 +263,7 @@ def test_get_logging_directory():
     launch.logging.launch_config.reset()
     os.environ.pop('ROS_LOG_DIR', None)
     os.environ.pop('ROS_HOME', None)
-    home = os.environ.get('HOME', None)
+    home = str(pathlib.Path.home())
     assert home
 
     # Default case without ROS_LOG_DIR or ROS_HOME being set (but with HOME)

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -18,10 +18,10 @@ import logging
 import os
 import pathlib
 import re
+from unittest import mock
 
 import launch.logging
 
-import mock
 import pytest
 
 

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -273,8 +273,13 @@ def test_get_logging_directory():
     assert launch.logging.launch_config.log_dir == default_dir
 
     # Use $ROS_LOG_DIR if it is set
-    my_log_dir = '/my/ros_log_dir'
+    my_log_dir_raw = '/my/ros_log_dir'
+    my_log_dir = str(pathlib.Path(my_log_dir_raw))
     os.environ['ROS_LOG_DIR'] = my_log_dir
+    launch.logging.launch_config.log_dir = None
+    assert launch.logging.launch_config.log_dir == my_log_dir
+    # Make sure it converts path separators when necessary
+    os.environ['ROS_LOG_DIR'] = my_log_dir_raw
     launch.logging.launch_config.log_dir = None
     assert launch.logging.launch_config.log_dir == my_log_dir
     # Setting ROS_HOME won't change anything since ROS_LOG_DIR is used first


### PR DESCRIPTION
This allows configuring the logging directory through environment variables using the following logic:

* Use $ROS_LOG_DIR if ROS_LOG_DIR is set and not empty.
* Otherwise, use $ROS_HOME/log, using ~/.ros for ROS_HOME if not set or if empty.

Includes a test.

Perhaps this logic should be moved to `launch_ros` in the future.

Relates to https://github.com/ros2/rcl_logging/issues/50

See also https://github.com/ros2/rcl_logging/pull/53