### PR TITLE
Evaluate math symbols and functions in python expression

### DIFF
--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -33,8 +33,8 @@ class PythonExpression(Substitution):
     Substitution that can access contextual local variables.
 
     The expression may contain Substitutions, but must return something that can
-    be converted to a string with `str()`. It also may contain math symbols and
-    functions.
+    be converted to a string with `str()`.
+    It also may contain math symbols and functions.
     """
 
     def __init__(self, expression: SomeSubstitutionsType) -> None:

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -15,6 +15,7 @@
 """Module for the PythonExpression substitution."""
 
 import collections.abc
+import math
 from typing import Iterable
 from typing import List
 from typing import Text
@@ -32,7 +33,8 @@ class PythonExpression(Substitution):
     Substitution that can access contextual local variables.
 
     The expression may contain Substitutions, but must return something that can
-    be converted to a string with `str()`.
+    be converted to a string with `str()`. It also may contain math symbols and
+    functions.
     """
 
     def __init__(self, expression: SomeSubstitutionsType) -> None:
@@ -67,4 +69,4 @@ class PythonExpression(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by evaluating the expression."""
         from ..utilities import perform_substitutions
-        return str(eval(perform_substitutions(context, self.expression)))
+        return str(eval(perform_substitutions(context, self.expression), {}, math.__dict__))

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -205,6 +205,14 @@ def test_eval_subst():
     assert 'asdbsd' == expr.perform(LaunchContext())
 
 
+def test_eval_subst_of_math_expr():
+    subst = parse_substitution(r'$(eval "ceil(1.3)")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+    assert '2' == expr.perform(LaunchContext())
+
+
 def expand_cmd_subs(cmd_subs: List[SomeSubstitutionsType]):
     return [perform_substitutions_without_context(x) for x in cmd_subs]
 


### PR DESCRIPTION
This feature was available in ROS1.

Without that only builtin python functions can be used in eval statements.