### PR TITLE
Declare frontend group dependency & use explicit dependencies in launch_testing

### DIFF
--- a/launch_testing/package.xml
+++ b/launch_testing/package.xml
@@ -15,6 +15,9 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>
+  <!-- explicitly depend on the main launch frontends -->
+  <exec_depend>launch_xml</exec_depend>
+  <exec_depend>launch_yaml</exec_depend>
   <exec_depend>osrf_pycommon</exec_depend>
   <exec_depend>python3-pytest</exec_depend>
 

--- a/launch_testing/package.xml
+++ b/launch_testing/package.xml
@@ -26,6 +26,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>launch</test_depend>
 
+  <group_depend>launch_frontend_packages</group_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/launch_testing/package.xml
+++ b/launch_testing/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>launch_testing</name>
   <version>0.19.0</version>
   <description>A package to create tests which involve launch files and multiple processes.</description>

--- a/launch_xml/package.xml
+++ b/launch_xml/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>launch_xml</name>
   <version>0.19.0</version>
   <description>XML frontend for the launch package.</description>

--- a/launch_xml/package.xml
+++ b/launch_xml/package.xml
@@ -18,6 +18,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <member_of_group>launch_frontend_packages</member_of_group>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/launch_yaml/package.xml
+++ b/launch_yaml/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>launch_yaml</name>
   <version>0.19.0</version>
   <description>YAML frontend for the launch package.</description>

--- a/launch_yaml/package.xml
+++ b/launch_yaml/package.xml
@@ -18,6 +18,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <member_of_group>launch_frontend_packages</member_of_group>
+
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
Part of https://github.com/ros2/launch_ros/issues/255

As suggested/discussed under https://github.com/ros2/launch/pull/516#issuecomment-880342455, this declares a group dependency for the launch frontends and declares explicit dependencies on `launch_xml` and `launch_yaml` for `launch_testing`.

Using both a group dependency and hard/explicit dependencies allows this to work fine with binaries (with bloom) and also allows us to include any future launch frontend (or any user's custom frontend) in source builds. This is similar to how `rcl` depends on both the `rcl_logging_packages` group and the default logging implementation explicitly.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>