### PR TITLE
Add filtering mechanism for executable prefix application

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -231,10 +231,9 @@ class ExecuteProcess(Action):
         self.__prefix = normalize_to_list_of_substitutions(
             LaunchConfiguration('launch-prefix', default='') if prefix is None else prefix
         )
-        self.__override_filter = False if prefix is None else True
         self.__prefix_filter = normalize_to_list_of_substitutions(
             LaunchConfiguration('launch-prefix-filter', default='')
-        )
+        ) if prefix is None else None
         self.__output = os.environ.get('OVERRIDE_LAUNCH_PROCESS_OUTPUT', output)
         self.__output_format = output_format
 

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -189,8 +189,9 @@ class ExecuteProcess(Action):
         :param: prefix a set of commands/arguments to preceed the cmd, used for
             things like gdb/valgrind and defaults to the LaunchConfiguration
             called 'launch-prefix'. Note that a non-default prefix provided in
-            a launch file will override the prefix provided via the `--launch-prefix` CLI
-            argument regardless of whether `--launch-prefix-filter` is provided.
+            a launch file will override the prefix provided via the `launch-prefix`
+            launch configuration regardless of whether the `launch-prefix-filter` launch
+            configuration is provided.
         :param: output configuration for process output logging. Defaults to 'log'
             i.e. log both stdout and stderr to launch main log file and stderr to
             the screen.

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -18,6 +18,7 @@ import asyncio
 import io
 import os
 import platform
+import re
 import shlex
 import signal
 import threading
@@ -687,15 +688,14 @@ class ExecuteProcess(Action):
 
         # Peform filtering for prefix application
         filter_str = perform_substitutions(context, self.__prefix_filter)
-        filter_list = []
+        regex_filter = None
         if len(filter_str):
-            filter_list = filter_str.split('/')
-        for filter_elem in filter_list:
-            if filter_elem == os.path.basename(cmd[0]):
-                cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
-                break
+            regex_filter = re.compile(filter_str)
+        if regex_filter is not None and regex_filter.match(os.path.basename(cmd[0])):
+            cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
+
         # Apply to all if no filter is provided
-        if not len(filter_list):
+        if regex_filter is None:
             cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
 
         with _global_process_counter_lock:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -231,6 +231,7 @@ class ExecuteProcess(Action):
         self.__prefix = normalize_to_list_of_substitutions(
             LaunchConfiguration('launch-prefix', default='') if prefix is None else prefix
         )
+        self.__override_filter = False if prefix is None else True
         self.__prefix_filter = normalize_to_list_of_substitutions(
             LaunchConfiguration('launch-prefix-filter', default='')
         )
@@ -694,8 +695,8 @@ class ExecuteProcess(Action):
         if regex_filter is not None and regex_filter.match(os.path.basename(cmd[0])):
             cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
 
-        # Apply to all if no filter is provided
-        if regex_filter is None:
+        # Apply to all if no filter is provided or filter is overridden
+        if regex_filter is None or self.__override_filter:
             cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
 
         with _global_process_counter_lock:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -687,15 +687,12 @@ class ExecuteProcess(Action):
             else perform_substitutions(context, self.__name)
 
         # Perform filtering for prefix application
-        filter_str = perform_substitutions(context, self.__prefix_filter)
-        regex_filter = None
-        if len(filter_str):
-            regex_filter = re.compile(filter_str)
-        if regex_filter is not None and regex_filter.match(os.path.basename(cmd[0])):
-            cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
-
-        # Apply to all if no filter is provided or filter is overridden
-        if regex_filter is None or self.__override_filter:
+        should_apply_prefix = True  # by default
+        if self.__prefix_filter is not None:  # no prefix given on construction
+            prefix_filter = perform_substitutions(context, self.__prefix_filter)
+            # Apply if filter regex matches (empty regex matches all strings)
+            should_apply_prefix = re.match(prefix_filter, os.path.basename(cmd[0]))
+        if should_apply_prefix:
             cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
 
         with _global_process_counter_lock:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -188,7 +188,9 @@ class ExecuteProcess(Action):
             'emulate_tty' configuration does not represent a boolean.
         :param: prefix a set of commands/arguments to preceed the cmd, used for
             things like gdb/valgrind and defaults to the LaunchConfiguration
-            called 'launch-prefix'
+            called 'launch-prefix'. Note that a non-default prefix provided in
+            a launch file will override the prefix provided via the `--launch-prefix` CLI
+            argument regardless of whether `--launch-prefix-filter` is provided.
         :param: output configuration for process output logging. Defaults to 'log'
             i.e. log both stdout and stderr to launch main log file and stderr to
             the screen.

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -686,7 +686,7 @@ class ExecuteProcess(Action):
         name = os.path.basename(cmd[0]) if self.__name is None \
             else perform_substitutions(context, self.__name)
 
-        # Peform filtering for prefix application
+        # Perform filtering for prefix application
         filter_str = perform_substitutions(context, self.__prefix_filter)
         regex_filter = None
         if len(filter_str):

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -14,13 +14,16 @@
 
 """Tests for the ExecuteProcess Action."""
 
+import asyncio
 import os
 import platform
 import signal
 import sys
 
+from launch import LaunchContext
 from launch import LaunchDescription
 from launch import LaunchService
+from launch.actions import SetLaunchConfiguration
 from launch.actions.emit_event import EmitEvent
 from launch.actions.execute_process import ExecuteProcess
 from launch.actions.opaque_function import OpaqueFunction
@@ -168,3 +171,40 @@ def test_execute_process_with_respawn():
     ls.include_launch_description(generate_launch_description())
     assert 0 == ls.run()
     assert expected_called_count == on_exit_callback.called_count
+
+
+def test_execute_process_prefix_filter_match():
+    lc = LaunchContext()
+    lc._set_asyncio_loop(asyncio.get_event_loop())
+    SetLaunchConfiguration('launch-prefix', 'time').visit(lc)
+    assert len(lc.launch_configurations) == 1
+    SetLaunchConfiguration(
+        'launch-prefix-filter',
+        f'{os.path.basename(sys.executable)}').visit(lc)
+    assert len(lc.launch_configurations) == 2
+
+    test_process = ExecuteProcess(
+        cmd=[sys.executable, '-c', "print('action')"],
+        output='screen'
+    )
+
+    test_process.execute(lc)
+    assert 'time' in test_process.process_details['cmd']
+
+
+def test_execute_process_prefix_filter_no_match():
+    lc = LaunchContext()
+    lc._set_asyncio_loop(asyncio.get_event_loop())
+    SetLaunchConfiguration('launch-prefix', 'time').visit(lc)
+    assert len(lc.launch_configurations) == 1
+    SetLaunchConfiguration(
+        'launch-prefix-filter', 'no-match').visit(lc)
+    assert len(lc.launch_configurations) == 2
+
+    test_process = ExecuteProcess(
+        cmd=[sys.executable, '-c', "print('action')"],
+        output='screen'
+    )
+
+    test_process.execute(lc)
+    assert 'time' not in test_process.process_details['cmd']

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -208,3 +208,23 @@ def test_execute_process_prefix_filter_no_match():
 
     test_process.execute(lc)
     assert 'time' not in test_process.process_details['cmd']
+
+
+def test_execute_process_prefix_filter_override_in_launch_file():
+    lc = LaunchContext()
+    lc._set_asyncio_loop(asyncio.get_event_loop())
+    SetLaunchConfiguration('launch-prefix', 'time').visit(lc)
+    assert len(lc.launch_configurations) == 1
+    SetLaunchConfiguration(
+        'launch-prefix-filter', 'no-match').visit(lc)
+    assert len(lc.launch_configurations) == 2
+
+    test_process = ExecuteProcess(
+        prefix='echo',
+        cmd=[sys.executable, '-c', "print('action')"],
+        output='screen'
+    )
+
+    test_process.execute(lc)
+    assert 'echo' in test_process.process_details['cmd'] and \
+        'time' not in test_process.process_details['cmd']


### PR DESCRIPTION
In order to support the `--launch-prefix-filter` argument proposed in https://github.com/ros2/launch_ros/issues/257, the regex filter supplied via the `launch-prefix-filter` LaunchConfiguration must be matched against the executable name. In the case of a match, the prefix passed via the `launch-prefix` LaunchConfiguration is prepended to the executable command. If a match is not found, the prefix is not applied.

Additionally, if the user provides a specific prefix for an executable in the launch file, the filter will be overridden and the prefix will be applied as expected.

Corresponding PR: https://github.com/ros2/launch_ros/pull/261 will implement the `--launch-prefix-filter` argument into `launch_ros`.