### PR TITLE
Make each parser extension provide a set of file extensions

### DIFF
--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -18,12 +18,14 @@
 import itertools
 import os.path
 from typing import List
+from typing import Optional
 from typing import Set
 from typing import Text
 from typing import TextIO
 from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
+import warnings
 
 try:
     import importlib.metadata as importlib_metadata
@@ -119,6 +121,32 @@ class Parser:
         """Return the registered extensions."""
         cls.load_parser_implementations()
         return cls.frontend_parsers.keys()
+
+    @classmethod
+    def is_extension_valid(
+        cls,
+        extension: Text,
+    ) -> bool:
+        """Return an entity loaded with a markup file."""
+        warnings.warn(
+            'Parser.is_extension_valid is deprecated, use Parser.is_filename_valid instead')
+        cls.load_parser_implementations()
+        return extension in cls.frontend_parsers
+
+    @classmethod
+    def get_parser_from_extension(
+        cls,
+        extension: Text,
+    ) -> Optional[Type['Parser']]:
+        """Return an entity loaded with a markup file."""
+        warnings.warn(
+            'Parser.get_parser_from_extension is deprecated, '
+            'use Parser.get_parsers_from_filename instead')
+        cls.load_parser_implementations()
+        try:
+            return cls.frontend_parsers[extension]
+        except KeyError:
+            raise RuntimeError('Not recognized frontend implementation')
 
     @classmethod
     def may_parse(

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -198,5 +198,5 @@ class Parser:
 
     @classmethod
     def get_file_extensions(cls) -> Set[Text]:
-        """Return a set of file extensions for this parser."""
+        """Return the set of file extensions known to this parser."""
         return {}

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -81,11 +81,12 @@ class Parser:
     def load_parser_implementations(cls):
         """Load all the available frontend entities."""
         if cls.frontend_parsers is None:
-            cls.frontend_parsers = {
+            parsers = {
                 entry_point.name: entry_point.load()
                 for entry_point in importlib_metadata.entry_points().get(
                         'launch.frontend.parser', [])
             }
+            cls.frontend_parsers = dict(sorted(parsers.items()))
 
     def parse_action(self, entity: Entity) -> Action:
         """Parse an action, using its registered parsing method."""
@@ -176,7 +177,7 @@ class Parser:
         """Return a list of parsers which entity loaded with a markup file."""
         cls.load_parser_implementations()
         return [
-            parser for _, parser in sorted(cls.frontend_parsers.items())
+            parser for _, parser in cls.frontend_parsers.items()
             if parser.may_parse(filename)
         ]
 
@@ -216,7 +217,7 @@ class Parser:
             filename = getattr(fileobj, 'name', '')
             implementations = cls.get_parsers_from_filename(filename)
             implementations += [
-                parser for _, parser in sorted(cls.frontend_parsers.items())
+                parser for _, parser in cls.frontend_parsers.items()
                 if parser not in implementations
             ]
 

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -15,9 +15,11 @@
 
 """Module for Parser class and parsing methods."""
 
+import itertools
 import os.path
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Text
 from typing import TextIO
 from typing import Type
@@ -56,8 +58,9 @@ class Parser:
     Abstract class for parsing launch actions, substitutions and descriptions.
 
     Implementations of the parser class, should override the load method.
-    They could also override the parse_substitution method, or not.
-    load_launch_extensions, parse_action and parse_description are not suposed to be overrided.
+    They could also override the parse_substitution and/or get_file_extensions methods, or not.
+    load_launch_extensions, parse_action, parse_description and get_file_extensions_from_parsers
+    are not suposed to be overrided.
     """
 
     extensions_loaded = False
@@ -139,6 +142,15 @@ class Parser:
             raise RuntimeError('Not recognized frontend implementation')
 
     @classmethod
+    def get_file_extensions_from_parsers(cls) -> Set[Type['Parser']]:
+        """Return a set of file extensions gathered from the parser implementations."""
+        cls.load_parser_implementations()
+        return set(itertools.chain.from_iterable([
+            parser_extension.get_file_extensions()
+            for parser_extension in cls.frontend_parsers.values()
+        ]))
+
+    @classmethod
     def load(
         cls,
         file: Union[FilePath, TextIO],
@@ -183,3 +195,8 @@ class Parser:
         finally:
             if didopen:
                 fileobj.close()
+
+    @classmethod
+    def get_file_extensions(cls) -> Set[Text]:
+        """Return a set of file extensions for this parser."""
+        return {}

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -58,8 +58,9 @@ class Parser:
 
     Implementations of the parser class, should override the load method.
     They could also override the parse_substitution and/or get_file_extensions methods, or not.
-    load_launch_extensions, parse_action, parse_description and get_file_extensions_from_parsers
-    are not suposed to be overrided.
+    load_launch_extensions, parse_action, parse_description, get_available_extensions, may_parse,
+    is_filename_valid, get_parsers_from_filename and get_file_extensions_from_parsers are not
+    suposed to be overrided.
     """
 
     extensions_loaded = False
@@ -120,14 +121,12 @@ class Parser:
         return cls.frontend_parsers.keys()
 
     @classmethod
-    def is_filename_valid_for_parser(
+    def may_parse(
         cls,
         filename: Text,
-        parser: Type['Parser'],
     ) -> bool:
-        """Return `true` if the filename is valid for the given parser."""
-        return any(
-            filename.endswith('.' + parser_ext) for parser_ext in parser.get_file_extensions())
+        """Return `true` if the filename is valid for this parser."""
+        return any(filename.endswith('.' + ext) for ext in cls.get_file_extensions())
 
     @classmethod
     def is_filename_valid(
@@ -137,7 +136,7 @@ class Parser:
         """Return `true` if the filename is valid for any parser."""
         cls.load_parser_implementations()
         return any(
-            cls.is_filename_valid_for_parser(filename, parser)
+            parser.may_parse(filename)
             for parser in cls.frontend_parsers.values()
         )
 
@@ -150,7 +149,7 @@ class Parser:
         cls.load_parser_implementations()
         return [
             parser for _, parser in sorted(cls.frontend_parsers.items())
-            if cls.is_filename_valid_for_parser(filename, parser)
+            if parser.may_parse(filename)
         ]
 
     @classmethod

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -145,10 +145,10 @@ class Parser:
     def get_file_extensions_from_parsers(cls) -> Set[Type['Parser']]:
         """Return a set of file extensions gathered from the parser implementations."""
         cls.load_parser_implementations()
-        return set(itertools.chain.from_iterable([
+        return set(itertools.chain.from_iterable(
             parser_extension.get_file_extensions()
             for parser_extension in cls.frontend_parsers.values()
-        ]))
+        ))
 
     @classmethod
     def load(

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -189,7 +189,8 @@ class Parser:
             filename = getattr(fileobj, 'name', '')
             implementations = cls.get_parsers_from_filename(filename)
             implementations += [
-                parser for parser in cls.frontend_parsers.values() if parser not in implementations
+                parser for _, parser in sorted(cls.frontend_parsers.items())
+                if parser not in implementations
             ]
 
             exceptions = []

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -62,7 +62,7 @@ class Parser:
     They could also override the parse_substitution and/or get_file_extensions methods, or not.
     load_launch_extensions, parse_action, parse_description, get_available_extensions, may_parse,
     is_filename_valid, get_parsers_from_filename and get_file_extensions_from_parsers are not
-    suposed to be overrided.
+    supposed to be overriden.
     """
 
     extensions_loaded = False
@@ -154,7 +154,7 @@ class Parser:
         cls,
         filename: Text,
     ) -> bool:
-        """Return `true` if the filename is valid for this parser."""
+        """Return `True` if the filename is valid for this parser."""
         return any(filename.endswith('.' + ext) for ext in cls.get_file_extensions())
 
     @classmethod
@@ -162,7 +162,7 @@ class Parser:
         cls,
         filename: Text,
     ) -> bool:
-        """Return `true` if the filename is valid for any parser."""
+        """Return `True` if the filename is valid for any parser."""
         cls.load_parser_implementations()
         return any(
             parser.may_parse(filename)
@@ -177,7 +177,7 @@ class Parser:
         """Return a list of parsers which entity loaded with a markup file."""
         cls.load_parser_implementations()
         return [
-            parser for _, parser in cls.frontend_parsers.items()
+            parser for parser in cls.frontend_parsers.values()
             if parser.may_parse(filename)
         ]
 
@@ -217,7 +217,7 @@ class Parser:
             filename = getattr(fileobj, 'name', '')
             implementations = cls.get_parsers_from_filename(filename)
             implementations += [
-                parser for _, parser in cls.frontend_parsers.items()
+                parser for parser in cls.frontend_parsers.values()
                 if parser not in implementations
             ]
 

--- a/launch/launch/launch_description_sources/any_launch_file_utilities.py
+++ b/launch/launch/launch_description_sources/any_launch_file_utilities.py
@@ -39,14 +39,15 @@ def get_launch_description_from_any_launch_file(
     :raise `ValueError`: Invalid file. The file may not be a text file.
     """
     loaders = [get_launch_description_from_frontend_launch_file]
-    extension = os.path.splitext(launch_file_path)[1]
+    launch_file_name = os.path.basename(launch_file_path)
+    extension = os.path.splitext(launch_file_name)[1]
     if extension:
         extension = extension[1:]
     if extension == 'py':
         loaders.insert(0, get_launch_description_from_python_launch_file)
     else:
         loaders.append(get_launch_description_from_python_launch_file)
-        extension = '' if not Parser.is_extension_valid(extension) else extension
+        extension = '' if not Parser.is_filename_valid(launch_file_name) else extension
     exceptions = []
     for loader in loaders:
         try:

--- a/launch_xml/launch_xml/parser.py
+++ b/launch_xml/launch_xml/parser.py
@@ -15,6 +15,8 @@
 """Module for XML Parser class."""
 
 import io
+from typing import Set
+from typing import Text
 from typing import Union
 import xml.etree.ElementTree as ET
 
@@ -33,3 +35,8 @@ class Parser(frontend.Parser):
     ) -> (Entity, 'Parser'):
         """Return entity loaded from XML file."""
         return (Entity(ET.parse(file).getroot()), cls())
+
+    @classmethod
+    def get_file_extensions(cls) -> Set[Text]:
+        """Return a set of file extensions for this parser."""
+        return {'launch.xml'}

--- a/launch_xml/launch_xml/parser.py
+++ b/launch_xml/launch_xml/parser.py
@@ -39,4 +39,4 @@ class Parser(frontend.Parser):
     @classmethod
     def get_file_extensions(cls) -> Set[Text]:
         """Return the set of file extensions known to this parser."""
-        return {'launch.xml'}
+        return {'launch.xml', 'xml'}

--- a/launch_xml/launch_xml/parser.py
+++ b/launch_xml/launch_xml/parser.py
@@ -38,5 +38,5 @@ class Parser(frontend.Parser):
 
     @classmethod
     def get_file_extensions(cls) -> Set[Text]:
-        """Return a set of file extensions for this parser."""
+        """Return the set of file extensions known to this parser."""
         return {'launch.xml'}

--- a/launch_yaml/launch_yaml/parser.py
+++ b/launch_yaml/launch_yaml/parser.py
@@ -57,4 +57,4 @@ class Parser(frontend.Parser):
     @classmethod
     def get_file_extensions(cls) -> Set[Text]:
         """Return the set of file extensions known to this parser."""
-        return {'launch.yaml'}
+        return {'launch.yaml', 'launch.yml', 'yaml', 'yml'}

--- a/launch_yaml/launch_yaml/parser.py
+++ b/launch_yaml/launch_yaml/parser.py
@@ -56,5 +56,5 @@ class Parser(frontend.Parser):
 
     @classmethod
     def get_file_extensions(cls) -> Set[Text]:
-        """Return a set of file extensions for this parser."""
+        """Return the set of file extensions known to this parser."""
         return {'launch.yaml'}

--- a/launch_yaml/launch_yaml/parser.py
+++ b/launch_yaml/launch_yaml/parser.py
@@ -15,6 +15,8 @@
 
 """Module for YAML Parser class."""
 
+from typing import Set
+from typing import Text
 from typing import TextIO
 from typing import Union
 
@@ -51,3 +53,8 @@ class Parser(frontend.Parser):
         finally:
             if didopen:
                 fileobj.close()
+
+    @classmethod
+    def get_file_extensions(cls) -> Set[Text]:
+        """Return a set of file extensions for this parser."""
+        return {'launch.yaml'}


### PR DESCRIPTION
This is an implementation of an idea from this comment: https://github.com/ros2/launch_ros/issues/149#issuecomment-713670587. I think asking the parser implementations for extensions instead of basing it on the name of the extension definitely makes sense. For example, we could now easily add `launch.yml` (vs `launch.yaml`) as a recognized extension.

It can go alonside https://github.com/ros2/launch_ros/pull/251.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>