### PR TITLE
Workaround asyncio signal handling on Unix

### DIFF
--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -131,14 +131,14 @@ class AsyncSafeSignalManager:
         self.__current = self.__parent
 
     def __chain_wakeup_handle(self, wakeup_handle):
-        if isinstance(wakeup_handle, socket.socket):
+        prev_wakeup_handle = self.__prev_wakeup_handle
+        if isinstance(prev_wakeup_handle, socket.socket):
             # Detach (Windows) socket and retrieve the raw OS handle.
-            wakeup_handle, _ = wakeup_handle.fileno(), wakeup_handle.detach()
+            prev_wakeup_handle, _ = prev_wakeup_handle.fileno(), prev_wakeup_handle.detach()
         if wakeup_handle != -1 and is_winsock_handle(wakeup_handle):
             # On Windows, os.write will fail on a WinSock handle. There is no WinSock API
             # in the standard library either. Thus we wrap it in a socket.socket instance.
             wakeup_handle = socket.socket(fileno=wakeup_handle)
-        prev_wakeup_handle = self.__prev_wakeup_handle
         self.__prev_wakeup_handle = wakeup_handle
         return prev_wakeup_handle
 


### PR DESCRIPTION
Unix `asyncio` loops override existing signal wakeup file descriptors with no regards for existing ones -- set by user code or by another loop. For further reference, see [here](https://github.com/python/cpython/blob/187f76def8a5bd0af7ab512575cad30cfe624b05/Lib/asyncio/unix_events.py#L95). This is a problem when the child watcher gets lazy initialized (e.g. on first async subprocess execution, see [here](https://github.com/python/cpython/blob/187f76def8a5bd0af7ab512575cad30cfe624b05/Lib/asyncio/unix_events.py#L188) and [here](https://github.com/python/cpython/blob/187f76def8a5bd0af7ab512575cad30cfe624b05/Lib/asyncio/unix_events.py#L927)).

CI up to `launch`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13422)](http://ci.ros2.org/job/ci_linux/13422/)
* CentOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=99)](https://ci.ros2.org/job/ci_linux-centos/99/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8337)](http://ci.ros2.org/job/ci_linux-aarch64/8337/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11143)](http://ci.ros2.org/job/ci_osx/11143/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13478)](http://ci.ros2.org/job/ci_windows/13478/)

