### PR TITLE
Use unittest.mock instead of mock

### DIFF
--- a/launch_testing/package.xml
+++ b/launch_testing/package.xml
@@ -21,7 +21,6 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>python3-mock</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/launch_testing/test/launch_testing/test_runner_results.py
+++ b/launch_testing/test/launch_testing/test_runner_results.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import unittest
+import unittest.mock as mock
 
 import ament_index_python
 import launch
@@ -23,7 +24,6 @@ import launch_testing
 import launch_testing.actions
 from launch_testing.loader import TestRun as TR
 from launch_testing.test_runner import LaunchTestRunner
-import mock
 
 
 # Run tests on processes that die early with an exit code and make sure the results returned


### PR DESCRIPTION
`mock` is just a backport of Python 3.3 `unittest.mock`.

CI up to `launch_testing`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13687)](http://ci.ros2.org/job/ci_linux/13687/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8566)](http://ci.ros2.org/job/ci_linux-aarch64/8566/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11404)](http://ci.ros2.org/job/ci_osx/11404/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13758)](http://ci.ros2.org/job/ci_windows/13758/)
