### PR TITLE
Make test_parser compatible with Python older than 3.8

### DIFF
--- a/launch/test/launch/frontend/test_parser.py
+++ b/launch/test/launch/frontend/test_parser.py
@@ -14,10 +14,10 @@
 
 """Test the abstract Parser class."""
 
-import importlib.metadata  # noqa: F401
 from unittest.mock import patch
 import warnings  # noqa: F401
 
+from launch.frontend.parser import importlib_metadata
 from launch.frontend.parser import Parser
 
 
@@ -30,7 +30,8 @@ class InvalidEntryPoint:
 
 
 def test_invalid_launch_extension():
-    with patch('warnings.warn') as mock_warn, patch('importlib.metadata.entry_points') as mock_ep:
+    with patch('warnings.warn') as mock_warn, \
+            patch(importlib_metadata.__name__ + '.entry_points') as mock_ep:
         mock_ep.return_value = {
             'launch.frontend.launch_extension': [InvalidEntryPoint()]
         }
@@ -39,11 +40,12 @@ def test_invalid_launch_extension():
 
         assert mock_ep.called
         assert mock_warn.call_args
-        assert mock_warn.call_args.args[0].startswith('Failed to load')
+        assert mock_warn.call_args[0][0].startswith('Failed to load')
 
 
 def test_invalid_parser_implementations():
-    with patch('warnings.warn') as mock_warn, patch('importlib.metadata.entry_points') as mock_ep:
+    with patch('warnings.warn') as mock_warn, \
+            patch(importlib_metadata.__name__ + '.entry_points') as mock_ep:
         mock_ep.return_value = {
             'launch.frontend.parser': [InvalidEntryPoint()]
         }
@@ -52,4 +54,4 @@ def test_invalid_parser_implementations():
 
         assert mock_ep.called
         assert mock_warn.call_args
-        assert mock_warn.call_args.args[0].startswith('Failed to load')
+        assert mock_warn.call_args[0][0].startswith('Failed to load')


### PR DESCRIPTION
1. Handle importlib_metadata backport package
2. Use [tuple-based unpacking](https://docs.python.org/3.7/library/unittest.mock.html#calls-as-tuples) of call() object

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15867)](http://ci.ros2.org/job/ci_linux/15867/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10544)](http://ci.ros2.org/job/ci_linux-aarch64/10544/)
* Linux-RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=170)](http://ci.ros2.org/job/ci_linux-rhel/170/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=13533)](http://ci.ros2.org/job/ci_osx/13533/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16165)](http://ci.ros2.org/job/ci_windows/16165/)

Alternative to #574