### PR TITLE
Propagate exceptions of completed actions to launch service main loop

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -319,10 +319,14 @@ class LaunchService:
                     entity_futures.append(process_one_event_task)
 
                     # Wait on events and futures
-                    await asyncio.wait(
+                    completed_tasks, _ = await asyncio.wait(
                         entity_futures,
                         return_when=asyncio.FIRST_COMPLETED
                     )
+                    # Propagate exception from completed task
+                    for completed_task in completed_tasks:
+                        if completed_task.exception():
+                            raise completed_task.exception()
 
                 except KeyboardInterrupt:
                     continue

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -327,7 +327,7 @@ class LaunchService:
                     completed_tasks_exceptions = [task.exception() for task in completed_tasks]
                     completed_tasks_exceptions = list(filter(None, completed_tasks_exceptions))
                     if completed_tasks_exceptions:
-                        self.__logger.debug("An exception was raised in an async action/event")
+                        self.__logger.debug('An exception was raised in an async action/event')
                         # in case there is more than one completed_task, log other exceptions
                         for completed_tasks_exception in completed_tasks_exceptions[1:]:
                             self.__logger.error(completed_tasks_exception)

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -323,10 +323,15 @@ class LaunchService:
                         entity_futures,
                         return_when=asyncio.FIRST_COMPLETED
                     )
-                    # Propagate exception from completed task
-                    for completed_task in completed_tasks:
-                        if completed_task.exception():
-                            raise completed_task.exception()
+                    # Propagate exception from completed tasks
+                    completed_tasks_exceptions = [task.exception() for task in completed_tasks]
+                    completed_tasks_exceptions = list(filter(None, completed_tasks_exceptions))
+                    if completed_tasks_exceptions:
+                        self.__logger.debug("An exception was raised in an async action/event")
+                        # in case there is more than one completed_task, log other exceptions
+                        for completed_tasks_exception in completed_tasks_exceptions[1:]:
+                            self.__logger.error(completed_tasks_exception)
+                        raise completed_tasks_exceptions[0]
 
                 except KeyboardInterrupt:
                     continue


### PR DESCRIPTION
Hi,

exceptions raised by launch actions (e.g. RuntimeError raised by action.DeclareLaunchArgument) are not handled by the "except Exception" block in https://github.com/tumtom/launch/blob/98bcc874fe6f459ade8571697be32c8c74f6b045/launch/launch/launch_service.py#L337.

This is, because the exception is not picked up from the completed Future (https://docs.python.org/3/library/asyncio-future.html#asyncio.Future.exception)

Instead, only the exception handler function in https://github.com/tumtom/launch/blob/98bcc874fe6f459ade8571697be32c8c74f6b045/launch/launch/launch_service.py#L280 is called then, which leads to the following message being printed

```
Task exception was never retrieved
future: <Task finished name='Task-2' coro=<LaunchService._process_one_event() done, defined at ..../opt/ros/foxy/lib/python3.8/site-packages/launch/launch_service.py:226> exception=RuntimeError("Included launch description missing required argument 'argument (description: 'A description), given: []")>
```

This commit changes the completed action's exception being handled by the "except Exception" block and being printed by the logger as:

`[ERROR] [launch]: Caught exception in launch (see debug for traceback): Included launch description missing required argument 'argument (description: 'A description), given: []`

Signed-off-by: Thomas Rehner <thomas.rehner@aed-engineering.com>