### PR TITLE
Add 'launch' to sets of launch file extensions

### DIFF
--- a/launch_xml/launch_xml/parser.py
+++ b/launch_xml/launch_xml/parser.py
@@ -39,4 +39,4 @@ class Parser(frontend.Parser):
     @classmethod
     def get_file_extensions(cls) -> Set[Text]:
         """Return the set of file extensions known to this parser."""
-        return {'launch.xml', 'xml'}
+        return {'launch.xml', 'xml', 'launch'}

--- a/launch_yaml/launch_yaml/parser.py
+++ b/launch_yaml/launch_yaml/parser.py
@@ -57,4 +57,4 @@ class Parser(frontend.Parser):
     @classmethod
     def get_file_extensions(cls) -> Set[Text]:
         """Return the set of file extensions known to this parser."""
-        return {'launch.yaml', 'launch.yml', 'yaml', 'yml'}
+        return {'launch.yaml', 'launch.yml', 'yaml', 'yml', 'launch'}


### PR DESCRIPTION
Closes https://github.com/ros2/launch_ros/issues/149

Alternative to https://github.com/ros2/launch_ros/pull/251 after https://github.com/ros2/launch/pull/516, but won't do anything until https://github.com/ros2/launch_ros/pull/252 is merged.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>