### PR TITLE
Add missing exec dependency on PyYAML

### DIFF
--- a/launch/package.xml
+++ b/launch/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-lark-parser</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
It's imported here: https://github.com/ros2/launch/blob/03ce3df1619659ecf81fe1d7cdfdbd244bd01dc8/launch/launch/utilities/type_utils.py#L29