### PR TITLE
Added support for handling launch-prefix injection from CLI argument

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -681,7 +681,16 @@ class ExecuteProcess(Action):
         cmd = [perform_substitutions(context, x) for x in self.__cmd]
         name = os.path.basename(cmd[0]) if self.__name is None \
             else perform_substitutions(context, self.__name)
-        cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
+
+        if context.launch_prefix is not None:
+            cmd = shlex.split(
+                perform_substitutions(
+                    context,
+                    normalize_to_list_of_substitutions(context.launch_prefix)
+                )
+            ) + cmd
+        else:
+            cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
         with _global_process_counter_lock:
             global _global_process_counter
             _global_process_counter += 1

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -28,6 +28,7 @@ import launch.logging
 from .event import Event
 from .event_handler import BaseEventHandler
 from .substitution import Substitution
+from .some_substitutions_type import SomeSubstitutionsType
 
 
 class LaunchContext:
@@ -37,7 +38,8 @@ class LaunchContext:
         self,
         *,
         argv: Optional[Iterable[Text]] = None,
-        noninteractive: bool = False
+        noninteractive: bool = False,
+        launch_prefix: Optional[SomeSubstitutionsType] = None
     ) -> None:
         """
         Create a LaunchContext.
@@ -48,6 +50,7 @@ class LaunchContext:
         """
         self.__argv = argv if argv is not None else []
         self.__noninteractive = noninteractive
+        self.__launch_prefix = launch_prefix
 
         self._event_queue = asyncio.Queue()  # type: asyncio.Queue
         self._event_handlers = collections.deque()  # type: collections.deque
@@ -75,6 +78,11 @@ class LaunchContext:
     def noninteractive(self):
         """Getter for noninteractive."""
         return self.__noninteractive
+
+    @property
+    def launch_prefix(self):
+        """Getter for launch_prefix."""
+        return self.__launch_prefix
 
     def _set_is_shutdown(self, state: bool) -> None:
         self.__is_shutdown = state

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -41,6 +41,7 @@ from .events import IncludeLaunchDescription
 from .events import Shutdown
 from .launch_context import LaunchContext
 from .launch_description import LaunchDescription
+from .some_substitutions_type import SomeSubstitutionsType
 from .launch_description_entity import LaunchDescriptionEntity
 from .some_actions_type import SomeActionsType
 from .utilities import AsyncSafeSignalManager
@@ -55,7 +56,8 @@ class LaunchService:
         *,
         argv: Optional[Iterable[Text]] = None,
         noninteractive: bool = False,
-        debug: bool = False
+        debug: bool = False,
+        launch_prefix: Optional[SomeSubstitutionsType] = None
     ) -> None:
         """
         Create a LaunchService.
@@ -74,7 +76,10 @@ class LaunchService:
         self.__logger = launch.logging.get_logger('launch')
 
         # Setup context and register a built-in event handler for bootstrapping.
-        self.__context = LaunchContext(argv=self.__argv, noninteractive=noninteractive)
+        self.__context = LaunchContext(
+            argv=self.__argv, noninteractive=noninteractive,
+            launch_prefix=launch_prefix
+        )
         self.__context.register_event_handler(OnIncludeLaunchDescription())
         self.__context.register_event_handler(OnShutdown(on_shutdown=self.__on_shutdown))
 

--- a/launch/test/launch/test_launch_context.py
+++ b/launch/test/launch/test_launch_context.py
@@ -47,6 +47,15 @@ def test_launch_context_get_noninteractive():
     assert not lc.noninteractive
 
 
+def test_launch_context_get_launch_prefix():
+    """Test the getting of launch_prefix in the LaunchContext class."""
+    lc = LaunchContext(launch_prefix="testing")
+    assert lc.launch_prefix == "testing"
+
+    lc = LaunchContext()
+    assert not lc.launch_prefix
+
+
 def test_launch_context_get_set_asyncio_loop():
     """Test the getting and settings for asyncio_loop in the LaunchContext class."""
     lc = LaunchContext()


### PR DESCRIPTION
Added support for passing the `--launch-prefix` CLI argument that will be added via [launch_ros PR 254](https://github.com/ros2/launch_ros/pull/254) to `LaunchService` and `LaunchContext`. This `launch-prefix`, when provided, is then directly injected to all `ExecuteProcess` commands.

Testing was also added to `LaunchContext` for the new constructor argument.