### PR TITLE
Warn when loading launch extensions fails

### DIFF
--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -79,7 +79,7 @@ class Parser:
                     entry_point.load()
                 except Exception:
                     warnings.warn(f'Failed to load the launch extension: {entry_point.name}\n'
-                                  f'{traceback.format_exec()}')
+                                  f'{traceback.format_exc()}')
             cls.extensions_loaded = True
 
     @classmethod
@@ -92,7 +92,7 @@ class Parser:
                     parsers[entry_point.name] = entry_point.load()
                 except Exception:
                     warnings.warn(f'Failed to load the parser extension: {entry_point.name}\n'
-                                  f'{traceback.format_exec()}')
+                                  f'{traceback.format_exc()}')
             cls.frontend_parsers = dict(sorted(parsers.items()))
 
     def parse_action(self, entity: Entity) -> Action:

--- a/launch/launch/frontend/parser.py
+++ b/launch/launch/frontend/parser.py
@@ -17,6 +17,7 @@
 
 import itertools
 import os.path
+import traceback
 from typing import List
 from typing import Optional
 from typing import Set
@@ -74,18 +75,24 @@ class Parser:
         if cls.extensions_loaded is False:
             for entry_point in importlib_metadata.entry_points().get(
                     'launch.frontend.launch_extension', []):
-                entry_point.load()
+                try:
+                    entry_point.load()
+                except Exception:
+                    warnings.warn(f'Failed to load the launch extension: {entry_point.name}\n'
+                                  f'{traceback.format_exec()}')
             cls.extensions_loaded = True
 
     @classmethod
     def load_parser_implementations(cls):
         """Load all the available frontend entities."""
         if cls.frontend_parsers is None:
-            parsers = {
-                entry_point.name: entry_point.load()
-                for entry_point in importlib_metadata.entry_points().get(
-                        'launch.frontend.parser', [])
-            }
+            parsers = {}
+            for entry_point in importlib_metadata.entry_points().get('launch.frontend.parser', []):
+                try:
+                    parsers[entry_point.name] = entry_point.load()
+                except Exception:
+                    warnings.warn(f'Failed to load the parser extension: {entry_point.name}\n'
+                                  f'{traceback.format_exec()}')
             cls.frontend_parsers = dict(sorted(parsers.items()))
 
     def parse_action(self, entity: Entity) -> Action:

--- a/launch/test/launch/frontend/test_parser.py
+++ b/launch/test/launch/frontend/test_parser.py
@@ -15,8 +15,8 @@
 """Test the abstract Parser class."""
 
 from unittest.mock import patch
-import warnings  # noqa: F401
 import importlib.metadata  # noqa: F401
+import warnings  # noqa: F401
 
 from launch.frontend.parser import Parser
 

--- a/launch/test/launch/frontend/test_parser.py
+++ b/launch/test/launch/frontend/test_parser.py
@@ -1,0 +1,55 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the abstract Parser class."""
+
+from unittest.mock import patch
+import warnings  # noqa: F401
+import importlib.metadata  # noqa: F401
+
+from launch.frontend.parser import Parser
+
+
+class InvalidEntryPoint:
+
+    name = 'RefusesToLoad'
+
+    def load(self):
+        raise ValueError('I dont want to load!')
+
+
+def test_invalid_launch_extension():
+    with patch('warnings.warn') as mock_warn, patch('importlib.metadata.entry_points') as mock_ep:
+        mock_ep.return_value = {
+            'launch.frontend.launch_extension': [InvalidEntryPoint()]
+        }
+
+        Parser.load_launch_extensions()
+
+        assert mock_ep.called
+        assert mock_warn.call_args
+        assert mock_warn.call_args.args[0].startswith('Failed to load')
+
+
+def test_invalid_parser_implementations():
+    with patch('warnings.warn') as mock_warn, patch('importlib.metadata.entry_points') as mock_ep:
+        mock_ep.return_value = {
+            'launch.frontend.parser': [InvalidEntryPoint()]
+        }
+
+        Parser.load_parser_implementations()
+
+        assert mock_ep.called
+        assert mock_warn.call_args
+        assert mock_warn.call_args.args[0].startswith('Failed to load')

--- a/launch/test/launch/frontend/test_parser.py
+++ b/launch/test/launch/frontend/test_parser.py
@@ -14,8 +14,8 @@
 
 """Test the abstract Parser class."""
 
-from unittest.mock import patch
 import importlib.metadata  # noqa: F401
+from unittest.mock import patch
 import warnings  # noqa: F401
 
 from launch.frontend.parser import Parser


### PR DESCRIPTION
This makes `launch` warn instead of raising an exception when an extension fails to load. My motivation is I cannot figure out why a launch extension is failing to load `rclpy` in this PR: https://github.com/ros2/rmw_implementation/pull/201#issuecomment-998161026 , but I also think this is reasonable behavior. IIUC any third party extension a user has installed that fails to load would prevent all launch extensions from being used. This PR allows launch files using working extensions to still be loaded.