### PR TITLE
Support Python 3.8-provided importlib.metadata

### DIFF
--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -24,7 +24,10 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
 
 from .entity import Entity
 from .expose import instantiate_action


### PR DESCRIPTION
The importlib_metadata package is a backport of the importlib.metadata module from Python 3.8. Fedora (and possibly others) no longer package importlib_metadata because they ship Python versions which have the functionality built-in.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13459)](http://ci.ros2.org/job/ci_linux/13459/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8370)](http://ci.ros2.org/job/ci_linux-aarch64/8370/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11183)](http://ci.ros2.org/job/ci_osx/11183/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13523)](http://ci.ros2.org/job/ci_windows/13523/)