### PR TITLE
Support non-interactive launch.LaunchService runs

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -577,9 +577,10 @@ class ExecuteProcess(Action):
             self.__stderr_buffer.truncate(0)
 
     def __on_shutdown(self, event: Event, context: LaunchContext) -> Optional[SomeActionsType]:
+        due_to_sigint = cast(Shutdown, event).due_to_sigint
         return self._shutdown_process(
             context,
-            send_sigint=(not cast(Shutdown, event).due_to_sigint),
+            send_sigint=not due_to_sigint or context.noninteractive,
         )
 
     def __get_shutdown_timer_actions(self) -> List[Action]:

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -34,7 +34,8 @@ class LaunchContext:
     """Runtime context used by various launch entities when being visited or executed."""
 
     def __init__(
-        self, *,
+        self,
+        *,
         argv: Optional[Iterable[Text]] = None,
         noninteractive: bool = False
     ) -> None:

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -33,13 +33,20 @@ from .substitution import Substitution
 class LaunchContext:
     """Runtime context used by various launch entities when being visited or executed."""
 
-    def __init__(self, *, argv: Optional[Iterable[Text]] = None) -> None:
+    def __init__(
+        self, *,
+        argv: Optional[Iterable[Text]] = None,
+        noninteractive: bool = False
+    ) -> None:
         """
         Create a LaunchContext.
 
         :param: argv stored in the context for access by the entities, None results in []
+        :param: noninteractive if True (not default), this service will assume it has
+            no terminal associated e.g. it is being executed from a non interactive script
         """
         self.__argv = argv if argv is not None else []
+        self.__noninteractive = noninteractive
 
         self._event_queue = asyncio.Queue()  # type: asyncio.Queue
         self._event_handlers = collections.deque()  # type: collections.deque
@@ -62,6 +69,11 @@ class LaunchContext:
     def argv(self):
         """Getter for argv."""
         return self.__argv
+
+    @property
+    def noninteractive(self):
+        """Getter for noninteractive."""
+        return self.__noninteractive
 
     def _set_is_shutdown(self, state: bool) -> None:
         self.__is_shutdown = state

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -56,6 +56,7 @@ class LaunchService:
         self,
         *,
         argv: Optional[Iterable[Text]] = None,
+        noninteractive: bool = False,
         debug: bool = False
     ) -> None:
         """
@@ -67,6 +68,8 @@ class LaunchService:
         outside of the main-thread.
 
         :param: argv stored in the context for access by the entities, None results in []
+        :param: noninteractive if True (not default), this service will assume it has
+            no terminal associated e.g. it is being executed from a non interactive script
         :param: debug if True (not default), asyncio the logger are seutp for debug
         """
         # Setup logging and debugging.
@@ -82,7 +85,7 @@ class LaunchService:
         install_signal_handlers()
 
         # Setup context and register a built-in event handler for bootstrapping.
-        self.__context = LaunchContext(argv=self.__argv)
+        self.__context = LaunchContext(argv=self.__argv, noninteractive=noninteractive)
         self.__context.register_event_handler(OnIncludeLaunchDescription())
         self.__context.register_event_handler(OnShutdown(on_shutdown=self.__on_shutdown))
 

--- a/launch/test/launch/test_launch_context.py
+++ b/launch/test/launch/test_launch_context.py
@@ -38,6 +38,15 @@ def test_launch_context_get_argv():
     assert lc.argv == []
 
 
+def test_launch_context_get_noninteractive():
+    """Test the getting of noninteractive flag in the LaunchContext class."""
+    lc = LaunchContext(noninteractive=True)
+    assert lc.noninteractive
+
+    lc = LaunchContext()
+    assert not lc.noninteractive
+
+
 def test_launch_context_get_set_asyncio_loop():
     """Test the getting and settings for asyncio_loop in the LaunchContext class."""
     lc = LaunchContext()


### PR DESCRIPTION
Connected to #473. This patch allows the user to modify the underlying assumption `launch` currently makes about Ctrl+C behavior i.e. sent to all processes in the process group. In the same vein as `bash` interactive/non-interactive shells (see [here](https://tldp.org/LDP/abs/html/intandnonint.html)).