### PR TITLE
Add XacroFileContents substitution class

### DIFF
--- a/launch/launch/substitutions/xacro_file_contents.py
+++ b/launch/launch/substitutions/xacro_file_contents.py
@@ -1,0 +1,46 @@
+"""Module for the XacroFile substitution."""
+
+from pathlib import Path
+from typing import Text
+
+import xacro
+from launch.launch_context import LaunchContext
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitution import Substitution
+from launch.utilities import normalize_to_list_of_substitutions
+
+
+class XacroFileContents(Substitution):
+    """
+    Reads the xacro file provided and returns its context during evalution.
+    """
+
+    def __init__(self, substitution: SomeSubstitutionsType) -> None:
+        """Create a class instance."""
+        self.__substitution = normalize_to_list_of_substitutions((substitution,))[0]  # type: ignore
+
+    @property
+    def substitution(self) -> Substitution:
+        """Getter."""
+        return self.__substitution
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f"XacroFileContents({self.substitution.describe()})"
+
+    @classmethod
+    def read_xacro(cls, path: Path) -> str:
+        """Read the xacro contents and return the corresponding string."""
+        doc = xacro.process_file(path)
+        xacro_contents = doc.toprettyxml(indent="  ")  # type: ignore
+        return xacro_contents
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution - return the contents of the given xacro file."""
+        path = Path(self.substitution.perform(context))
+        xacro_contents = self.read_xacro(path)
+        # have to escape double quotes, then double quote the whole string so that the YAML
+        # parser is happy
+        out = xacro_contents.replace('"', '\\"')
+        out = f'"{out}"'
+        return out


### PR DESCRIPTION
Add a substitution class for loading a xacro file during evaluation.

P.S. Midway through writing this I discovered that I could use the `Command` substitution to call to the `xacro` executable (https://github.com/ros2/launch/issues/366). However I still believe there's value in having a dedicated class for in that
* it should be faster to call a pythn function than to invoke subprocess and
* it should be more straightforward for the developer at hand to discover and also use this substitution type for manipulating xacro files instead of concatenating the individual command parts