### PR TITLE
Handle signals within the asyncio loop.

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -58,11 +58,6 @@ class LaunchService:
         """
         Create a LaunchService.
 
-        If called outside of the main-thread before the function
-        :func:`launch.utilities.install_signal_handlers()` has been called,
-        a ValueError can be raised, as setting signal handlers cannot be done
-        outside of the main-thread.
-
         :param: argv stored in the context for access by the entities, None results in []
         :param: debug if True (not default), asyncio the logger are seutp for debug
         """
@@ -261,9 +256,6 @@ class LaunchService:
         This should only ever be run from the main thread and not concurrently with other
         asynchronous runs.
 
-        Note that custom signal handlers are set, and KeyboardInterrupt is caught and ignored
-        around the original signal handler. After the run ends, this behavior is undone.
-
         :param: shutdown_when_idle if True (default), the service will shutdown when idle.
         """
         # Make sure this has not been called from any thread but the main thread.
@@ -348,6 +340,9 @@ class LaunchService:
 
         This should only ever be run from the main thread and not concurrently with
         asynchronous runs (see `run_async()` documentation).
+
+        Note that KeyboardInterrupt is caught and ignored, as signals are handled separately.
+        After the run ends, this behavior is undone.
 
         :param: shutdown_when_idle if True (default), the service will shutdown when idle
         """

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -18,6 +18,7 @@ import asyncio
 import collections.abc
 import contextlib
 import logging
+import platform
 import signal
 import threading
 import traceback
@@ -208,7 +209,8 @@ class LaunchService:
                 # Setup signal handlers
                 manager.handle(signal.SIGINT, _on_sigint)
                 manager.handle(signal.SIGTERM, _on_sigterm)
-                manager.handle(signal.SIGQUIT, _on_sigterm)
+                if platform.system() != 'Windows':
+                    manager.handle(signal.SIGQUIT, _on_sigterm)
                 # Yield asyncio loop and current task.
                 yield this_loop, this_task
         finally:

--- a/launch/launch/utilities/__init__.py
+++ b/launch/launch/utilities/__init__.py
@@ -19,10 +19,7 @@ from .create_future_impl import create_future
 from .ensure_argument_type_impl import ensure_argument_type
 from .normalize_to_list_of_substitutions_impl import normalize_to_list_of_substitutions
 from .perform_substitutions_impl import perform_substitutions
-from .signal_management import install_signal_handlers
-from .signal_management import on_sigint
-from .signal_management import on_sigquit
-from .signal_management import on_sigterm
+from .signal_management import AsyncSafeSignalManager
 from .visit_all_entities_and_collect_futures_impl import visit_all_entities_and_collect_futures
 
 __all__ = [
@@ -32,10 +29,7 @@ __all__ = [
     'create_future',
     'ensure_argument_type',
     'perform_substitutions',
-    'install_signal_handlers',
-    'on_sigint',
-    'on_sigquit',
-    'on_sigterm',
+    'AsyncSafeSignalManager',
     'normalize_to_list_of_substitutions',
     'visit_all_entities_and_collect_futures',
 ]

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -34,8 +34,10 @@ def is_winsock_handle(fd):
     try:
         # On Windows, WinSock handles and regular file handles
         # have disjoint APIs. This test leverages the fact that
-        # attempting to os.dup a WinSock handle will fail.
-        os.close(os.dup(fd))
+        # attempting to get an MSVC runtime file handle from a
+        # WinSock handle will fail.
+        import msvcrt
+        msvcrt.get_osfhandle(fd)
         return False
     except OSError:
         return True

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -106,8 +106,11 @@ class AsyncSafeSignalManager:
         :return: previous handler if any, otherwise None
         """
         signum = signal.Signals(signum)
-        if handler is not None and not callable(handler):
-            raise ValueError('signal handler must be a callable')
-        old_handler = self.__handlers.get(signum, None)
-        self.__handlers[signum] = handler
+        if handler is not None:
+            if not callable(handler):
+                raise ValueError('signal handler must be a callable')
+            old_handler = self.__handlers.get(signum, None)
+            self.__handlers[signum] = handler
+        else:
+            old_handler = self.__handlers.pop(signum, None)
         return old_handler

--- a/launch/test/launch/utilities/test_signal_management.py
+++ b/launch/test/launch/utilities/test_signal_management.py
@@ -14,64 +14,33 @@
 
 """Tests for the signal_management module."""
 
-from launch.utilities import install_signal_handlers, on_sigint, on_sigquit, on_sigterm
+import asyncio
+import signal
 
-import pytest
+from launch.utilities import AsyncSafeSignalManager
 
-
-def test_install_signal_handlers():
-    """Test the install_signal_handlers() function."""
-    install_signal_handlers()
-    install_signal_handlers()
-    install_signal_handlers()
+import osrf_pycommon.process_utils
 
 
-def test_on_sigint():
-    """Test the on_sigint() function."""
-    # None is acceptable
-    on_sigint(None)
+def test_async_safe_signal_manager():
+    """Test AsyncSafeSignalManager class."""
+    loop = osrf_pycommon.process_utils.get_loop()
 
-    def mock_sigint_handler():
-        pass
-
-    on_sigint(mock_sigint_handler)
-
-    # Non-callable is not
-    with pytest.raises(ValueError):
-        on_sigint('non-callable')
-
-    # TODO(jacobperron): implement a functional test by using subprocess.Popen
-
-
-def test_on_sigquit():
-    """Test the on_sigquit() function."""
-    # None is acceptable
-    on_sigquit(None)
-
-    def mock_sigquit_handler():
-        pass
-
-    on_sigquit(mock_sigquit_handler)
-
-    # Non-callable is not
-    with pytest.raises(ValueError):
-        on_sigquit('non-callable')
-
-    # TODO(jacobperron): implement a functional test by using subprocess.Popen
-
-
-def test_on_sigterm():
-    """Test the on_sigterm() function."""
-    # None is acceptable
-    on_sigterm(None)
-
-    def mock_sigterm_handler():
-        pass
-
-    on_sigterm(mock_sigterm_handler)
-
-    # Non-callable is not
-    with pytest.raises(ValueError):
-        on_sigterm('non-callable')
-
-    # TODO(jacobperron): implement a functional test by using subprocess.Popen
+    prev_signal_handler = signal.signal(
+        signal.SIGUSR1, lambda signum: None
+    )
+    try:
+        got_signal = asyncio.Future(loop=loop)
+        with AsyncSafeSignalManager(loop) as manager:
+            manager.handle(
+                signal.SIGUSR1,
+                lambda signum: got_signal.set_result(signum)
+            )
+            loop.call_soon(signal.raise_signal, signal.SIGUSR1)
+            loop.run_until_complete(
+                asyncio.wait([got_signal], timeout=5.0)
+            )
+            assert got_signal.done()
+            assert got_signal.result() == signal.SIGUSR1
+    finally:
+        signal.signal(signal.SIGUSR1, prev_signal_handler)

--- a/launch/test/launch/utilities/test_signal_management.py
+++ b/launch/test/launch/utilities/test_signal_management.py
@@ -31,8 +31,10 @@ def cap_signals(*signals):
     def _decorator(func):
         @functools.wraps(func)
         def _wrapper(*args, **kwargs):
+            handlers = {}
             try:
-                handlers = {s: signal.signal(s, _noop) for s in signals}
+                for s in signals:
+                    handlers[s] = signal.signal(s, _noop)
                 return func(*args, **kwargs)
             finally:
                 assert all(signal.signal(s, h) is _noop for s, h in handlers.items())
@@ -42,8 +44,9 @@ def cap_signals(*signals):
 
 
 if platform.system() == 'Windows':
-    SIGNAL = signal.CTRL_C_EVENT
-    ANOTHER_SIGNAL = signal.CTRL_BREAK_EVENT
+    # NOTE(hidmic): this is risky, but we have few options.
+    SIGNAL = signal.SIGINT
+    ANOTHER_SIGNAL = signal.SIGBREAK
 else:
     SIGNAL = signal.SIGUSR1
     ANOTHER_SIGNAL = signal.SIGUSR2


### PR DESCRIPTION
Connected to #473. This patch uses `signal.set_wakeup_fd` to delegate signal handling to the running loop. Similar to [`asyncio._UnixSelectorEventLoop.add_signal_handler()`](https://github.com/python/cpython/blob/66d3b589c44fcbcf9afe1e442d9beac3bd8bcd34/Lib/asyncio/unix_events.py#L88) implementation, but not limited to Unix platforms.

For additional context, without this patch, in a scenario like the one in #473, events emitted within a signal handler do not seem to wake up the loop.
