### PR TITLE
Add pathlib.Path to SomeSubstitutionsType

### DIFF
--- a/launch/launch/some_substitutions_type.py
+++ b/launch/launch/some_substitutions_type.py
@@ -15,6 +15,7 @@
 """Module for SomeSubstitutionsType type."""
 
 import collections.abc
+import pathlib
 from typing import Iterable
 from typing import Text
 from typing import Union
@@ -24,11 +25,13 @@ from .substitution import Substitution
 SomeSubstitutionsType = Union[
     Text,
     Substitution,
-    Iterable[Union[Text, Substitution]],
+    pathlib.Path,
+    Iterable[Union[Text, Substitution, pathlib.Path]],
 ]
 
 SomeSubstitutionsType_types_tuple = (
     str,
     Substitution,
+    pathlib.Path,
     collections.abc.Iterable,
 )


### PR DESCRIPTION
I'm making this change relatively blindly as a way to start discussion. 

In https://github.com/ament/ament_index/pull/73 I added the ability to load the path to a package as a `pathlib.Path`. I'd like to be able to directly use that in my launch files without manually converting to `str`. Consider the following example:

```
from ament_index_python.packages import get_package_share_path

from launch import LaunchDescription
from launch.actions import IncludeLaunchDescription
from launch.launch_description_sources import PythonLaunchDescriptionSource

def generate_launch_description():
    pkg_path = get_package_share_path('super_launch_package')
    launch_py_1 = PythonLaunchDescriptionSource(str(pkg_path / 'launch/launch_1.launch.py'))
    launch_py_2 = PythonLaunchDescriptionSource(str(pkg_path / 'launch/launch_2.launch.py'))
    ld.add_action(IncludeLaunchDescription(launch_py_1))
    ld.add_action(IncludeLaunchDescription(launch_py_2))
    return ld
```

Questions I have:
 * Where are there repercussions of this that I'm missing? 
 * Where should tests be added? 