### PR TITLE
Expose Timer action in launch xml

### DIFF
--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -25,6 +25,7 @@ from typing import Optional
 from typing import Text
 from typing import Tuple
 from typing import Union
+import warnings
 
 import launch.logging
 
@@ -69,6 +70,12 @@ class TimerAction(Action):
         period_types = list(SomeSubstitutionsType_types_tuple) + [float]
         ensure_argument_type(period, period_types, 'period', 'TimerAction')
         ensure_argument_type(actions, collections.abc.Iterable, 'actions', 'TimerAction')
+        if isinstance(period, str):
+            period = float(period)
+            warnings.warn(
+                "The parameter 'period' must be a float or substitution,"
+                'passing a string literal was deprecated',
+                stacklevel=2)
         self.__period = type_utils.normalize_typed_substitution(period, float)
         self.__actions = actions
         self.__context_locals = {}  # type: Dict[Text, Any]

--- a/launch/test/launch/test_timer_action.py
+++ b/launch/test/launch/test_timer_action.py
@@ -34,7 +34,7 @@ def test_multiple_launch_with_timers():
             ),
 
             launch.actions.TimerAction(
-                period='1',
+                period=1.,
                 actions=[
                     launch.actions.Shutdown(reason='Timer expired')
                 ]
@@ -72,7 +72,7 @@ def test_timer_action_sanity_check():
         ),
 
         launch.actions.TimerAction(
-            period='1',
+            period=1.,
             actions=[
                 launch.actions.Shutdown(reason='One second timeout')
             ]
@@ -97,14 +97,14 @@ def test_shutdown_preempts_timers():
         ),
 
         launch.actions.TimerAction(
-            period='1',
+            period=1.,
             actions=[
                 launch.actions.Shutdown(reason='fast shutdown')
             ]
         ),
 
         launch.actions.TimerAction(
-            period='2',
+            period=2.,
             actions=[
                 launch.actions.Shutdown(reason='slow shutdown')
             ]
@@ -130,14 +130,14 @@ def test_timer_can_block_preemption():
         ),
 
         launch.actions.TimerAction(
-            period='1',
+            period=1.,
             actions=[
                 launch.actions.Shutdown(reason='fast shutdown')
             ]
         ),
 
         launch.actions.TimerAction(
-            period='2',
+            period=2.,
             actions=[
                 launch.actions.Shutdown(reason='slow shutdown')
             ],


### PR DESCRIPTION
Example usage:
```xml
<launch>
  <timer period="5">
    <node pkg="turtlesim" exec="turtlesim_node" name="sim"/>
  </timer>
</launch>
```

Other changes:
- `cancel_on_shutdown` now can be a substitution.
- `period` can still be a substitution, but not a string literal (e.g. `TextSubstitution(text='5')` is valid, but '5' isn't).
- Used new `type_utils` functions to handle "typed" substitutions.