### PR TITLE
Add stderr message print when command failed

### DIFF
--- a/launch/launch/substitutions/command.py
+++ b/launch/launch/substitutions/command.py
@@ -113,7 +113,10 @@ class Command(Substitution):
         except FileNotFoundError as ex:
             raise SubstitutionFailure(f'file not found: {ex}')
         if result.returncode != 0:
-            raise SubstitutionFailure(f'executed command failed. Command: {command_str}')
+            on_error_message = f'executed command failed. Command: {command_str}'
+            if result.stderr:
+                on_error_message += f'\nCaptured stderr output: {result.stderr}'
+            raise SubstitutionFailure(on_error_message)
         if result.stderr:
             on_stderr_message = f'executed command showed stderr output.' \
                 f' Command: {command_str}\n' \


### PR DESCRIPTION
Fix PR for https://github.com/ros2/launch/issues/471.

Please check if the stderr message is printed properly.

For example, when the command is failed by missing required attribute, 

Before
```
launch.substitutions.substitution_failure.SubstitutionFailure: executed command failed. Command: xacro /home/horibe/workspace/test.xacro
when processing file: /home/horibe/workspace/test.xacro
```

After
```
launch.substitutions.substitution_failure.SubstitutionFailure: executed command failed. Command: xacro /home/horibe/workspace/test.xacro
Captured stderr output: error: xacro:arg: missing attribute 'default'
when processing file: /home/horibe/workspace/test.xacro
```