### PR TITLE
[Backport] [Foxy] fix max() with empty sequence (#440)

### DIFF
--- a/launch_testing/launch_testing/pytest/hooks.py
+++ b/launch_testing/launch_testing/pytest/hooks.py
@@ -38,11 +38,12 @@ class LaunchTestFailureRepr:
     """A `_pytest._code.code.ExceptionReprChain`-like object."""
 
     def __init__(self, failures):
-        max_length = max(
-            len(line)
+        lines = [
+            line
             for _, error_description in failures
             for line in error_description.splitlines()
-        )
+        ]
+        max_length = max(len(line) for line in lines) if lines else 3
         thick_sep_line = '=' * max_length
         thin_sep_line = '-' * max_length
         self._fulldescr = '\n' + '\n\n'.join([


### PR DESCRIPTION
Foxy CI up to `launch_testing`, `test_launch_testing`, and `test_communication` :
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13936)](http://ci.ros2.org/job/ci_linux/13936/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8777)](http://ci.ros2.org/job/ci_linux-aarch64/8777/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11639)](http://ci.ros2.org/job/ci_osx/11639/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14022)](http://ci.ros2.org/job/ci_windows/14022/)

