### PR TITLE
Validate unparsed attributes and subentities in launch_xml and launch_yaml

### DIFF
--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -106,6 +106,8 @@ class DeclareLaunchArgument(Action):
         parser: 'Parser'
     ):
         """Parse `arg` tag."""
+        entity.assert_attribute_names(('name', 'default', 'description', 'if', 'unless'))
+        entity.assert_no_children()
         _, kwargs = super().parse(entity, parser)
         kwargs['name'] = parser.escape_characters(entity.get_attr('name'))
         default_value = entity.get_attr('default', optional=True)

--- a/launch/launch/actions/declare_launch_argument.py
+++ b/launch/launch/actions/declare_launch_argument.py
@@ -106,8 +106,6 @@ class DeclareLaunchArgument(Action):
         parser: 'Parser'
     ):
         """Parse `arg` tag."""
-        entity.assert_attribute_names(('name', 'default', 'description', 'if', 'unless'))
-        entity.assert_no_children()
         _, kwargs = super().parse(entity, parser)
         kwargs['name'] = parser.escape_characters(entity.get_attr('name'))
         default_value = entity.get_attr('default', optional=True)

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -324,6 +324,12 @@ class ExecuteProcess(Action):
         :param: ignore A list of arguments that should be ignored while parsing.
             Intended for code reuse in derived classes (e.g.: launch_ros.actions.Node).
         """
+        if ignore is None:
+            entity.assert_attribute_names((
+                'cmd', 'cwd', 'name', 'launch-prefix', 'output', 'respawn', 'respawn_delay', 'shell',
+                'additional_env', 'if', 'unless'
+            ))
+            entity.assert_subentity_types(('env', ))
         _, kwargs = super().parse(entity, parser)
 
         if ignore is None:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -324,12 +324,6 @@ class ExecuteProcess(Action):
         :param: ignore A list of arguments that should be ignored while parsing.
             Intended for code reuse in derived classes (e.g.: launch_ros.actions.Node).
         """
-        if ignore is None:
-            entity.assert_attribute_names((
-                'cmd', 'cwd', 'name', 'launch-prefix', 'output', 'respawn', 'respawn_delay', 'shell',
-                'additional_env', 'if', 'unless'
-            ))
-            entity.assert_subentity_types(('env', ))
         _, kwargs = super().parse(entity, parser)
 
         if ignore is None:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -378,12 +378,12 @@ class ExecuteProcess(Action):
             # `unset_enviroment_variable` actions should be used.
             env = entity.get_attr('env', data_type=List[Entity], optional=True)
             if env is not None:
-                env = {
+                kwargs['additional_env'] = {
                     tuple(parser.parse_substitution(e.get_attr('name'))):
                     parser.parse_substitution(e.get_attr('value')) for e in env
                 }
-                kwargs['additional_env'] = env
-
+                for e in env:
+                    e.assert_entity_completely_parsed()
         return cls, kwargs
 
     @property

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -90,6 +90,8 @@ class IncludeLaunchDescription(Action):
                 )
                 for e in args
             ]
+            for e in args:
+                e.assert_entity_completely_parsed()
         return cls, kwargs
 
     @property

--- a/launch/launch/frontend/entity.py
+++ b/launch/launch/frontend/entity.py
@@ -83,7 +83,7 @@ class Entity:
         """
         raise NotImplementedError()
 
-    def assert_entity_complely_parsed(self):
+    def assert_entity_completely_parsed(self):
         """
         Assert that all attributes and children of the entity were parsed.
 

--- a/launch/launch/frontend/entity.py
+++ b/launch/launch/frontend/entity.py
@@ -14,6 +14,7 @@
 
 """Module for Entity class."""
 
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Text
@@ -80,5 +81,31 @@ class Entity:
             Only happens in frontend implementations that do type checking
         :raises `ValueError`: Attribute found but can't be coerced to one of the specified types.
             Only happens in frontend implementations that do type coercion.
+        """
+        raise NotImplementedError()
+
+    def assert_no_children(self):
+        """
+        Assert that this entity doesn't have any nested entity.
+
+        Either this method or `assert_subentity_types` should be used, but not both.
+        :raises `ValueError`: if a nested entity is found.
+        """
+        raise NotImplementedError()
+
+    def assert_subentity_types(self, types: Iterable[str]):
+        """
+        Assert that all subentities are of one of the types specified in `types`.
+
+        Either this method or `assert_subentity_types` should be used, but not both.
+        :raises `ValueError`: if a nested entity of a different type is found.
+        """
+        raise NotImplementedError()
+
+    def assert_attribute_names(self, names: Iterable[str]):
+        """
+        Assert that there are no other attributes than the provided `names`.
+
+        :raises `ValueError`: if an attribute named differently is found.
         """
         raise NotImplementedError()

--- a/launch/launch/frontend/entity.py
+++ b/launch/launch/frontend/entity.py
@@ -14,7 +14,6 @@
 
 """Module for Entity class."""
 
-from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Text
@@ -84,28 +83,11 @@ class Entity:
         """
         raise NotImplementedError()
 
-    def assert_no_children(self):
+    def assert_entity_complely_parsed(self):
         """
-        Assert that this entity doesn't have any nested entity.
+        Assert that all attributes and children of the entity were parsed.
 
-        Either this method or `assert_subentity_types` should be used, but not both.
-        :raises `ValueError`: if a nested entity is found.
-        """
-        raise NotImplementedError()
-
-    def assert_subentity_types(self, types: Iterable[str]):
-        """
-        Assert that all subentities are of one of the types specified in `types`.
-
-        Either this method or `assert_subentity_types` should be used, but not both.
-        :raises `ValueError`: if a nested entity of a different type is found.
-        """
-        raise NotImplementedError()
-
-    def assert_attribute_names(self, names: Iterable[str]):
-        """
-        Assert that there are no other attributes than the provided `names`.
-
-        :raises `ValueError`: if an attribute named differently is found.
+        This function is automatically called after the `parse(entity, parser)`
+        function completed.
         """
         raise NotImplementedError()

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -99,7 +99,7 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
                 )
             )
         if exposed_type == 'action':
-            # For actions, validate that the user didn't provide unkown attributes or children
+            # For actions, validate that the user didn't provide unknown attributes or children
             def wrapper(entity, parser):
                 ret = found_parse_method(entity, parser)
                 entity.assert_entity_complely_parsed()

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -14,6 +14,7 @@
 
 """Module which adds methods for exposing parsing methods."""
 
+import functools
 import inspect
 from typing import Iterable
 from typing import Optional
@@ -99,6 +100,7 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
             )
         if exposed_type == 'action':
             # For actions, validate that the user didn't provide unknown attributes or children
+            @functools.wraps(found_parse_method)
             def wrapper(entity, parser):
                 ret = found_parse_method(entity, parser)
                 entity.assert_entity_completely_parsed()

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -101,7 +101,7 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
             # For actions, validate that the user didn't provide unknown attributes or children
             def wrapper(entity, parser):
                 ret = found_parse_method(entity, parser)
-                entity.assert_entity_complely_parsed()
+                entity.assert_entity_completely_parsed()
                 return ret
             parse_methods_map[name] = wrapper
         else:

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -98,7 +98,15 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
                     name
                 )
             )
-        parse_methods_map[name] = found_parse_method
+        if exposed_type == 'action':
+            # For actions, validate that the user didn't provide unkown attributes or children
+            def wrapper(entity, parser):
+                ret = found_parse_method(entity, parser)
+                entity.assert_entity_complely_parsed()
+                return ret
+            parse_methods_map[name] = wrapper
+        else:
+            parse_methods_map[name] = found_parse_method
         return exposed
     return expose_impl_decorator
 

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -70,7 +70,6 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
         method in the dictionary.
     :param parse_methods_map: a dict where the parsing method will be stored.
     :param exposed_type: A string specifing the parsing function type.
-        Only used for having clearer error log messages.
     """
     # TODO(ivanpauno): Check signature of the registered method/parsing function.
     # TODO(ivanpauno): Infer a parsing function from the constructor annotations.

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -14,6 +14,7 @@
 
 """Module for Entity class."""
 
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Text
@@ -54,6 +55,28 @@ class Entity(BaseEntity):
     def children(self) -> List['Entity']:
         """Get the Entity's children."""
         return [Entity(item) for item in self.__xml_element]
+
+    def assert_no_children(self):
+        if len(self.__xml_element):
+            raise ValueError(
+                f'Entity `{self.type_name}`` should not have any nested entity,'
+                f'but the following were found: {tuple(item.tag for item in self.__xml_element)}'
+            )
+
+    def assert_subentity_types(self, types: Iterable[str]):
+        for item in self.__xml_element:
+            if item.tag not in types:
+                raise ValueError(
+                    f'Found subentity of type `{item.tag}` in a `{self.__xml_element.tag}`, '
+                    f'which expects only the following subentities: {types}'
+                )
+
+    def assert_attribute_names(self, names: Iterable[str]):
+        for attr in self.__xml_element.attrib:
+            if attr not in names:
+                raise ValueError(
+                    f'Found attribute named `{attr}` in `{self.__xml_element.tag}``, '
+                    f'expected one of {names}')
 
     def get_attr(
         self,

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -58,7 +58,7 @@ class Entity(BaseEntity):
         self.__read_children = {item.tag for item in self.__xml_element}
         return [Entity(item) for item in self.__xml_element]
 
-    def assert_entity_complely_parsed(self):
+    def assert_entity_completely_parsed(self):
         unparsed_nested_tags = {item.tag for item in self.__xml_element} - self.__read_children
         if unparsed_nested_tags:
             raise ValueError(

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -62,14 +62,14 @@ class Entity(BaseEntity):
         unparsed_nested_tags = {item.tag for item in self.__xml_element} - self.__read_children
         if unparsed_nested_tags:
             raise ValueError(
-                f'Found the following nested tags of `{self.__xml_element.tag}` that were not '
-                f'parsed: {unparsed_nested_tags}'
+                f'Unexpected nested tag(s) found in `{self.__xml_element.tag}`: '
+                f'{unparsed_nested_tags}'
             )
         unparsed_attributes = set(self.__xml_element.attrib.keys()) - self.__read_attributes
         if unparsed_attributes:
             raise ValueError(
-                f'Found the following attributes of `{self.__xml_element.tag}` that were not '
-                f'parsed: {unparsed_attributes}'
+                f'Unexpected attribute(s) found in `{self.__xml_element.tag}`: '
+                f'{unparsed_attributes}'
             )
 
     def get_attr(

--- a/launch_xml/test/launch_xml/test_arg.py
+++ b/launch_xml/test/launch_xml/test_arg.py
@@ -19,6 +19,8 @@ import textwrap
 
 from launch.frontend import Parser
 
+import pytest
+
 
 def test_arg():
     xml_file = \
@@ -34,3 +36,18 @@ def test_arg():
     assert 'my_arg' == arg.name
     assert 'asd' == ''.join([x.perform(None) for x in arg.default_value])
     assert 'something' == arg.description
+
+
+def test_arg_wrong_attribute():
+    xml_file = \
+        """\
+        <launch>
+            <arg name="my_arg" whats_this="hello" default="asd" description="something"/>
+        </launch>
+        """
+    xml_file = textwrap.dedent(xml_file)
+    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    with pytest.raises(ValueError) as excinfo:
+        parser.parse_description(root_entity)
+    assert '`arg`' in str(excinfo.value)
+    assert '`whats_this`' in str(excinfo.value)

--- a/launch_xml/test/launch_xml/test_arg.py
+++ b/launch_xml/test/launch_xml/test_arg.py
@@ -50,4 +50,4 @@ def test_arg_wrong_attribute():
     with pytest.raises(ValueError) as excinfo:
         parser.parse_description(root_entity)
     assert '`arg`' in str(excinfo.value)
-    assert '`whats_this`' in str(excinfo.value)
+    assert 'whats_this' in str(excinfo.value)

--- a/launch_xml/test/launch_xml/test_arg.py
+++ b/launch_xml/test/launch_xml/test_arg.py
@@ -51,3 +51,20 @@ def test_arg_wrong_attribute():
         parser.parse_description(root_entity)
     assert '`arg`' in str(excinfo.value)
     assert 'whats_this' in str(excinfo.value)
+
+
+def test_arg_with_subtag():
+    xml_file = \
+        """\
+        <launch>
+            <arg name="my_arg" default="asd" description="something">
+                <whats_this/>
+            </arg>
+        </launch>
+        """
+    xml_file = textwrap.dedent(xml_file)
+    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    with pytest.raises(ValueError) as excinfo:
+        parser.parse_description(root_entity)
+    assert '`arg`' in str(excinfo.value)
+    assert 'whats_this' in str(excinfo.value)

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -65,7 +65,7 @@ class Entity(BaseEntity):
         if isinstance(self.__element, dict):
             if 'children' not in self.__element:
                 raise ValueError(
-                    f'Expected entity {self.__type_name} to have children entities.'
+                    f'Expected entity `{self.__type_name}` to have children entities.'
                     f'That can be a list of subentities or a dictionary with a `children` '
                     'list element')
             self.__read_keys.add('children')
@@ -86,14 +86,13 @@ class Entity(BaseEntity):
         if isinstance(self.__element, list):
             if not self.__children_called:
                 raise ValueError(
-                    f'Entity `{self.__type_name}` has nested entities that were not '
-                    f'parsed: {self.__element}')
+                    f'Unexpected nested entity(ies) found in `{self.__type_name}`: '
+                    f'{self.__element}')
             return
         unparsed_keys = set(self.__element.keys()) - self.__read_keys
         if unparsed_keys:
             raise ValueError(
-                f'Found the following keys of `{self.__type_name}` that were not '
-                f'parsed: {unparsed_keys}'
+                f'Unexpected key(s) found in `{self.__type_name}`: {unparsed_keys}'
             )
 
     def get_attr(

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -82,7 +82,7 @@ class Entity(BaseEntity):
             entities.append(Entity(child[type_name], type_name))
         return entities
 
-    def assert_entity_complely_parsed(self):
+    def assert_entity_completely_parsed(self):
         if isinstance(self.__element, list):
             if not self.__children_called:
                 raise ValueError(

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -32,7 +32,7 @@ def test_executable():
                 name: my_ls
                 shell: true
                 output: log
-                launch_prefix: $(env LAUNCH_PREFIX)
+                'launch-prefix': $(env LAUNCH_PREFIX '')
                 env:
                     -   name: var
                         value: '1'


### PR DESCRIPTION
Fixes https://github.com/ros2/launch/issues/338.

Adds three methods to `launch.frontend.Entity`:
- `assert_no_children(self)`
- `assert_subentity_types(self, types: Iterable[str])`
- `assert_attribute_names(self, names: Iterable[str])`

It might make the `parse` methods a bit more verbose, but it's not hard to use.
I have modified two parsing functions to use this, and it has already caught a preexisting error!

There might be some other ways to achieve the same, so I would like to get feedback about the approach before applying this more broadly.