### PR TITLE
Add in two fixes for Jammy

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -574,8 +574,9 @@ class ExecuteLocal(Action):
                 # wait for a timeout(`self.__respawn_delay`) to respawn the process
                 # and handle shutdown event with future(`self.__shutdown_future`)
                 # to make sure `ros2 launch` exit in time
+                respawn_task = asyncio.create_task(asyncio.sleep(self.__respawn_delay))
                 await asyncio.wait(
-                    [asyncio.sleep(self.__respawn_delay), self.__shutdown_future],
+                    [respawn_task, self.__shutdown_future],
                     return_when=asyncio.FIRST_COMPLETED
                 )
             if not self.__shutdown_future.done():

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -152,7 +152,7 @@ def extract_type(data_type: AllowedTypesType) -> Tuple[ScalarTypesType, bool]:
     """
     is_list = False
     scalar_type: ScalarTypesType = cast(ScalarTypesType, data_type)
-    if is_typing_list(data_type) and data_type.__args__:
+    if is_typing_list(data_type) and hasattr(data_type, '__args__'):
         is_list = True
         scalar_type = data_type.__args__[0]  # type: ignore
     if is_valid_scalar_type(scalar_type) is False:

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -152,7 +152,7 @@ def extract_type(data_type: AllowedTypesType) -> Tuple[ScalarTypesType, bool]:
     """
     is_list = False
     scalar_type: ScalarTypesType = cast(ScalarTypesType, data_type)
-    if is_typing_list(data_type) and hasattr(data_type, '__args__'):
+    if is_typing_list(data_type) and getattr(data_type, '__args__', None):
         is_list = True
         scalar_type = data_type.__args__[0]  # type: ignore
     if is_valid_scalar_type(scalar_type) is False:


### PR DESCRIPTION
1. Make sure to wrap asyncio.sleep in an asyncio task.  Passing a "bare" coroutine to asyncio.wait is deprecated in Python 3.9 and later.
2. Check if a data type has an __args__ attribute before attempting to use it.

With these in place, tests for launch on Jammy succeed without errors or warnings.  They *should* also be compatible with Python 3.8 (CI will show that).