### PR TITLE
Remove is_winsock_handle() and instead test if wrapping the handle in a socket.socket() works

### DIFF
--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import os
-import platform
 import signal
 import socket
 import threading

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -26,21 +26,10 @@ from typing import Optional
 from typing import Tuple  # noqa: F401
 from typing import Union
 
-
-def is_winsock_handle(fd):
-    """Check if the given file descriptor is WinSock handle."""
-    if platform.system() != 'Windows':
-        return False
-    try:
-        # On Windows, WinSock handles and regular file handles
-        # have disjoint APIs. This test leverages the fact that
-        # attempting to get an MSVC runtime file handle from a
-        # WinSock handle will fail.
-        import msvcrt
-        msvcrt.get_osfhandle(fd)
-        return False
-    except OSError:
-        return True
+try:
+    _WindowsError = WindowsError
+except NameError:
+    _WindowsError = None
 
 
 class AsyncSafeSignalManager:
@@ -185,10 +174,14 @@ class AsyncSafeSignalManager:
         if isinstance(prev_wakeup_handle, socket.socket):
             # Detach (Windows) socket and retrieve the raw OS handle.
             prev_wakeup_handle = prev_wakeup_handle.detach()
-        if wakeup_handle != -1 and is_winsock_handle(wakeup_handle):
+        if wakeup_handle != -1:
             # On Windows, os.write will fail on a WinSock handle. There is no WinSock API
             # in the standard library either. Thus we wrap it in a socket.socket instance.
-            wakeup_handle = socket.socket(fileno=wakeup_handle)
+            try:
+                wakeup_handle = socket.socket(fileno=wakeup_handle)
+            except _WindowsError as e:
+                if e.winerror != 10038:  # WSAENOTSOCK
+                    raise
         self.__prev_wakeup_handle = wakeup_handle
         return prev_wakeup_handle
 


### PR DESCRIPTION
When investigating failures in the nightly windows debug job I was getting a lot of debug assertions dialogs about invalid file descriptions.
I don't think this was causing the CI failures, but it was pretty anoying when debugging locally.

Testing `os.dup(os.close())` had a similar issue.
This seems to work fine :crossed_fingers: .