### PR TITLE
Add frontend substitution for logging directory

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -309,8 +309,7 @@ def get_logger(name=None):
 def _log_dir(data: Iterable[SomeSubstitutionsType]):
     if len(data) > 0:
         raise ValueError('log_dir substitution does not expect any arguments')
-    # Parser expects callable
-    return lambda: TextSubstitution(text=launch_config.log_dir), {}
+    return TextSubstitution, {'text': launch_config.log_dir}
 
 
 def _normalize_output_configuration(config):

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -24,9 +24,13 @@ import os
 import socket
 import sys
 
+from typing import Iterable
 from typing import List
 
 from . import handlers
+
+from ..frontend import expose_substitution
+from ..some_substitutions_type import SomeSubstitutionsType
 
 __all__ = [
     'get_logger',
@@ -298,6 +302,14 @@ def get_logger(name=None):
     if launch_log_file_handler not in logger.handlers:
         logger.addHandler(launch_log_file_handler)
     return logger
+
+
+@expose_substitution('log_dir')
+def _log_dir(data: Iterable[SomeSubstitutionsType]):
+    if len(data) > 0:
+        raise ValueError('log_dir substitution does not expect any arguments')
+    # Parser expects callable
+    return lambda: launch_config.log_dir, {}
 
 
 def _normalize_output_configuration(config):

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -31,6 +31,7 @@ from . import handlers
 
 from ..frontend import expose_substitution
 from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitutions import TextSubstitution
 
 __all__ = [
     'get_logger',
@@ -309,7 +310,7 @@ def _log_dir(data: Iterable[SomeSubstitutionsType]):
     if len(data) > 0:
         raise ValueError('log_dir substitution does not expect any arguments')
     # Parser expects callable
-    return lambda: launch_config.log_dir, {}
+    return lambda: TextSubstitution(text=launch_config.log_dir), {}
 
 
 def _normalize_output_configuration(config):

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 from launch.frontend.parse_substitution import parse_substitution
 import launch.logging
+from launch.substitutions import TextSubstitution
 
 import pytest
 
@@ -332,4 +333,5 @@ def test_get_log_dir_frontend(log_dir):
     subst = parse_substitution('$(log_dir)')
     assert len(subst) == 1
     result = subst[0]
-    assert result == log_dir
+    assert isinstance(result, TextSubstitution)
+    assert result.text == log_dir

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -20,6 +20,7 @@ import pathlib
 import re
 from unittest import mock
 
+from launch.frontend.parse_substitution import parse_substitution
 import launch.logging
 
 import pytest
@@ -321,3 +322,14 @@ def test_get_logging_directory():
 
     os.environ.pop('ROS_HOME', None)
     launch.logging.launch_config.reset()
+
+
+def test_get_log_dir_frontend(log_dir):
+    """Test log_dir frontend substitution."""
+    launch.logging.reset()
+    launch.logging.launch_config.log_dir = log_dir
+
+    subst = parse_substitution('$(log_dir)')
+    assert len(subst) == 1
+    result = subst[0]
+    assert result == log_dir


### PR DESCRIPTION
This allows users to access the launch logging directory in a frontend launch script, for example:

    <launch>
      <log message="The logging directory is $(log_dir)" />
    </launch>