### PR TITLE
Only try to wrap the fd in a socket on Windows

### DIFF
--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -16,6 +16,7 @@
 
 import asyncio
 import os
+import platform
 import signal
 import socket
 import threading
@@ -24,11 +25,6 @@ from typing import Callable
 from typing import Optional
 from typing import Tuple  # noqa: F401
 from typing import Union
-
-try:
-    _WindowsError = WindowsError
-except NameError:
-    _WindowsError = None
 
 
 class AsyncSafeSignalManager:
@@ -173,12 +169,12 @@ class AsyncSafeSignalManager:
         if isinstance(prev_wakeup_handle, socket.socket):
             # Detach (Windows) socket and retrieve the raw OS handle.
             prev_wakeup_handle = prev_wakeup_handle.detach()
-        if wakeup_handle != -1:
+        if wakeup_handle != -1 and platform.system() == 'Windows':
             # On Windows, os.write will fail on a WinSock handle. There is no WinSock API
             # in the standard library either. Thus we wrap it in a socket.socket instance.
             try:
                 wakeup_handle = socket.socket(fileno=wakeup_handle)
-            except _WindowsError as e:
+            except WindowsError as e:
                 if e.winerror != 10038:  # WSAENOTSOCK
                     raise
         self.__prev_wakeup_handle = wakeup_handle


### PR DESCRIPTION
After rereading https://github.com/ros2/launch/pull/494 I noticed that we shouldn't be trying to wrap the `fd` in a socket on non-Windows platforms.

I'm not sure if that could cause a bug or not, but this is more clean.