### PR TITLE
[foxy] Backport parser fixes and type_utils refactor

### DIFF
--- a/launch/launch/frontend/entity.py
+++ b/launch/launch/frontend/entity.py
@@ -14,11 +14,13 @@
 
 """Module for Entity class."""
 
-from typing import Any
 from typing import List
 from typing import Optional
 from typing import Text
 from typing import Union
+
+from launch.utilities.type_utils import AllowedTypesType
+from launch.utilities.type_utils import AllowedValueType
 
 
 class Entity:
@@ -43,46 +45,40 @@ class Entity:
         self,
         name: Text,
         *,
-        data_type: Any = str,
-        optional: bool = False
+        data_type: AllowedTypesType = str,
+        optional: bool = False,
+        can_be_str: bool = True,
     ) -> Optional[Union[
-        List[Union[int, str, float, bool]],
-        Union[int, str, float, bool],
-        List['Entity']
+        AllowedValueType,
+        List['Entity'],
     ]]:
         """
         Access an attribute of the entity.
 
         By default, it will try to return it as an string.
-        `types` states the expected types of the attribute. Type coercion or type checking is
+        `data_type` is the expected type of the attribute. Type coercion or type checking is
         applied depending on the particular frontend.
 
-        The allowed types are:
-            - a scalar type i.e. `str`, `int`, `float`, `bool`;
-            - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
-            - a non-uniform list of known scalar types e.g. `List[Union[int, str]]`;
-            - a non-uniform list of any scalar type i.e. `list` or `List`;
-            - a `Union` of any of the above;
-            - `List[Entity]`, see below.
+        See :py:obj:`launch.utilities.AllowedTypesTuple` to see what types are allowed.
 
-        `types = None` works in the same way as:
-            `Union[int, float, bool, list, str]`
+        `data_type = None` will result in yaml parsing of the attribute value as a string.
 
         `List[Entity]` allows accessing a list of subentities with an specific name.
-        Check the documentation of each specific frontend implementation to see how `list`
-        and `List[Entity]` look like.
+
+        Check the documentation of each specific frontend implementation to see how a list of
+        attributes or `List[Entity]` look like.
 
         If `optional` is `True` and the attribute cannot be found, `None` will be returned
         instead of raising `AttributeError`.
 
         :param name: name of the attribute
-        :param types: type of the attribute to be read. Default to 'str'
+        :param data_type: type of the attribute to be read. Defaults to 'str'
         :param optional: when `True`, it doesn't raise an error when the attribute is not found.
             It returns `None` instead. Defaults to `False`
         :raises `AttributeError`: Attribute not found. Only possible if `optional` is `False`
         :raises `TypeError`: Attribute found but it is not of the correct type.
             Only happens in frontend implementations that do type checking
-        :raises `ValueError`: Attribute found but can't be coerced to one of the types.
-            Only happens in frontend implementations that do type coercion
+        :raises `ValueError`: Attribute found but can't be coerced to one of the specified types.
+            Only happens in frontend implementations that do type coercion.
         """
         raise NotImplementedError()

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Avatar Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +15,15 @@
 
 """Module for Parser class and parsing methods."""
 
-import io
-import os
+import os.path
 from typing import Any
 from typing import List
 from typing import Optional
 from typing import Text
+from typing import TextIO
 from typing import Tuple
 from typing import Type
+from typing import TYPE_CHECKING
 from typing import Union
 
 from pkg_resources import iter_entry_points
@@ -33,16 +35,16 @@ from .parse_substitution import replace_escaped_characters
 from ..action import Action
 from ..invalid_launch_file_error import InvalidLaunchFileError
 from ..some_substitutions_type import SomeSubstitutionsType
-from ..utilities import is_a
+from ..utilities.typing_file_path import FilePath
 
-if False:
-    from ..launch_description import LaunchDescription  # noqa: F401
+if TYPE_CHECKING:
+    from ..launch_description import LaunchDescription
 
 
 class InvalidFrontendLaunchFileError(InvalidLaunchFileError):
     """Exception raised when the given frontend launch file is not valid."""
 
-    ...
+    pass
 
 
 class Parser:
@@ -127,7 +129,7 @@ class Parser:
     @classmethod
     def load(
         cls,
-        file: Union[str, io.TextIOBase],
+        file: Union[FilePath, TextIO],
     ) -> (Entity, 'Parser'):
         """
         Parse an Entity from a markup language-based launch file.
@@ -140,28 +142,32 @@ class Parser:
         # Imported here, to avoid recursive import.
         cls.load_parser_implementations()
 
-        def get_key(extension):
-            def key(x):
-                return x[0] != extension
-            return key
-        exceptions = []
-        extension = ''
-        if is_a(file, str):
-            extension = file
-        elif hasattr(file, 'name'):
-            extension = file.name
-        extension = os.path.splitext(extension)[1]
-        if extension:
-            extension = extension[1:]
-        for (frontend_name, implementation) in sorted(
-            cls.frontend_parsers.items(), key=get_key(extension)
-        ):
-            try:
-                return implementation.load(file)
-            except Exception as ex:
-                if is_a(file, io.TextIOBase):
-                    file.seek(0)
-                else:
+        try:
+            fileobj = open(file, 'r')
+            didopen = True
+        except TypeError:
+            fileobj = file
+            didopen = False
+
+        try:
+            filename = getattr(fileobj, 'name', '')
+            # file extension without leading '.'
+            extension = os.path.splitext(filename)[1][1:]
+
+            sorted_parsers = sorted(cls.frontend_parsers.items())
+            implementations = [v for k, v in sorted_parsers if k == extension] + [
+                v for k, v in sorted_parsers if k != extension
+            ]
+
+            exceptions = []
+            for implementation in implementations:
+                try:
+                    return implementation.load(fileobj)
+                except Exception as ex:
                     exceptions.append(ex)
-        extension = '' if not cls.is_extension_valid(extension) else extension
-        raise InvalidFrontendLaunchFileError(extension, likely_errors=exceptions)
+                    fileobj.seek(0)
+            extension = '' if not cls.is_extension_valid(extension) else extension
+            raise InvalidFrontendLaunchFileError(extension, likely_errors=exceptions)
+        finally:
+            if didopen:
+                fileobj.close()

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -16,12 +16,10 @@
 """Module for Parser class and parsing methods."""
 
 import os.path
-from typing import Any
 from typing import List
 from typing import Optional
 from typing import Text
 from typing import TextIO
-from typing import Tuple
 from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
@@ -30,11 +28,14 @@ from pkg_resources import iter_entry_points
 
 from .entity import Entity
 from .expose import instantiate_action
+from .parse_substitution import parse_if_substitutions
 from .parse_substitution import parse_substitution
 from .parse_substitution import replace_escaped_characters
 from ..action import Action
 from ..invalid_launch_file_error import InvalidLaunchFileError
-from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+from ..utilities.type_utils import NormalizedValueType
+from ..utilities.type_utils import StrSomeValueType
 from ..utilities.typing_file_path import FilePath
 
 if TYPE_CHECKING:
@@ -76,16 +77,22 @@ class Parser:
                 for entry_point in iter_entry_points('launch.frontend.parser')
             }
 
-    def parse_action(self, entity: Entity) -> (Action, Tuple[Any]):
+    def parse_action(self, entity: Entity) -> Action:
         """Parse an action, using its registered parsing method."""
         self.load_launch_extensions()
         return instantiate_action(entity, self)
 
-    def parse_substitution(self, value: Text) -> SomeSubstitutionsType:
+    def parse_substitution(self, value: Text) -> List[Substitution]:
         """Parse a substitution."""
         return parse_substitution(value)
 
-    def escape_characters(self, value: Text) -> SomeSubstitutionsType:
+    def parse_if_substitutions(
+        self, value: StrSomeValueType
+    ) -> NormalizedValueType:
+        """See :py:func:`launch.frontend.parser.parse_if_substitutions`."""
+        return parse_if_substitutions(value)
+
+    def escape_characters(self, value: Text) -> Text:
         """Escape characters in strings."""
         return replace_escaped_characters(value)
 

--- a/launch/launch/frontend/type_utils.py
+++ b/launch/launch/frontend/type_utils.py
@@ -14,8 +14,10 @@
 
 """Extra type utils for launch frontend implementations."""
 
+from typing import Any
 from typing import List
 from typing import Text
+from typing import Tuple
 from typing import Type
 from typing import Union
 
@@ -45,3 +47,224 @@ def get_data_type_from_identifier(type_identifier: Text):
     if type_identifier not in mapping:
         raise ValueError(f"Got invalid type identifier '{type_identifier}'")
     return mapping[type_identifier]
+
+
+# The following definitions were moved/refactored into launch.utilities.type_utils since Foxy
+# Kept here for backwards compatibility
+
+__ScalarTypesTuple = (
+    int, float, bool, str
+)
+
+__TypesForGuessTuple = (
+    int, float, bool, list, str
+)
+
+
+def check_is_list(data_type: Any) -> bool:
+    """Check if `data_type` is based on a `typing.List`."""
+    return hasattr(data_type, '__origin__') and \
+        data_type.__origin__ in (list, List)  # On Linux/Mac is List, on Windows is list.
+
+
+def check_is_union(data_type: Any) -> bool:
+    """Check if `data_type` is based on a `typing.Union`."""
+    return hasattr(data_type, '__origin__') and \
+        data_type.__origin__ is Union
+
+
+def get_tuple_of_types(data_type: Any) -> Tuple:
+    """
+    Normalize `data_type` to a tuple of types.
+
+    If `data_type` is based on a `typing.Union`, return union types.
+    Otherwise, return a `(data_type,)` tuple.
+    """
+    if check_is_union(data_type):
+        return data_type.__args__
+    else:
+        return (data_type,)
+
+
+def check_valid_scalar_type(data_type: Any) -> bool:
+    """Check if `data_type` is a valid scalar type."""
+    return all(data_type in __ScalarTypesTuple for x in get_tuple_of_types(data_type))
+
+
+def extract_type(data_type: Any) -> Tuple[Any, bool]:
+    """
+    Extract type information from type object.
+
+    :param data_type: It can be:
+        - a scalar type i.e. `str`, `int`, `float`, `bool`;
+        - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
+        - a non-uniform list of known scalar types e.g. `List[Union[int, str]]`;
+        - a non-uniform list of any scalar type i.e. `list` or `List`;
+    :returns: a tuple (type_obj, is_list).
+        is_list is `True` for the supported list types, if not is `False`.
+        type_obj is the object representing that type in python. In the case of list
+        is the type of the items.
+        e.g.:
+            `name = List[int]` -> `(int, True)`
+            `name = bool` -> `(bool, False)`
+            `name = Union[bool, str]` -> `(Union[bool, str], False)`
+            `name = List[Union[bool, str]]` -> `(Union[bool, str], True)`
+            `name = List -> `(None, True)`
+    """
+    is_list = False
+    if data_type is list:
+        is_list = True
+        data_type = None
+    elif check_is_list(data_type):
+        is_list = True
+        data_type = data_type.__args__[0]
+    if data_type is not None and check_valid_scalar_type(data_type) is False:
+        raise ValueError('Unrecognized data type: {}'.format(data_type))
+    return (data_type, is_list)
+
+
+def check_type(value: Any, data_type: Any) -> bool:
+    """
+    Check if `value` is of `type`.
+
+    The allowed types are:
+        - a scalar type i.e. `str`, `int`, `float`, `bool`;
+        - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
+        - a non-uniform list of known scalar types e.g. `List[Union[int, str]]`;
+        - a non-uniform list of any scalar type i.e. `list` or `List`;
+        - a `Union` of any of the above.
+    `types = None` works in the same way as:
+        `Union[int, float, bool, list, str]`
+    """
+    def check_scalar_type(value, data_type):
+        data_type = get_tuple_of_types(data_type)
+        return isinstance(value, data_type)
+    types = __TypesForGuessTuple
+    if data_type is not None:
+        data_type = get_tuple_of_types(data_type)
+    for x in types:
+        type_obj, is_list = extract_type(x)
+        if is_list:
+            if not isinstance(value, list) or not value:
+                continue
+            if type_obj is None:
+                return True
+            if all(check_scalar_type(x, type_obj) for x in value):
+                return True
+        else:
+            if check_scalar_type(value, type_obj):
+                return True
+    return False
+
+
+def coerce_to_bool(x: str) -> bool:
+    """Convert string to bool value."""
+    if x.lower() in ('true', 'yes', 'on', '1', 'false', 'no', 'off', '0'):
+        return x.lower() in ('true', 'yes', 'on', '1')
+    raise ValueError()
+
+
+def coerce_to_str(x: str) -> str:
+    """Strip outer quotes if we have them."""
+    if x.startswith("'") and x.endswith("'"):
+        return x[1:-1]
+    elif x.startswith('"') and x.endswith('"'):
+        return x[1:-1]
+    else:
+        return x
+
+
+def scalar_type_key(data_type: Any) -> int:
+    """Get key. Used for sorting the scalar data_types."""
+    keys = {
+        int: 0,
+        float: 1,
+        bool: 2,
+        str: 3,
+    }
+    return keys[data_type]
+
+
+def coerce_scalar(x: str, data_type: Any = None) -> Union[int, str, float, bool]:
+    """
+    Convert string to int, flot, bool, str with the above conversion rules.
+
+    If data_type is not `None`, only those conversions are tried.
+    If not, all the possible convertions are tried.
+    The order is always: `int`, `float`, `bool`, `str`.
+    :param x: string to be converted.
+    :param type_obj: should be `int`, `float`, `bool`, `str`.
+        It can also be an iterable combining the above types, or `None`.
+    """
+    coercion_rules = {
+        str: coerce_to_str,
+        bool: coerce_to_bool,
+        int: int,
+        float: float,
+    }
+    if data_type is None:
+        conversions_to_try = __ScalarTypesTuple
+    else:
+        conversions_to_try = sorted(get_tuple_of_types(data_type), key=scalar_type_key)
+        if not set(conversions_to_try).issubset(set(__ScalarTypesTuple)):
+            raise ValueError('Unrecognized data type: {}'.format(data_type))
+    for t in conversions_to_try:
+        try:
+            return coercion_rules[t](x)
+        except ValueError:
+            pass
+    raise ValueError('Not conversion is possible')
+
+
+def coerce_list(x: List[str], data_type: Any = None) -> List[Union[int, str, float, bool]]:
+    """Coerce each member of the list using `coerce_scalar` function."""
+    return [coerce_scalar(i, data_type) for i in x]
+
+
+def get_typed_value(
+    value: Union[Text, List[Text]],
+    data_type: Any
+) -> Union[
+    List[Union[int, str, float, bool]],
+    Union[int, str, float, bool],
+]:
+    """
+    Try to convert `value` to the type specified in `data_type`.
+
+    If not raise `AttributeError`.
+    The allowed types are:
+        - a scalar type i.e. `str`, `int`, `float`, `bool`;
+        - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
+        - a non-uniform list of known scalar types e.g. `List[Union[int, str]]`;
+        - a non-uniform list of any scalar type i.e. `list` or `List`;
+        - a `Union` of any of the above.
+    `types = None` works in the same way as:
+        `Union[int, float, bool, list, str]`
+    The coercion order for scalars is always: `int`, `float`, `bool`, `str`.
+    """
+    if data_type is None:
+        types = __TypesForGuessTuple
+    else:
+        types = get_tuple_of_types(data_type)
+
+    value_is_list = isinstance(value, list)
+
+    for x in types:
+        type_obj, type_is_list = extract_type(x)
+        if type_is_list != value_is_list:
+            continue
+        if type_is_list:
+            try:
+                return coerce_list(value, type_obj)
+            except ValueError:
+                pass
+        else:
+            try:
+                return coerce_scalar(value, type_obj)
+            except ValueError:
+                pass
+    raise ValueError(
+        'Can not convert value {} to one of the types in {}'.format(
+            value, types
+        )
+    )

--- a/launch/launch/frontend/type_utils.py
+++ b/launch/launch/frontend/type_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,241 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module which implements get_typed_value function."""
+"""Extra type utils for launch frontend implementations."""
 
-from typing import Any
 from typing import List
 from typing import Text
-from typing import Tuple
+from typing import Type
 from typing import Union
 
 from .entity import Entity
-
-__ScalarTypesTuple = (
-    int, float, bool, str
-)
-
-__TypesForGuessTuple = (
-    int, float, bool, list, str
-)
+from ..utilities.type_utils import AllowedTypesType
+from ..utilities.type_utils import is_typing_list
 
 
-def check_is_list(data_type: Any) -> bool:
-    """Check if `data_type` is based on a `typing.List`."""
-    return hasattr(data_type, '__origin__') and \
-        data_type.__origin__ in (list, List)  # On Linux/Mac is List, on Windows is list.
-
-
-def check_is_union(data_type: Any) -> bool:
-    """Check if `data_type` is based on a `typing.Union`."""
-    return hasattr(data_type, '__origin__') and \
-        data_type.__origin__ is Union
-
-
-def check_is_list_entity(data_type: Any) -> bool:
+def check_is_list_entity(data_type: Union[AllowedTypesType, Type[List[Entity]]]) -> bool:
     """Check if `data_type` is a `typing.List` with elements of `Entity` type or derived."""
-    return check_is_list(data_type) and \
-        issubclass(data_type.__args__[0], Entity)
+    return is_typing_list(data_type) and \
+        issubclass(data_type.__args__[0], Entity)  # type: ignore
 
 
-def get_tuple_of_types(data_type: Any) -> Tuple:
-    """
-    Normalize `data_type` to a tuple of types.
-
-    If `data_type` is based on a `typing.Union`, return union types.
-    Otherwise, return a `(data_type,)` tuple.
-    """
-    if check_is_union(data_type):
-        return data_type.__args__
-    else:
-        return (data_type,)
-
-
-def check_valid_scalar_type(data_type: Any) -> bool:
-    """Check if `data_type` is a valid scalar type."""
-    return all(data_type in __ScalarTypesTuple for x in get_tuple_of_types(data_type))
-
-
-def extract_type(data_type: Any) -> Tuple[Any, bool]:
-    """
-    Extract type information from type object.
-
-    :param data_type: It can be:
-        - a scalar type i.e. `str`, `int`, `float`, `bool`;
-        - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
-        - a non-uniform list of known scalar types e.g. `List[Union[int, str]]`;
-        - a non-uniform list of any scalar type i.e. `list` or `List`;
-
-    :returns: a tuple (type_obj, is_list).
-        is_list is `True` for the supported list types, if not is `False`.
-        type_obj is the object representing that type in python. In the case of list
-        is the type of the items.
-        e.g.:
-            `name = List[int]` -> `(int, True)`
-            `name = bool` -> `(bool, False)`
-            `name = Union[bool, str]` -> `(Union[bool, str], False)`
-            `name = List[Union[bool, str]]` -> `(Union[bool, str], True)`
-            `name = List -> `(None, True)`
-    """
-    is_list = False
-    if data_type is list:
-        is_list = True
-        data_type = None
-    elif check_is_list(data_type):
-        is_list = True
-        data_type = data_type.__args__[0]
-    if data_type is not None and check_valid_scalar_type(data_type) is False:
-        raise ValueError('Unrecognized data type: {}'.format(data_type))
-    return (data_type, is_list)
-
-
-def check_type(value: Any, data_type: Any) -> bool:
-    """
-    Check if `value` is of `type`.
-
-    The allowed types are:
-        - a scalar type i.e. `str`, `int`, `float`, `bool`;
-        - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
-        - a non-uniform list of known scalar types e.g. `List[Union[int, str]]`;
-        - a non-uniform list of any scalar type i.e. `list` or `List`;
-        - a `Union` of any of the above.
-
-    `types = None` works in the same way as:
-        `Union[int, float, bool, list, str]`
-    """
-    def check_scalar_type(value, data_type):
-        data_type = get_tuple_of_types(data_type)
-        return isinstance(value, data_type)
-    types = __TypesForGuessTuple
-    if data_type is not None:
-        data_type = get_tuple_of_types(data_type)
-    for x in types:
-        type_obj, is_list = extract_type(x)
-        if is_list:
-            if not isinstance(value, list) or not value:
-                continue
-            if type_obj is None:
-                return True
-            if all(check_scalar_type(x, type_obj) for x in value):
-                return True
-        else:
-            if check_scalar_type(value, type_obj):
-                return True
-    return False
-
-
-def coerce_to_bool(x: str) -> bool:
-    """Convert string to bool value."""
-    if x.lower() in ('true', 'yes', 'on', '1', 'false', 'no', 'off', '0'):
-        return x.lower() in ('true', 'yes', 'on', '1')
-    raise ValueError()
-
-
-def coerce_to_str(x: str) -> str:
-    """Strip outer quotes if we have them."""
-    if x.startswith("'") and x.endswith("'"):
-        return x[1:-1]
-    elif x.startswith('"') and x.endswith('"'):
-        return x[1:-1]
-    else:
-        return x
-
-
-def scalar_type_key(data_type: Any) -> int:
-    """Get key. Used for sorting the scalar data_types."""
-    keys = {
-        int: 0,
-        float: 1,
-        bool: 2,
-        str: 3,
+def get_data_type_from_identifier(type_identifier: Text):
+    mapping = {
+        'str': str,
+        'bool': bool,
+        'float': float,
+        'int': int,
+        'list_of_str': List[str],
+        'list_of_bool': List[bool],
+        'list_of_float': List[float],
+        'list_of_int': List[int],
+        'yaml': None,
     }
-    return keys[data_type]
-
-
-def coerce_scalar(x: str, data_type: Any = None) -> Union[int, str, float, bool]:
-    """
-    Convert string to int, flot, bool, str with the above conversion rules.
-
-    If data_type is not `None`, only those conversions are tried.
-    If not, all the possible convertions are tried.
-    The order is always: `int`, `float`, `bool`, `str`.
-
-    :param x: string to be converted.
-    :param type_obj: should be `int`, `float`, `bool`, `str`.
-        It can also be an iterable combining the above types, or `None`.
-    """
-    coercion_rules = {
-        str: coerce_to_str,
-        bool: coerce_to_bool,
-        int: int,
-        float: float,
-    }
-    if data_type is None:
-        conversions_to_try = __ScalarTypesTuple
-    else:
-        conversions_to_try = sorted(get_tuple_of_types(data_type), key=scalar_type_key)
-        if not set(conversions_to_try).issubset(set(__ScalarTypesTuple)):
-            raise ValueError('Unrecognized data type: {}'.format(data_type))
-    for t in conversions_to_try:
-        try:
-            return coercion_rules[t](x)
-        except ValueError:
-            pass
-    raise ValueError('Not conversion is possible')
-
-
-def coerce_list(x: List[str], data_type: Any = None) -> List[Union[int, str, float, bool]]:
-    """Coerce each member of the list using `coerce_scalar` function."""
-    return [coerce_scalar(i, data_type) for i in x]
-
-
-def get_typed_value(
-    value: Union[Text, List[Text]],
-    data_type: Any
-) -> Union[
-    List[Union[int, str, float, bool]],
-    Union[int, str, float, bool],
-]:
-    """
-    Try to convert `value` to the type specified in `data_type`.
-
-    If not raise `AttributeError`.
-
-    The allowed types are:
-        - a scalar type i.e. `str`, `int`, `float`, `bool`;
-        - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
-        - a non-uniform list of known scalar types e.g. `List[Union[int, str]]`;
-        - a non-uniform list of any scalar type i.e. `list` or `List`;
-        - a `Union` of any of the above.
-
-    `types = None` works in the same way as:
-        `Union[int, float, bool, list, str]`
-
-    The coercion order for scalars is always: `int`, `float`, `bool`, `str`.
-    """
-    if data_type is None:
-        types = __TypesForGuessTuple
-    else:
-        types = get_tuple_of_types(data_type)
-
-    value_is_list = isinstance(value, list)
-
-    for x in types:
-        type_obj, type_is_list = extract_type(x)
-        if type_is_list != value_is_list:
-            continue
-        if type_is_list:
-            try:
-                return coerce_list(value, type_obj)
-            except ValueError:
-                pass
-        else:
-            try:
-                return coerce_scalar(value, type_obj)
-            except ValueError:
-                pass
-    raise ValueError(
-        'Can not convert value {} to one of the types in {}'.format(
-            value, types
-        )
-    )
+    if type_identifier not in mapping:
+        raise ValueError(f"Got invalid type identifier '{type_identifier}'")
+    return mapping[type_identifier]

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -231,6 +231,10 @@ def coerce_to_type(
     :return: `value` coerced to `data_type`.
     """
     def convert_as_yaml(value, error_msg):
+        # Forward empty strings
+        if not value:
+            return value
+
         try:
             output = yaml.safe_load(value)
         except Exception as err:

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -1,0 +1,573 @@
+# Copyright 2019-2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module that implements type coercion and checking utilities."""
+
+import collections.abc
+from typing import Any
+from typing import cast
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Set
+from typing import Text
+from typing import Tuple
+from typing import Type
+from typing import Union
+
+import yaml
+
+from .ensure_argument_type_impl import ensure_argument_type
+from .normalize_to_list_of_substitutions_impl import normalize_to_list_of_substitutions
+from .perform_substitutions_impl import perform_substitutions
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+
+"""Tuple of valid scalar types."""
+ScalarTypesTuple = (
+    int, float, bool, str
+)
+
+"""Tuple of valid list types."""
+ListTypesTuple = (
+    List[int], List[float], List[bool], List[str]
+)
+
+AllowedTypesTuple = ScalarTypesTuple + ListTypesTuple
+
+"""Allowed scalar types."""
+ScalarTypesType = Type[Union[int, float, bool, str]]
+"""Allowed uniform list types."""
+ListTypesType = Type[Union[
+    List[int], List[float], List[bool], List[str]
+]]
+"""Allowed types."""
+AllowedTypesType = Union[ScalarTypesType, ListTypesType]
+
+"""Allowed scalar values."""
+ScalarValueType = Union[int, float, bool, str]
+"""Allowed uniform list values."""
+ListValueType = Union[List[int], List[float], List[bool], List[str]]
+"""Allowed uniform sequence values."""
+SequenceValueType = Union[Sequence[int], Sequence[float], Sequence[bool], Sequence[str]]
+"""Allowed values."""
+AllowedValueType = Union[ScalarValueType, SequenceValueType]
+
+"""Substitution to a scalar type or a scalar type."""
+SomeScalarType = Union[SomeSubstitutionsType, ScalarValueType]
+"""Substitution that can be performed to a uniform list."""
+SomeSequenceType = Union[(
+    Sequence[Union[int, SomeSubstitutionsType]],
+    Sequence[Union[float, SomeSubstitutionsType]],
+    Sequence[Union[bool, SomeSubstitutionsType]],
+    Sequence[Union[str, SomeSubstitutionsType]],
+)]
+"""Union of SomeScalarType and SomeSequenceType."""
+SomeValueType = Union[SomeScalarType, SomeSequenceType]
+
+"""Normalized version of SomeScalarType."""
+NormalizedScalarType = Union[List[Substitution], ScalarValueType]
+"""Normalized version of SomeSequenceType."""
+NormalizedSequenceType = Union[
+    List[Union[int, List[Substitution]]],
+    List[Union[float, List[Substitution]]],
+    List[Union[bool, List[Substitution]]],
+    List[Union[str, List[Substitution]]],
+]
+"""Normalized version of SomeValueType."""
+NormalizedValueType = Union[NormalizedScalarType, NormalizedSequenceType]
+
+"""String embedded substitution version of SomeScalarType"""
+StrSomeScalarType = SomeScalarType
+"""String embedded substitution version of SomeSequenceType"""
+StrSomeSequenceType = Union[(
+    Sequence[Union[int, str]],
+    Sequence[Union[float, str]],
+    Sequence[Union[bool, str]],
+    Sequence[Union[str]],
+)]
+"""String embedded substitution version of SomeValueType"""
+StrSomeValueType = Union[StrSomeScalarType, StrSomeSequenceType]
+
+
+def is_typing_list(data_type: Any) -> bool:
+    """
+    Return `True` if data_type is `typing.List` or a subscription of it.
+
+    Examples
+    --------
+    ```python3
+    assert is_typing_list(typing.List)
+    assert is_typing_list(typing.List[int])
+    assert not is_typing_list(int)
+    ```
+
+    """
+    return data_type is List or (
+        hasattr(data_type, '__origin__') and
+        hasattr(data_type, '__args__') and
+        data_type.__origin__ in  # type: ignore
+        # This has changed in newer Python implementations to `List`,
+        # `list` is checked for compatibility.
+        (list, List) and
+        len(data_type.__args__) > 0 and
+        data_type is List[data_type.__args__[0]]  # type: ignore
+    )
+
+
+def is_valid_scalar_type(data_type: AllowedTypesType) -> bool:
+    """
+    Return `True` if `data_type` is an instance of a valid scalar type.
+
+    See :py:data:`ScalarTypesTuple` for further reference.
+    """
+    return data_type in ScalarTypesTuple
+
+
+def extract_type(data_type: AllowedTypesType) -> Tuple[ScalarTypesType, bool]:
+    """
+    Extract type information from type object.
+
+    :param data_type: It can be:
+        - a scalar type i.e. `str`, `int`, `float`, `bool`;
+        - a uniform list i.e `List[str]`, `List[int]`, `List[float]`, `List[bool]`;
+
+    :returns: a tuple (type_obj, is_list).
+        `is_list` is `True` for the supported list types, if not is `False`.
+        `type_obj` is the object representing that type in Python. In the case of a list,
+        it's the type of the items.
+        e.g.:
+            `data_type = List[int]` -> `(int, True)`
+            `data_type = bool` -> `(bool, False)`
+    """
+    is_list = False
+    scalar_type: ScalarTypesType = cast(ScalarTypesType, data_type)
+    if is_typing_list(data_type):
+        is_list = True
+        scalar_type = data_type.__args__[0]  # type: ignore
+    if is_valid_scalar_type(scalar_type) is False:
+        raise ValueError(f'Unrecognized data type: {data_type}')
+    return (scalar_type, is_list)
+
+
+def is_instance_of_valid_type(value: Any, *, can_be_str: bool = False) -> bool:
+    """
+    Return `True` if value is an instance of an allowed type.
+
+    See :py:data:`AllowedTypesTuple` definition for further reference.
+
+    :param value: variable to be checked.
+    :param can_be_str: when True, non-uniform lists mixed with strings are allowed.
+    :return: `True` when value is an instance of a valid type, `False` if not.
+    """
+    if isinstance(value, list):
+        if not value:
+            return True  # Accept empty lists.
+        member_type = next((type(x) for x in value if type(x) is not str), str)
+        if member_type not in ScalarTypesTuple:
+            return False
+        valid_types = (member_type, str) if can_be_str else member_type
+        return all(isinstance(x, valid_types) for x in value)
+    return isinstance(value, ScalarTypesTuple)
+
+
+def is_instance_of(
+    value: Any,
+    data_type: Optional[AllowedTypesType] = None,
+    *,
+    can_be_str: bool = False,
+) -> bool:
+    """
+    Check if `value` is instance of `data_type`.
+
+    :param value: variable to check.
+    :param data_type: type that `value` should be an instance of.
+        When `None` the function behaves like :py:func:`is_instance_of_valid_type`.
+    :param can_be_str: if `True`, strings will also be accepted.
+      :py:mod:`launch.frontend` makes use of this for string embedded substitutions.
+    :raise: `ValueError` if `data_type` is invalid.
+    :return: `True` if `value` is an instance of `data_type`, else `False`.
+    """
+    if data_type is None:
+        return is_instance_of_valid_type(value, can_be_str=can_be_str)
+    type_obj, is_list = extract_type(data_type)
+    if can_be_str:
+        type_obj = (str, type_obj)
+    if not is_list:
+        return isinstance(value, type_obj)
+    if not isinstance(value, list):
+        return False
+    return all(isinstance(x, type_obj) for x in value)
+
+
+def coerce_to_type(
+    value: Text,
+    data_type: Optional[AllowedTypesType] = None,
+    *,
+    can_be_str: bool = False,
+) -> StrSomeValueType:
+    """
+    Coerce `value` type to `data_type`.
+
+    :param value: string to be coerced.
+    :param data_type: value will be coerced to data_type.
+    :param can_be_str: if `True`, the result will be kept as an string if it cannot be coerced.
+      In the case of lists, it will also accept strings as items.
+      :py:mod:`launch.frontend` makes use of this for string embedded substitutions.
+    :raise: `ValueError` if the coercion failed or `data_type` is invalid.
+    :raise: `TypeError` if `value` is not a `str`.
+    :return: `value` coerced to `data_type`.
+    """
+    def convert_as_yaml(value, error_msg):
+        try:
+            output = yaml.safe_load(value)
+        except Exception as err:
+            if can_be_str:
+                return value
+            raise ValueError(f'{error_msg}: yaml.safe_load() failed\n{err}')
+
+        if not is_instance_of_valid_type(output, can_be_str=can_be_str):
+            raise ValueError(
+                f'{error_msg}: output type is not allowed, got {type(output)}'
+            )
+        return output
+
+    ensure_argument_type(value, str, 'value', 'coerce_to_type')
+    if data_type is None:
+        # No type specified, return best conversion.
+        return convert_as_yaml(value, f"Failed to convert '{value}' using yaml rules")
+
+    type_obj, is_list = extract_type(data_type)
+    valid_types = (str, type_obj) if can_be_str else type_obj
+
+    if is_list:
+        output = convert_as_yaml(
+            value, f"Cannot convert value '{value}' to a list of '{valid_types}'")
+        if not isinstance(output, list):
+            raise ValueError(f"Cannot convert value '{value}' to a list of '{valid_types}'")
+        if not all(isinstance(x, valid_types) for x in output):
+            raise ValueError(
+                f"Cannot convert value '{value}' to a list of '{valid_types}', got {output}")
+        return output
+
+    if type_obj is str:
+        return value
+    if type_obj in (int, float):
+        try:
+            return type_obj(value)
+        except ValueError:
+            if can_be_str:
+                return value
+            else:
+                raise
+
+    if type_obj is not bool:
+        raise ValueError(
+            'data_type is invalid. Expected one of: '
+            'int, float, str, bool, List[int], List[float], List[str], List[bool]'
+            f'. Got {data_type}')
+    output = convert_as_yaml(value, f"Failed to convert '{value}' to '{type_obj}'")
+    if isinstance(output, valid_types):
+        return output
+    raise ValueError(f"Cannot convert value '{value}' to '{type_obj}'")
+
+
+def coerce_list(
+    value: List[Text],
+    data_type: Optional[ScalarTypesType] = None,
+    *,
+    can_be_str: bool = False,
+) -> StrSomeSequenceType:
+    """
+    Coerce a list of strings to a list of scalars.
+
+    :param value: list of strings to be coerced.
+    :param data_type: value will be coerced to data_type.
+    :param can_be_str: if `True`, strings will be kept in case coercion fails.
+      launch.frontend makes use of this for string embedded substitutions.
+    :raise: `ValueError` if the coercion failed.
+    :raise: `TypeError` if `value` is not a list of `str`.
+    :return: `value` coerced to `data_type`.
+    """
+    ensure_argument_type(value, list, 'value', 'coerce_list')
+    output = [coerce_to_type(i, data_type, can_be_str=can_be_str) for i in value]
+    if not is_instance_of_valid_type(output, can_be_str=can_be_str):
+        raise ValueError(f'cannot convert value to {data_type}. Got value=`{value}`')
+    return cast(ListValueType, output)
+
+
+def get_typed_value(
+    value: Union[Text, List[Text]],
+    data_type: Optional[AllowedTypesType],
+    *,
+    can_be_str: bool = False,
+) -> StrSomeValueType:
+    """
+    Try to convert `value` to the type specified in `data_type`.
+
+    :param value: string or list of strings to be coerced.
+    :param data_type: value will be coerced to data_type.
+    :param can_be_str: if `True`, strings will be kept in case coercion fails.
+      In the case of lists, it will also accepts strings as items.
+      launch.frontend makes use of this for string embedded substitutions.
+    :raise: `ValueError` if the coercion failed.
+    :raise: `TypeError` if `value` is a `list` and `data_type` is not a `typing.List[x]` object.
+    :raise: `TypeError` if `value` is neither a `str` of a list of `str`.
+    :return: `value` coerced to `data_type`.
+    """
+    if isinstance(value, list):
+        if data_type is not None:
+            data_type, is_list = extract_type(data_type)
+            if not is_list:
+                raise TypeError(
+                    f"Cannot convert input '{value}' of type '{type(value)}' to"
+                    f" '{data_type}'"
+                )
+        output: AllowedValueType = coerce_list(value, data_type, can_be_str=can_be_str)
+    else:
+        output = coerce_to_type(value, data_type, can_be_str=can_be_str)
+    return output
+
+
+def is_substitution(x):
+    """
+    Return `True` if `x` is some substitution.
+
+    This can be:
+    - A :py:class:`launch.Substitution` instance.
+    - A list of mixed `launch.Substitution` and `str` instances,
+        with at least one instance of the former.
+    """
+    return (
+        isinstance(x, Substitution) or
+        (
+            isinstance(x, collections.abc.Iterable) and
+            len(x) > 0 and
+            all(isinstance(item, (Substitution, str)) for item in x) and
+            any(isinstance(item, Substitution) for item in x)
+        )
+    )
+
+
+def normalize_typed_substitution(
+    value: SomeValueType, data_type: Optional[AllowedTypesType]
+) -> NormalizedValueType:
+    """
+    Normalize a mix of substitution and values.
+
+    This function becomes handy when you need a substitution whose result will be coerced to a
+    specific type.
+
+    Example:
+    -------
+    ```python3
+    class MyAction(Action):
+        def __init__(self, my_int: Union[int, SomeSubstitutionsType]):
+            self.__my_int_normalized = normalize_typed_substitution(some_int, int)
+            ...
+
+        def execute(self, context):
+            my_int = perform_typed_substitution(context, self.__my_int_normalized, int)
+            ...
+    ```
+
+    List of substitutions coerced a list to strings can be confused with a single substitution
+    that is coerced to a list of strings.
+    e.g.: `['asd', TextSubstitution(text='bsd')]`
+    To avoid confusions, the passed value will always be interpreted as a single substitution
+    if possible, like in the above example (which will resolved to `'asdbsd'`).
+    To make it a list of substitutions:
+    `['asd', [TextSubstitution(text='bsd')]]`
+
+    :param value: value to be normalized.
+    :param data_type: `value` can be either an instance of `data_type` or a substitution.
+        In the case of lists, `value` can be either a substitution or a list.
+        In the later case, its items should match the type specified by `data_type` or be a
+        substitution.
+        If `None`, it should be possible to perform the resulting normalized `value` to a valid
+        type.
+        See :py:func:`is_substitution`.
+    :return: the normalized `value`.
+    :raise: `TypeError` if the normalized `value` cannot later be resolved to an instance
+        of `data_type`, or to a valid type when `data_type is `None`.
+    :raise: `ValueError` if `data_type` is not valid.
+        See :py:obj:`AllowedTypesTuple`.
+
+    """
+    # Resolve scalar types immediately
+    if isinstance(value, ScalarTypesTuple):
+        if not is_instance_of(value, data_type):
+            raise TypeError(f"value='{value}' is not an instance of {data_type}")
+        return value
+    # Resolve substitutions and list of substitutions immediately
+    if is_substitution(value):
+        return normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, value))
+    # For the other cases, the input must be an iterable
+    if not isinstance(value, collections.abc.Iterable):
+        raise TypeError(
+            'value should be either a scalar, a substitutions,'
+            ' or a mixed list of scalars and substitutions. '
+            f'Got `value={value}` of type `{type(value)}`. '
+        )
+    # Collect the types of the items of the list
+    types_in_list: Set[Optional[Type[Union[str, int, float, bool, Substitution]]]] = set()
+    for x in value:
+        if isinstance(x, ScalarTypesTuple):
+            types_in_list.add(type(x))
+        elif is_substitution(x):
+            types_in_list.add(Substitution)
+        else:
+            raise TypeError(
+                'value is a list, and one of the items is not a scalar, a Substitution '
+                f"or a list of substitutions. Got value='{value}'"
+            )
+    # Extract expected type information
+    is_list = True
+    if data_type is not None:
+        data_type, is_list = extract_type(data_type)
+    # Must be expecting a list
+    if not is_list:
+        raise TypeError(
+            'The provided value resolves to a list, though the required type is a scalar. '
+            f"Got value='{value}', data_type='{data_type}'."
+        )
+
+    # Normalize each specific uniform list input
+    err_msg = (
+        "Got a list of '{}'"
+        f", expected a list of '{data_type}'. value='{value}'"
+    )
+    if types_in_list == {Substitution}:
+        # list of substitutions, can be coerced later to anything
+        return cast(List[Union[List[Substitution], str]], [
+            normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, x)) for x in value
+        ])
+    if types_in_list.issubset({str, Substitution}):
+        # list of mixed strings and substitutions
+        if data_type not in (None, str):
+            raise TypeError(err_msg.format(str))
+        return cast(List[Union[List[Substitution], str]], [
+            x if isinstance(x, str) else  # Don't convert strings to TextSubstitution
+            normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, x)) for x in value
+        ])
+    if types_in_list.issubset({bool, Substitution}):
+        # list of booleans and substitutions
+        if data_type not in (None, bool):
+            raise TypeError(err_msg.format(bool))
+        return cast(List[Union[List[Substitution], bool]], [
+            normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, x))
+            if is_substitution(x) else x for x in value
+        ])
+    if types_in_list.issubset({int, Substitution}):
+        # list of ints and substitutions
+        if data_type not in (None, int):
+            raise TypeError(err_msg.format(int))
+        return cast(List[Union[List[Substitution], int]], [
+            normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, x))
+            if is_substitution(x) else x for x in value
+        ])
+    if types_in_list.issubset({int, float, Substitution}):
+        # list of floats and substitutions
+        if data_type not in (None, float):
+            raise TypeError(err_msg.format(float))
+        return cast(List[Union[List[Substitution], float]], [
+            normalize_to_list_of_substitutions(cast(SomeSubstitutionsType, x))
+            if is_substitution(x) else float(cast(Union[int, float], x)) for x in value
+        ])
+    # Invalid input
+    raise TypeError(
+        "Input value is not an acceptable 'SomeValueType'."
+        f"Got value='{value}'"
+    )
+
+
+def is_normalized_substitution(x):
+    """
+    Return `True` if `x` is a normalized substitution.
+
+    A normalized substitution is a list with :py:class:`launch.Substitution` instances as items.
+    """
+    return (
+        isinstance(x, list) and
+        len(x) > 0 and
+        all(isinstance(item, Substitution) for item in x)
+    )
+
+
+def perform_typed_substitution(
+    context: LaunchContext,
+    value: NormalizedValueType,
+    data_type: Optional[AllowedTypesType]
+) -> AllowedValueType:
+    """
+    Perform a normalized typed substitution.
+
+    This function becomes handy when you need a substitution whose result will be coerced to a
+    specific type.
+
+    See :py:obj:`normalize_typed_substitution` for an example.
+
+    :param context: A :py:class:`launch.LaunchContext` instance.
+        It will be used to perform the substitutions in `value`, if there are any.
+    :param value: normalized typed substitution to be performed.
+    :param data_type: The return value will satisfy `is_instance_of(output) == True`.
+        If after trying to coerce the performed substitution that isn't achieved,
+        `ValueError` is raised.
+        See :py:func:`is_instance_of`.
+    :return: the result of performing all the substitutions in value and coercing the result.
+    :raise: `TypeError` if the normalized `value` cannot later be resolved to an instance
+        of `data_type`, or to a valid type when `data_type is `None`.
+    :raise: `ValueError` if `data_type` is not valid.
+        See :py:obj:`AllowedTypesTuple`.
+    :raise: `ValueError` if after coercing the substitutions the end result is not of the
+        expected type.
+    """
+    if isinstance(value, ScalarTypesTuple):
+        if data_type is not None and not is_instance_of(value, data_type):
+            raise TypeError(
+                f'value=`{value}` is a scalar and not an instance of `{data_type}`')
+        return value
+    elif is_normalized_substitution(value):
+        return coerce_to_type(
+            perform_substitutions(context, cast(List[Substitution], value)),
+            data_type
+        )
+    elif isinstance(value, list):
+        scalar_type: Optional[ScalarTypesType] = None
+        if data_type is not None:
+            scalar_type, is_list = extract_type(data_type)
+            if not is_list:
+                raise ValueError(
+                    'The input value is a list, cannot convert it to a scalar. '
+                    f"Got value='{value}', expected type {scalar_type}."
+                )
+        output = [
+            coerce_to_type(
+                perform_substitutions(context, cast(List[Substitution], x)), scalar_type)
+            if is_normalized_substitution(x) else x for x in value
+        ]
+        if not is_instance_of(output, data_type):
+            raise ValueError(
+                    'The output list does not match the expected type '
+                    f"Got value='{value}', expected type {scalar_type}."
+                    if scalar_type is not None else
+                    'The output list is not uniform'
+                )
+        return cast(ListValueType, output)
+    # Invalid input
+    raise TypeError(
+        "Input value is not an acceptable 'NormalizedValueType'."
+        f"Got value='{value}'"
+    )

--- a/launch/launch/utilities/typing_file_path.py
+++ b/launch/launch/utilities/typing_file_path.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Open Avatar Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import typing
+
+# Type of a filesystem path
+FilePath = typing.TypeVar('FilePath', str, bytes, os.PathLike)

--- a/launch/test/launch/utilities/test_type_utils.py
+++ b/launch/test/launch/utilities/test_type_utils.py
@@ -1,0 +1,581 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test type checking/coercion utils."""
+
+from typing import List
+from typing import Union
+
+from launch.substitutions import TextSubstitution
+from launch.utilities.type_utils import coerce_list
+from launch.utilities.type_utils import coerce_to_type
+from launch.utilities.type_utils import extract_type
+from launch.utilities.type_utils import get_typed_value
+from launch.utilities.type_utils import is_instance_of
+from launch.utilities.type_utils import is_instance_of_valid_type
+from launch.utilities.type_utils import is_normalized_substitution
+from launch.utilities.type_utils import is_substitution
+from launch.utilities.type_utils import is_typing_list
+from launch.utilities.type_utils import is_valid_scalar_type
+from launch.utilities.type_utils import normalize_typed_substitution
+from launch.utilities.type_utils import perform_typed_substitution
+
+import pytest
+
+
+def test_is_typing_list():
+    assert is_typing_list(List)
+    assert is_typing_list(List[int])
+    assert is_typing_list(List[float])
+    assert is_typing_list(List[Union[int, float]])
+    assert not is_typing_list(list)
+    assert not is_typing_list(int)
+    assert not is_typing_list(Union[int, float])
+    assert not is_typing_list(None)
+
+
+def test_is_valid_scalar_type():
+    assert is_valid_scalar_type(int)
+    assert is_valid_scalar_type(float)
+    assert is_valid_scalar_type(bool)
+    assert is_valid_scalar_type(str)
+    assert not is_valid_scalar_type(bytes)
+    assert not is_valid_scalar_type(None)
+    assert not is_valid_scalar_type(List[float])
+    assert not is_valid_scalar_type(list)
+    assert not is_typing_list(int)
+
+
+def test_extract_type():
+    assert extract_type(int) == (int, False)
+    assert extract_type(float) == (float, False)
+    assert extract_type(bool) == (bool, False)
+    assert extract_type(str) == (str, False)
+
+    assert extract_type(List[int]) == (int, True)
+    assert extract_type(List[float]) == (float, True)
+    assert extract_type(List[bool]) == (bool, True)
+    assert extract_type(List[str]) == (str, True)
+
+    with pytest.raises(ValueError):
+        extract_type(List)
+    with pytest.raises(ValueError):
+        extract_type(bytes)
+
+
+@pytest.mark.parametrize(
+    'is_instance_of_valid_type_impl',
+    (
+        is_instance_of_valid_type,
+        lambda x, can_be_str=False: is_instance_of(x, None, can_be_str=can_be_str),
+    ),
+    ids=[
+        'testing is_instance_of_valid_type implementation',
+        'testing is_instance_of implementation',
+    ]
+)
+def test_is_instance_of_valid_type(is_instance_of_valid_type_impl):
+    assert is_instance_of_valid_type_impl(1)
+    assert is_instance_of_valid_type_impl(1.)
+    assert is_instance_of_valid_type_impl('asd')
+    assert is_instance_of_valid_type_impl(True)
+
+    assert is_instance_of_valid_type_impl([1, 2])
+    assert is_instance_of_valid_type_impl([1., 2.])
+    assert is_instance_of_valid_type_impl(['asd', 'bsd'])
+    assert is_instance_of_valid_type_impl([True, False])
+
+    assert not is_instance_of_valid_type_impl([1, '2'])
+    assert not is_instance_of_valid_type_impl(object)
+    assert not is_instance_of_valid_type_impl(test_is_instance_of_valid_type)
+    assert not is_instance_of_valid_type_impl({'key': 'value'})
+
+    assert is_instance_of_valid_type_impl(1, can_be_str=True)
+    assert is_instance_of_valid_type_impl(1., can_be_str=True)
+    assert is_instance_of_valid_type_impl('asd', can_be_str=True)
+    assert is_instance_of_valid_type_impl(True, can_be_str=True)
+
+    assert is_instance_of_valid_type_impl([1, 2], can_be_str=True)
+    assert is_instance_of_valid_type_impl([1, '2'], can_be_str=True)
+    assert is_instance_of_valid_type_impl([1., '2.'], can_be_str=True)
+    assert is_instance_of_valid_type_impl(['asd', 'bsd'], can_be_str=True)
+    assert is_instance_of_valid_type_impl([True, 'False'], can_be_str=True)
+
+    assert not is_instance_of_valid_type_impl([1, '2', 1.], can_be_str=True)
+    assert not is_instance_of_valid_type_impl(object, can_be_str=True)
+    assert not is_instance_of_valid_type_impl(test_is_instance_of_valid_type, can_be_str=True)
+    assert not is_instance_of_valid_type_impl({'key': 'value'}, can_be_str=True)
+
+
+def test_is_instance_of():
+    assert is_instance_of(1, int)
+    assert is_instance_of(1., float)
+    assert is_instance_of('asd', str)
+    assert is_instance_of(True, bool)
+
+    assert is_instance_of([1, 2], List[int])
+    assert is_instance_of([1., 2.], List[float])
+    assert is_instance_of(['asd', 'bsd'], List[str])
+    assert is_instance_of([True, False], List[bool])
+
+    assert not is_instance_of(1., int)
+    assert not is_instance_of(1, float)
+    assert not is_instance_of(True, str)
+    assert not is_instance_of('asd', bool)
+
+    assert not is_instance_of([1, 2.], List[int])
+    assert not is_instance_of([1, 2.], List[float])
+    assert not is_instance_of([True, False], List[str])
+    assert not is_instance_of(['True', 'False'], List[bool])
+
+    assert not is_instance_of(1, List[int])
+    assert not is_instance_of(['1', 2], List[str])
+    assert not is_instance_of(['1', '2'], str)
+
+    assert is_instance_of(1, int, can_be_str=True)
+    assert is_instance_of('1', int, can_be_str=True)
+    assert is_instance_of([1, 2], List[int], can_be_str=True)
+    assert is_instance_of(['1', 2], List[int], can_be_str=True)
+    assert not is_instance_of(['1', 2.], List[int], can_be_str=True)
+    assert not is_instance_of([1, 2.], List[int], can_be_str=True)
+    assert not is_instance_of([1, 2], int, can_be_str=True)
+    assert not is_instance_of([1, '2'], List[str], can_be_str=True)
+
+    with pytest.raises(ValueError):
+        is_instance_of(1, bytes)
+    with pytest.raises(ValueError):
+        is_instance_of([1], List)
+    with pytest.raises(ValueError):
+        is_instance_of([True, False], list)
+    with pytest.raises(ValueError):
+        is_instance_of([True, False], Union[int, str])
+
+
+@pytest.mark.parametrize(
+    'coerce_to_type_impl',
+    (
+        coerce_to_type,
+        lambda value, data_type=None, can_be_str=False: get_typed_value(
+            value, data_type, can_be_str=can_be_str),
+    ),
+    ids=[
+        'testing coerce_to_type implementation',
+        'testing get_typed_value implementation',
+    ]
+)
+def test_coercions_using_yaml_rules(coerce_to_type_impl):
+    assert coerce_to_type_impl('asd') == 'asd'
+    assert coerce_to_type_impl('tRuE') == 'tRuE'
+    assert coerce_to_type_impl("'1'") == '1'
+    assert coerce_to_type_impl("'off'") == 'off'
+
+    assert coerce_to_type_impl('1') == 1
+    assert coerce_to_type_impl('1000') == 1000
+
+    assert coerce_to_type_impl('1.') == 1.0
+    assert coerce_to_type_impl('1000.0') == 1000.
+    assert coerce_to_type_impl('0.2') == .2
+    assert coerce_to_type_impl('.3') == 0.3
+
+    assert coerce_to_type_impl('on') is True
+    assert coerce_to_type_impl('off') is False
+    assert coerce_to_type_impl('True') is True
+
+    assert coerce_to_type_impl('[2, 1, 1]') == [2, 1, 1]
+    assert coerce_to_type_impl('[.2, .1, .1]') == [.2, .1, .1]
+    assert coerce_to_type_impl('[asd, bsd, csd]') == ['asd', 'bsd', 'csd']
+    assert coerce_to_type_impl('[on, false, no]') == [True, False, False]
+
+    assert coerce_to_type_impl('[asd, 2.0]', can_be_str=True) == ['asd', 2.0]
+
+
+@pytest.mark.parametrize(
+    'coerce_to_type_impl',
+    (
+        coerce_to_type,
+        lambda value, data_type=None, can_be_str=False: get_typed_value(
+            value, data_type, can_be_str=can_be_str),
+    ),
+    ids=[
+        'testing coerce_to_type implementation',
+        'testing get_typed_value implementation',
+    ]
+)
+def test_coercions_given_specific_type(coerce_to_type_impl):
+    assert coerce_to_type_impl('asd', data_type=str) == 'asd'
+    assert coerce_to_type_impl('tRuE', data_type=str) == 'tRuE'
+    assert coerce_to_type_impl("'1'", data_type=str) == "'1'"
+    assert coerce_to_type_impl("'off'", data_type=str) == "'off'"
+    assert coerce_to_type_impl("''1''", data_type=str) == "''1''"
+    assert coerce_to_type_impl('{1}', data_type=str) == '{1}'
+
+    assert coerce_to_type_impl('1', data_type=int) == 1
+    assert coerce_to_type_impl('1000', data_type=int) == 1000
+
+    assert coerce_to_type_impl('1', data_type=float) == 1.0
+    assert coerce_to_type_impl('1.', data_type=float) == 1.0
+    assert coerce_to_type_impl('1000.0', data_type=float) == 1000.
+    assert coerce_to_type_impl('0.2', data_type=float) == .2
+    assert coerce_to_type_impl('.3', data_type=float) == 0.3
+
+    assert coerce_to_type_impl('on', data_type=bool) is True
+    assert coerce_to_type_impl('off', data_type=bool) is False
+    assert coerce_to_type_impl('True', data_type=bool) is True
+
+    assert coerce_to_type_impl('[.2, .1, .1]', data_type=List[float]) == [.2, .1, .1]
+    assert coerce_to_type_impl('[asd, bsd, csd]', data_type=List[str]) == ['asd', 'bsd', 'csd']
+    assert coerce_to_type_impl('[on, false, no]', data_type=List[bool]) == [True, False, False]
+
+    assert coerce_to_type_impl(
+        'asd', data_type=float, can_be_str=True) == 'asd'
+    assert coerce_to_type_impl(
+        '[asd, 2.0]', data_type=List[float], can_be_str=True) == ['asd', 2.0]
+
+
+@pytest.mark.parametrize(
+    'coerce_to_type_impl',
+    (
+        coerce_to_type,
+        lambda value, data_type=None, can_be_str=False: get_typed_value(
+            value, data_type, can_be_str=can_be_str),
+    ),
+    ids=[
+        'testing coerce_to_type implementation',
+        'testing get_typed_value implementation',
+    ]
+)
+def test_coercion_raises_value_error(coerce_to_type_impl):
+    with pytest.raises(ValueError):
+        coerce_to_type_impl("''1''")
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('{1}')
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('[1, 2.0]')
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('[asd, 2.0]')
+
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('1000.5', data_type=int)
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('Bsd', data_type=int)
+
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('Bsd', data_type=float)
+
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('Bsd', data_type=bool)
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('1', data_type=bool)
+
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('[1, 2.0]', data_type=List[float])
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('[asd, 2.0]', data_type=List[float])
+
+
+def coerce_to_type_raises_type_error():
+    with pytest.raises(TypeError):
+        coerce_to_type(['a', 'b'])
+
+
+@pytest.mark.parametrize(
+    'coerce_list_impl',
+    (
+        coerce_list,
+        lambda value, data_type=None, can_be_str=False: get_typed_value(
+            value, data_type, can_be_str=can_be_str),
+    ),
+    ids=[
+        'testing coerce_list implementation',
+        'testing get_typed_value implementation',
+    ]
+)
+def test_coercing_list_using_yaml_rules(coerce_list_impl):
+    assert coerce_list_impl(['asd', 'bsd']) == ['asd', 'bsd']
+    assert coerce_list_impl(['1', '1000']) == [1, 1000]
+    assert coerce_list_impl(['1.', '1000.']) == [1., 1000.]
+    assert coerce_list_impl(['on', 'off', 'True']) == [True, False, True]
+
+    assert coerce_list_impl(['asd', '1000'], data_type=None, can_be_str=True) == ['asd', 1000]
+    assert coerce_list_impl(['asd', '1000.'], data_type=None, can_be_str=True) == ['asd', 1000.]
+    assert coerce_list_impl(
+        ['asd', 'off', 'True'], data_type=None, can_be_str=True) == ['asd', False, True]
+
+    with pytest.raises(ValueError):
+        coerce_list_impl(['1000.', '1000'])
+    with pytest.raises(ValueError):
+        coerce_list_impl(['asd', '1000'])
+    with pytest.raises(ValueError):
+        coerce_list_impl(['asd', '1000.'])
+    with pytest.raises(ValueError):
+        coerce_list_impl(['asd', 'True'])
+
+
+@pytest.mark.parametrize(
+    'coerce_list_impl',
+    (
+        coerce_list,
+        lambda value, data_type=None, can_be_str=False: get_typed_value(
+            value, List[data_type], can_be_str=can_be_str),
+    ),
+    ids=[
+        'testing coerce_list implementation',
+        'testing get_typed_value implementation',
+    ]
+)
+def test_coercing_list_given_specific_type(coerce_list_impl):
+    assert coerce_list_impl(['asd', 'bsd'], str) == ['asd', 'bsd']
+    assert coerce_list_impl(['1', '1000'], int) == [1, 1000]
+    assert coerce_list_impl(['1.', '1000.'], float) == [1., 1000.]
+    assert coerce_list_impl(['on', 'off', 'True'], bool) == [True, False, True]
+    assert coerce_list_impl(['1000.', '1000'], float) == [1000., 1000.]
+
+    assert coerce_list_impl(['asd', '1000'], int, can_be_str=True) == ['asd', 1000]
+    assert coerce_list_impl(['asd', '1000.'], float, can_be_str=True) == ['asd', 1000.]
+    assert coerce_list_impl(['asd', 'off', 'True'], bool, can_be_str=True) == ['asd', False, True]
+
+    with pytest.raises(ValueError):
+        coerce_list_impl(['1', '2'], bool)
+    with pytest.raises(ValueError):
+        coerce_list_impl(['asd', '1000'], int)
+    with pytest.raises(ValueError):
+        coerce_list_impl(['asd', '1000.'], float)
+    with pytest.raises(ValueError):
+        coerce_list_impl(['asd', 'True'], bool)
+
+
+def test_coerce_list_raises_type_error():
+    with pytest.raises(TypeError):
+        coerce_list('a')
+    with pytest.raises(TypeError):
+        coerce_list([1, 2])
+
+
+def test_get_typed_value_raises_type_error():
+    with pytest.raises(TypeError):
+        get_typed_value({'a'})
+    with pytest.raises(TypeError):
+        get_typed_value(['1', '2'], int)
+    with pytest.raises(TypeError):
+        get_typed_value([1, 2])
+
+
+def test_is_substitution():
+    assert is_substitution(TextSubstitution(text='asd'))
+    assert is_substitution([
+        TextSubstitution(text='asd'),
+        'bsd'
+    ])
+    assert is_substitution([
+        'asd',
+        TextSubstitution(text='bsd'),
+    ])
+    assert is_substitution([
+        TextSubstitution(text='asd'),
+        TextSubstitution(text='bsd'),
+    ])
+    assert not is_substitution([])
+    assert not is_substitution('asd')
+    assert not is_substitution(['asd', 'bsd'])
+    assert not is_substitution(['asd', 'bsd'])
+    assert not is_substitution(1)
+
+
+def test_normalize_typed_substitution():
+    assert normalize_typed_substitution(1, int) == 1
+
+    nts = normalize_typed_substitution(TextSubstitution(text='bsd'), int)
+    assert isinstance(nts, list)
+    assert len(nts) == 1
+    assert isinstance(nts[0], TextSubstitution)
+
+    nts = normalize_typed_substitution(
+        [
+            TextSubstitution(text='asd'),
+            TextSubstitution(text='bsd'),
+        ],
+        int
+    )
+    assert len(nts) == 2
+    assert isinstance(nts[0], TextSubstitution)
+    assert isinstance(nts[1], TextSubstitution)
+
+    nts = normalize_typed_substitution(TextSubstitution(text='bsd'), int)
+    assert isinstance(nts, list)
+    assert len(nts) == 1
+    assert isinstance(nts[0], TextSubstitution)
+
+    nts = normalize_typed_substitution(
+        [
+            TextSubstitution(text='asd'),
+            TextSubstitution(text='bsd'),
+        ],
+        List[int]
+    )
+    assert len(nts) == 2
+    assert isinstance(nts[0], TextSubstitution)
+    assert isinstance(nts[1], TextSubstitution)
+
+    assert normalize_typed_substitution([1, 2], List[int]) == [1, 2]
+    nts = normalize_typed_substitution([TextSubstitution(text='bsd'), 2], List[int])
+    assert len(nts) == 2
+    assert isinstance(nts[0], list)
+    assert len(nts[0]) == 1
+    assert isinstance(nts[0][0], TextSubstitution)
+    assert nts[1] == 2
+
+    nts = normalize_typed_substitution([[TextSubstitution(text='bsd')], 2], List[int])
+    assert len(nts) == 2
+    assert len(nts[0]) == 1
+    assert isinstance(nts[0][0], TextSubstitution)
+    assert nts[1] == 2
+
+    nts = normalize_typed_substitution([[TextSubstitution(text='asd')], 'bsd'], List[str])
+    assert len(nts) == 2
+    assert len(nts[0]) == 1
+    assert isinstance(nts[0][0], TextSubstitution)
+    assert nts[1] == 'bsd'
+
+    nts = normalize_typed_substitution(
+        [
+            [TextSubstitution(text='asd')],
+            [TextSubstitution(text='bsd'), 'bsd'],
+        ],
+        List[int]
+    )
+    assert len(nts) == 2
+    assert isinstance(nts[0], list)
+    assert len(nts[0]) == 1
+    assert isinstance(nts[0][0], TextSubstitution)
+    assert isinstance(nts[1], list)
+    assert len(nts[1]) == 2
+    assert isinstance(nts[1][0], TextSubstitution)
+    assert isinstance(nts[1][1], TextSubstitution)  # should have been normalized
+
+    assert normalize_typed_substitution(1, data_type=None) == 1
+
+    nts = normalize_typed_substitution(TextSubstitution(text='bsd'), data_type=None)
+    assert isinstance(nts, list)
+    assert len(nts) == 1
+    assert isinstance(nts[0], TextSubstitution)
+
+    nts = normalize_typed_substitution(
+        [
+            TextSubstitution(text='asd'),
+            TextSubstitution(text='bsd'),
+        ],
+        data_type=None
+    )
+    assert len(nts) == 2
+    assert isinstance(nts[0], TextSubstitution)
+    assert isinstance(nts[1], TextSubstitution)
+
+    nts = normalize_typed_substitution([TextSubstitution(text='bsd'), 2], data_type=None)
+    assert len(nts) == 2
+    assert isinstance(nts[0], list)
+    assert len(nts[0]) == 1
+    assert isinstance(nts[0][0], TextSubstitution)
+    assert nts[1] == 2
+
+    with pytest.raises(ValueError):
+        normalize_typed_substitution(1, bytes)
+    with pytest.raises(TypeError):
+        normalize_typed_substitution(1, List[int])
+    with pytest.raises(TypeError):
+        normalize_typed_substitution(['asd', 2], List[int])
+
+
+def test_is_normalized_substitution():
+    assert is_normalized_substitution([TextSubstitution(text='asd')])
+    assert is_normalized_substitution(
+        [TextSubstitution(text='asd'), TextSubstitution(text='bsd')])
+
+    assert not is_normalized_substitution(TextSubstitution(text='asd'))
+    assert not is_normalized_substitution([TextSubstitution(text='asd'), 'bsd'])
+    assert not is_normalized_substitution(['bsd'])
+    assert not is_normalized_substitution('bsd')
+
+
+class MockContext:
+
+    def __init__(self):
+        self.launch_configurations = {}
+
+    def perform_substitution(self, sub):
+        return sub.perform(None)
+
+
+def test_perform_typed_substitution():
+    lc = MockContext()
+
+    assert perform_typed_substitution(lc, 1, int) == 1
+    assert perform_typed_substitution(lc, [TextSubstitution(text='1')], int) == 1
+    assert perform_typed_substitution(
+        lc, [TextSubstitution(text='[1, 2, 3]')], List[int]) == [1, 2, 3]
+    assert perform_typed_substitution(
+        lc, [TextSubstitution(text='[1, 2, 3]')], None) == [1, 2, 3]
+
+    assert perform_typed_substitution(
+        lc,
+        [
+            TextSubstitution(text='100'),
+            TextSubstitution(text='.'),
+            TextSubstitution(text='5'),
+        ],
+        float,
+    ) == 100.5
+
+    assert perform_typed_substitution(
+        lc,
+        [
+            [TextSubstitution(text='100')],
+            [TextSubstitution(text='1')],
+            [TextSubstitution(text='5')],
+        ],
+        List[int],
+    ) == [100, 1, 5]
+
+    assert perform_typed_substitution(
+        lc,
+        [
+            'asd',
+            [TextSubstitution(text='bsd')],
+            [TextSubstitution(text='csd')],
+        ],
+        List[str],
+    ) == ['asd', 'bsd', 'csd']
+
+    assert perform_typed_substitution(
+        lc,
+        [
+            'asd',
+            [TextSubstitution(text='bsd')],
+            [TextSubstitution(text='csd')],
+        ],
+        data_type=None,
+    ) == ['asd', 'bsd', 'csd']
+
+    with pytest.raises(TypeError):
+        perform_typed_substitution(lc, object, int)
+    with pytest.raises(TypeError):
+        perform_typed_substitution(lc, 1., int)
+    with pytest.raises(ValueError):
+        perform_typed_substitution(lc, 'asd', bytes)
+    with pytest.raises(ValueError):
+        perform_typed_substitution(lc, [TextSubstitution(text='1.')], int)
+    with pytest.raises(ValueError):
+        perform_typed_substitution(lc, [TextSubstitution(text='1')], List[int])
+    with pytest.raises(ValueError):
+        perform_typed_substitution(
+            lc, [[TextSubstitution(text='1.')], [TextSubstitution(text='1')]], data_type=None)

--- a/launch/test/launch/utilities/test_type_utils.py
+++ b/launch/test/launch/utilities/test_type_utils.py
@@ -175,6 +175,7 @@ def test_is_instance_of():
     ]
 )
 def test_coercions_using_yaml_rules(coerce_to_type_impl):
+    assert coerce_to_type_impl('') == ''
     assert coerce_to_type_impl('asd') == 'asd'
     assert coerce_to_type_impl('tRuE') == 'tRuE'
     assert coerce_to_type_impl("'1'") == '1'
@@ -213,6 +214,7 @@ def test_coercions_using_yaml_rules(coerce_to_type_impl):
     ]
 )
 def test_coercions_given_specific_type(coerce_to_type_impl):
+    assert coerce_to_type_impl('', data_type=str) == ''
     assert coerce_to_type_impl('asd', data_type=str) == 'asd'
     assert coerce_to_type_impl('tRuE', data_type=str) == 'tRuE'
     assert coerce_to_type_impl("'1'", data_type=str) == "'1'"
@@ -266,18 +268,26 @@ def test_coercion_raises_value_error(coerce_to_type_impl):
         coerce_to_type_impl('[asd, 2.0]')
 
     with pytest.raises(ValueError):
+        coerce_to_type_impl('', data_type=int)
+    with pytest.raises(ValueError):
         coerce_to_type_impl('1000.5', data_type=int)
     with pytest.raises(ValueError):
         coerce_to_type_impl('Bsd', data_type=int)
 
     with pytest.raises(ValueError):
+        coerce_to_type_impl('', data_type=float)
+    with pytest.raises(ValueError):
         coerce_to_type_impl('Bsd', data_type=float)
 
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('', data_type=bool)
     with pytest.raises(ValueError):
         coerce_to_type_impl('Bsd', data_type=bool)
     with pytest.raises(ValueError):
         coerce_to_type_impl('1', data_type=bool)
 
+    with pytest.raises(ValueError):
+        coerce_to_type_impl('', data_type=List[float])
     with pytest.raises(ValueError):
         coerce_to_type_impl('[1, 2.0]', data_type=List[float])
     with pytest.raises(ValueError):
@@ -302,16 +312,20 @@ def coerce_to_type_raises_type_error():
     ]
 )
 def test_coercing_list_using_yaml_rules(coerce_list_impl):
+    assert coerce_list_impl(['']) == ['']
     assert coerce_list_impl(['asd', 'bsd']) == ['asd', 'bsd']
     assert coerce_list_impl(['1', '1000']) == [1, 1000]
     assert coerce_list_impl(['1.', '1000.']) == [1., 1000.]
     assert coerce_list_impl(['on', 'off', 'True']) == [True, False, True]
 
+    assert coerce_list_impl(['', '1000'], data_type=None, can_be_str=True) == ['', 1000]
     assert coerce_list_impl(['asd', '1000'], data_type=None, can_be_str=True) == ['asd', 1000]
     assert coerce_list_impl(['asd', '1000.'], data_type=None, can_be_str=True) == ['asd', 1000.]
     assert coerce_list_impl(
         ['asd', 'off', 'True'], data_type=None, can_be_str=True) == ['asd', False, True]
 
+    with pytest.raises(ValueError):
+        coerce_list_impl(['', '1000'])
     with pytest.raises(ValueError):
         coerce_list_impl(['1000.', '1000'])
     with pytest.raises(ValueError):
@@ -335,12 +349,14 @@ def test_coercing_list_using_yaml_rules(coerce_list_impl):
     ]
 )
 def test_coercing_list_given_specific_type(coerce_list_impl):
+    assert coerce_list_impl([''], str) == ['']
     assert coerce_list_impl(['asd', 'bsd'], str) == ['asd', 'bsd']
     assert coerce_list_impl(['1', '1000'], int) == [1, 1000]
     assert coerce_list_impl(['1.', '1000.'], float) == [1., 1000.]
     assert coerce_list_impl(['on', 'off', 'True'], bool) == [True, False, True]
     assert coerce_list_impl(['1000.', '1000'], float) == [1000., 1000.]
 
+    assert coerce_list_impl(['', '1000'], int, can_be_str=True) == ['', 1000]
     assert coerce_list_impl(['asd', '1000'], int, can_be_str=True) == ['asd', 1000]
     assert coerce_list_impl(['asd', '1000.'], float, can_be_str=True) == ['asd', 1000.]
     assert coerce_list_impl(['asd', 'off', 'True'], bool, can_be_str=True) == ['asd', False, True]

--- a/launch_xml/README.md
+++ b/launch_xml/README.md
@@ -23,17 +23,11 @@ By default, the value of the attribute is returned as a string.
 
 Allowed types are:
     - scalar types: `str, int, float, bool`
-    - lists: Can be uniform like `List[int]`, or non-uniform like `List[Union[str, int]]`, `List` (same as `list`).
-        In any case, the members should be of one of the scalar types.
-    - An union of both any of the above. e.g.: `Union[List[int], int]`.
+    - An uniform list, e.g.: `List[int]`.
     - The list of entities type: `List[Entity]` (see below).
 
 `List` is the usual object from the `typing` package.
-`data_type` can also be set to `None`, which works in the same way as passing:
-
-```python
-Union[int, float, bool, list, str]
-```
+`data_type` can also be set to `None`, in which case yaml rules will be used.
 
 For handling lists, the `*-sep` attribute is used. e.g.:
 
@@ -49,6 +43,13 @@ tag2.get_attr('value', data_type=List[float]) == [2.0, 3.0, 4.0]
 tag3.get_attr('value', data_type=List[str]) == ['2', '3', '4']
 ```
 
+In the case a value can be either an instance of a type or a substitution, the `can_be_str` argument of `get_attr` must be used, followed by a call to `parser.parse_if_substitutions`:
+
+```python
+value = e.get_attr('value2', data_type=int, can_be_str=True)
+normalized_value = parser.parse_if_substitutions(value)
+```
+
 For checking if an attribute exists, use an optional argument:
 
 ```python
@@ -57,7 +58,7 @@ if value is not None:
     do_something(value)
 ```
 
-With `optional=False` (default), `AttributeError` is raised if it is not found.
+With `optional=False` (default), `AttributeError` is raised if the specified attribute is not found.
 
 ### Accessing XML children as attributes:
 

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -14,7 +14,6 @@
 
 """Module for Entity class."""
 
-from typing import Any
 from typing import List
 from typing import Optional
 from typing import Text
@@ -23,7 +22,9 @@ import xml.etree.ElementTree as ET
 
 from launch.frontend import Entity as BaseEntity
 from launch.frontend.type_utils import check_is_list_entity
-from launch.frontend.type_utils import get_typed_value
+from launch.utilities.type_utils import AllowedTypesType
+from launch.utilities.type_utils import AllowedValueType
+from launch.utilities.type_utils import get_typed_value
 
 
 class Entity(BaseEntity):
@@ -58,14 +59,20 @@ class Entity(BaseEntity):
         self,
         name: Text,
         *,
-        data_type: Any = str,
-        optional: bool = False
+        data_type: AllowedTypesType = str,
+        optional: bool = False,
+        can_be_str: bool = True,
     ) -> Optional[Union[
-        List[Union[int, str, float, bool]],
-        Union[int, str, float, bool],
-        List['Entity']
+        AllowedValueType,
+        List['Entity'],
     ]]:
-        """Access an attribute of the entity."""
+        """
+        Access an attribute of the entity.
+
+        See :ref:meth:`launch.frontend.Entity.get_attr`.
+        `launch_xml` uses type coercion.
+        If coercion fails, `ValueError` will be raised.
+        """
         attr_error = AttributeError(
             'Attribute {} of type {} not found in Entity {}'.format(
                 name, data_type, self.type_name
@@ -93,7 +100,7 @@ class Entity(BaseEntity):
             else:
                 return None
         try:
-            value = get_typed_value(value, data_type)
+            value = get_typed_value(value, data_type, can_be_str=can_be_str)
         except ValueError:
             raise TypeError(
                 'Attribute {} of Entity {} expected to be of type {}.'

--- a/launch_yaml/README.md
+++ b/launch_yaml/README.md
@@ -32,16 +32,21 @@ e.get_attr('value3')
 
 Allowed types are:
     - scalar types: `str, int, float, bool`
-    - lists: Can be uniform like `List[int]`, or non-uniform like `List[Union[str, int]]`, `List` (same as `list`).
-        In any case, the members should be of one of the scalar types.
-    - An union of both any of the above. e.g.: `Union[List[int], int]`.
+    - An uniform list, e.g.: `List[int]`.
     - The list of entities type: `List[Entity]` (see below).
 
 `List` is the usual object from the `typing` package.
-`data_type` can also be set to `None`, which works in the same way as passing:
+`data_type` can also be set to `None`, in which case any of the following scalar types or uniform lists of them are allowed:
 
 ```python
-Union[int, float, bool, list, str]
+int, float, bool, str
+```
+
+In the case a value can be either an instance of a type or a substitution, the `can_be_str` argument of `get_attr` must be used, followed by a call to `parser.parse_if_substitutions`:
+
+```python
+value = e.get_attr('value2', data_type=int, can_be_str=True)
+normalized_value = parser.parse_if_substitutions(value)
 ```
 
 For checking if an attribute exists, use optional argument:

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -14,7 +14,6 @@
 
 """Module for YAML Entity class."""
 
-from typing import Any
 from typing import List
 from typing import Optional
 from typing import Text
@@ -22,7 +21,9 @@ from typing import Union
 
 from launch.frontend import Entity as BaseEntity
 from launch.frontend.type_utils import check_is_list_entity
-from launch.frontend.type_utils import check_type
+from launch.utilities.type_utils import AllowedTypesType
+from launch.utilities.type_utils import AllowedValueType
+from launch.utilities.type_utils import is_instance_of
 
 
 class Entity(BaseEntity):
@@ -75,14 +76,20 @@ class Entity(BaseEntity):
         self,
         name: Text,
         *,
-        data_type: Any = str,
-        optional: bool = False
+        data_type: AllowedTypesType = str,
+        optional: bool = False,
+        can_be_str: bool = True,
     ) -> Optional[Union[
-        List[Union[int, str, float, bool]],
-        Union[int, str, float, bool],
-        List['Entity']
+        AllowedValueType,
+        List['Entity'],
     ]]:
-        """Access an attribute of the entity."""
+        """
+        Access an attribute of the entity.
+
+        See :ref:meth:`launch.frontend.Entity.get_attr`.
+        `launch_yaml` does not apply type coercion,
+        it only checks if the read value is of the correct type.
+        """
         if name not in self.__element:
             if not optional:
                 raise AttributeError(
@@ -99,7 +106,7 @@ class Entity(BaseEntity):
                     name, self.type_name
                 )
             )
-        if not check_type(data, data_type):
+        if not is_instance_of(data, data_type, can_be_str=can_be_str):
             raise TypeError(
                 'Attribute {} of Entity {} expected to be of type {}, got {}'.format(
                     name, self.type_name, data_type, type(data)


### PR DESCRIPTION
Backport #414 (prerequisite for #438) (6fd0e83)
Backport #438 (175c466)
Add back functions removed in #438 for backwards compatibility (7ce628f)

For context, this is part of an effort to fix https://github.com/ros2/launch_ros/issues/214 for Foxy.
This PR will enable us to easily backport https://github.com/ros2/launch_ros/pull/137

I don't think there are any significant changes to API, but it's a large change so I may be mistaken.