### PR TITLE
[launch_pytest] Modify how wait_for_output()/wait_for_stderr() work, add assert_*() alternatives

### DIFF
--- a/launch_pytest/launch_pytest/tools/__init__.py
+++ b/launch_pytest/launch_pytest/tools/__init__.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 from . import process
+from .process import assert_output
+from .process import assert_output_sync
+from .process import assert_stderr
+from .process import assert_stderr_sync
 from .process import wait_for_exit
 from .process import wait_for_exit_sync
 from .process import wait_for_output
@@ -23,6 +27,10 @@ from .process import wait_for_stderr
 from .process import wait_for_stderr_sync
 
 __all__ = [
+    'assert_output',
+    'assert_output_sync',
+    'assert_stderr',
+    'assert_stderr_sync',
     'process',
     'wait_for_exit',
     'wait_for_exit_sync',

--- a/launch_pytest/launch_pytest/tools/process.py
+++ b/launch_pytest/launch_pytest/tools/process.py
@@ -119,7 +119,8 @@ async def assert_output(
         _get_stdout_event_handler,
         condition,
         timeout)
-    return cond_value if cond_value else validate_output(execute_process_action.get_stdout())
+    if not cond_value:
+        validate_output(execute_process_action.get_stdout())
 
 
 def wait_for_output_sync(
@@ -148,7 +149,8 @@ def assert_output_sync(
         _get_stdout_event_handler,
         condition,
         timeout)
-    return cond_value if cond_value else validate_output(execute_process_action.get_stdout())
+    if not cond_value:
+        validate_output(execute_process_action.get_stdout())
 
 
 def _get_stderr_event_handler(action, pyevent):
@@ -182,7 +184,8 @@ async def assert_stderr(
         _get_stderr_event_handler,
         condition,
         timeout)
-    return cond_value if cond_value else validate_output(execute_process_action.get_stderr())
+    if not cond_value:
+        validate_output(execute_process_action.get_stderr())
 
 
 def wait_for_stderr_sync(
@@ -211,7 +214,8 @@ def assert_stderr_sync(
         _get_stderr_event_handler,
         condition,
         timeout)
-    return cond_value if cond_value else validate_output(execute_process_action.get_stderr())
+    if not cond_value:
+        validate_output(execute_process_action.get_stderr())
 
 
 def _get_on_process_start_event_handler(execute_process_action, pyevent):

--- a/launch_pytest/test/launch_pytest/examples/pytest_hello_world.py
+++ b/launch_pytest/test/launch_pytest/examples/pytest_hello_world.py
@@ -50,8 +50,7 @@ def test_read_stdout(hello_world_proc, launch_context):
         # this function can use assertions to validate the output or return a boolean.
         # pytest generates easier to understand failures when assertions are used.
         assert output.splitlines() == ['hello_world'], 'process never printed hello_world'
-        return True
-    assert process_tools.wait_for_output_sync(
+    process_tools.assert_output_sync(
         launch_context, hello_world_proc, validate_output, timeout=5)
 
     def validate_output(output):

--- a/launch_pytest/test/launch_pytest/tools/test_process.py
+++ b/launch_pytest/test/launch_pytest/tools/test_process.py
@@ -52,14 +52,12 @@ async def test_async_process_tools(dut, launch_context):
 
     def check_output(output):
         assert output.splitlines() == ['hello']
-        return True
-    assert await tools.wait_for_output(
+    await tools.assert_output(
         launch_context, dut, check_output, timeout=10)
 
     def check_stderr(err):
         assert err.splitlines() == ['world']
-        return True
-    assert await tools.wait_for_stderr(
+    await tools.assert_stderr(
         launch_context, dut, check_stderr, timeout=10)
     assert await tools.wait_for_exit(launch_context, dut, timeout=10)
 
@@ -70,13 +68,11 @@ def test_sync_process_tools(dut, launch_context):
 
     def check_output(output):
         assert output.splitlines() == ['hello']
-        return True
-    assert tools.wait_for_output_sync(
+    tools.assert_output_sync(
         launch_context, dut, check_output, timeout=10)
 
     def check_stderr(err):
         assert err.splitlines() == ['world']
-        return True
-    assert tools.wait_for_stderr_sync(
+    tools.assert_stderr_sync(
         launch_context, dut, check_stderr, timeout=10)
     assert tools.wait_for_exit_sync(launch_context, dut, timeout=10)


### PR DESCRIPTION
Addresses suggestion in https://github.com/ros2/launch/pull/552#discussion_r743890788.