### PR TITLE
Improve launch arguments introspection

### DIFF
--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -137,9 +137,9 @@ class IncludeLaunchDescription(Action):
             ]
         except Exception as exc:
             self.__logger.debug(
-                'Failed to get launch arguments names for launch description: '
-                f'{self.__launch_description_source.location}'
-                f'exception: {str(exc)}'
+                'Failed to get launch arguments names for launch description '
+                f"'{self.__launch_description_source.location}', "
+                f'with exception: {str(exc)}'
             )
         return None
 

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -135,10 +135,11 @@ class IncludeLaunchDescription(Action):
                 perform_substitutions(context, normalize_to_list_of_substitutions(arg_name))
                 for arg_name, arg_value in self.__launch_arguments
             ]
-        except Exception:
+        except Exception as exc:
             self.__logger.debug(
                 'Failed to get launch arguments names for launch description: '
                 f'{self.__launch_description_source.location}'
+                f'exception: {str(exc)}'
             )
         return None
 

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -21,6 +21,8 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+import launch.logging
+
 from .set_launch_configuration import SetLaunchConfiguration
 from ..action import Action
 from ..frontend import Entity
@@ -77,6 +79,7 @@ class IncludeLaunchDescription(Action):
             launch_description_source = AnyLaunchDescriptionSource(launch_description_source)
         self.__launch_description_source = launch_description_source
         self.__launch_arguments = () if launch_arguments is None else tuple(launch_arguments)
+        self.__logger = launch.logging.get_logger(__name__)
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
@@ -125,6 +128,20 @@ class IncludeLaunchDescription(Action):
         ret = self.__launch_description_source.try_get_launch_description_without_context()
         return [ret] if ret is not None else []
 
+    def _try_get_arguments_names_without_context(self):
+        try:
+            context = LaunchContext()
+            return [
+                perform_substitutions(context, normalize_to_list_of_substitutions(arg_name))
+                for arg_name, arg_value in self.__launch_arguments
+            ]
+        except Exception:
+            self.__logger.debug(
+                'Failed to get launch arguments names for launch description: '
+                f'{self.__launch_description_source.location}'
+            )
+        return None
+
     def execute(self, context: LaunchContext) -> List[LaunchDescriptionEntity]:
         """Execute the action."""
         launch_description = self.__launch_description_source.get_launch_description(context)
@@ -138,14 +155,19 @@ class IncludeLaunchDescription(Action):
 
         # Do best effort checking to see if non-optional, non-default declared arguments
         # are being satisfied.
-        argument_names = [
+        my_argument_names = [
             perform_substitutions(context, normalize_to_list_of_substitutions(arg_name))
             for arg_name, arg_value in self.launch_arguments
         ]
-        declared_launch_arguments = launch_description.get_launch_arguments()
-        for argument in declared_launch_arguments:
+        declared_launch_arguments = (
+            launch_description.get_launch_arguments_with_include_launch_descriptions())
+        for argument, ild_actions in declared_launch_arguments:
             if argument._conditionally_included or argument.default_value is not None:
                 continue
+            argument_names = my_argument_names
+            if ild_actions is not None:
+                for ild_action in ild_actions:
+                    argument_names.extend(ild_action._try_get_arguments_names_without_context())
             if argument.name not in argument_names:
                 raise RuntimeError(
                     "Included launch description missing required argument '{}' "

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -161,7 +161,7 @@ class IncludeLaunchDescription(Action):
             for arg_name, arg_value in self.launch_arguments
         ]
         declared_launch_arguments = (
-            launch_description.get_launch_arguments_with_include_launch_descriptions())
+            launch_description.get_launch_arguments_with_include_launch_description_actions())
         for argument, ild_actions in declared_launch_arguments:
             if argument._conditionally_included or argument.default_value is not None:
                 continue

--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -18,6 +18,8 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Text
+from typing import Tuple
+from typing import TYPE_CHECKING
 
 import launch.logging
 
@@ -25,6 +27,9 @@ from .action import Action
 from .actions import DeclareLaunchArgument
 from .launch_context import LaunchContext
 from .launch_description_entity import LaunchDescriptionEntity
+
+if TYPE_CHECKING:
+    from .actions.include_launch_description import IncludeLaunchDescription  # noqa: F401
 
 
 class LaunchDescription(LaunchDescriptionEntity):
@@ -86,9 +91,9 @@ class LaunchDescription(LaunchDescriptionEntity):
 
     def get_launch_arguments_with_include_launch_descriptions(
         self, conditional_inclusion=False
-    ) -> List[DeclareLaunchArgument]:
+    ) -> List[Tuple[DeclareLaunchArgument, List['IncludeLaunchDescription']]]:
         """
-        Return a list of (:py:class:`launch.actions.DeclareLaunchArgument`, Optional[List[:py:class:`launch.actions.IncludeLaunchDescription`]]) pairs.
+        Return a list of launch arguments with its associated include launch descriptions actions.
 
         The first element of the tuple is a declare launch argument action.
         The second is `None` if the argument was declared at the top level of this
@@ -116,8 +121,10 @@ class LaunchDescription(LaunchDescriptionEntity):
         Duplicate declarations of an argument are ignored, therefore the
         default value and description from the first instance of the argument
         declaration is used.
-        """  # noqa: E501
-        declared_launch_arguments = []  # type: List[DeclareLaunchArgument]
+        """
+        from .actions import IncludeLaunchDescription  # noqa: F811
+        declared_launch_arguments: List[
+            Tuple[DeclareLaunchArgument, List[IncludeLaunchDescription]]] = []
         from .actions import ResetLaunchConfigurations
 
         def process_entities(entities, *, _conditional_inclusion, nested_ild_actions=None):
@@ -135,7 +142,6 @@ class LaunchDescription(LaunchDescriptionEntity):
                     # Launch arguments after this cannot be set directly by top level arguments
                     return
                 else:
-                    from .actions import IncludeLaunchDescription
                     next_nested_ild_actions = nested_ild_actions
                     if isinstance(entity, IncludeLaunchDescription):
                         if next_nested_ild_actions is None:

--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -81,15 +81,16 @@ class LaunchDescription(LaunchDescriptionEntity):
         """
         Return a list of :py:class:`launch.actions.DeclareLaunchArgument` actions.
 
-        See :py:method:`get_launch_arguments_with_launch_descriptions()`
+        See :py:method:`get_launch_arguments_with_include_launch_description_actions()`
         for more details.
         """
         return [
             item[0] for item in
-            self.get_launch_arguments_with_include_launch_descriptions(conditional_inclusion)
+            self.get_launch_arguments_with_include_launch_description_actions(
+                conditional_inclusion)
         ]
 
-    def get_launch_arguments_with_include_launch_descriptions(
+    def get_launch_arguments_with_include_launch_description_actions(
         self, conditional_inclusion=False
     ) -> List[Tuple[DeclareLaunchArgument, List['IncludeLaunchDescription']]]:
         """

--- a/launch/test/launch/actions/test_include_launch_description.py
+++ b/launch/test/launch/actions/test_include_launch_description.py
@@ -22,6 +22,7 @@ from launch import LaunchDescriptionSource
 from launch import LaunchService
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.actions import ResetLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.utilities import perform_substitutions
@@ -183,6 +184,24 @@ def test_include_launch_description_launch_arguments():
     action2 = IncludeLaunchDescription(
         LaunchDescriptionSource(ld2),
         launch_arguments={'foo': 'FOO', 'foo2': 'FOO2'}.items(),
+    )
+    lc2 = LaunchContext()
+    action2.visit(lc2)
+
+    # Test that arguments after a ResetLaunchConfigurations action are not checked
+    ld1 = LaunchDescription([DeclareLaunchArgument('foo')])
+    action1 = IncludeLaunchDescription(
+        LaunchDescriptionSource(ld1)
+    )
+    ld2 = LaunchDescription(
+        [
+            DeclareLaunchArgument('foo2'),
+            ResetLaunchConfigurations(),
+            SetLaunchConfiguration('foo', 'asd'),
+            action1])
+    action2 = IncludeLaunchDescription(
+        LaunchDescriptionSource(ld2),
+        launch_arguments={'foo2': 'FOO2'}.items(),
     )
     lc2 = LaunchContext()
     action2.visit(lc2)

--- a/launch/test/launch/test_launch_description.py
+++ b/launch/test/launch/test_launch_description.py
@@ -60,7 +60,7 @@ def test_launch_description_get_launch_arguments():
         ]))),
     ])
     la = ld.get_launch_arguments()
-    assert len(la) == 0
+    assert len(la) == 1
 
     this_dir = os.path.dirname(os.path.abspath(__file__))
     ld = LaunchDescription([
@@ -68,7 +68,7 @@ def test_launch_description_get_launch_arguments():
             os.path.join(this_dir, 'launch_file_with_argument.launch.py'))),
     ])
     la = ld.get_launch_arguments()
-    assert len(la) == 0
+    assert len(la) == 1
 
     # From issue #144: get_launch_arguments was broken when an entitity had conditional
     # sub entities


### PR DESCRIPTION
Currently you can set an argument of a nested launch description from the top level, without the need of redeclaring the argument.
This updates the `get_launch_arguments()` method to return a more complete result (currently it doesn't return arguments from included launch descriptions).
It also updates the `include_launch_description` launch arguments validation by tracking all the include launch description actions in the middle (this basically avoids reintroducing https://github.com/ros2/launch/issues/248).

Related discussion https://github.com/ros2/launch/issues/313.