### PR TITLE
Use asyncio.wait with timeout rather than sleep

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -574,10 +574,9 @@ class ExecuteLocal(Action):
                 # wait for a timeout(`self.__respawn_delay`) to respawn the process
                 # and handle shutdown event with future(`self.__shutdown_future`)
                 # to make sure `ros2 launch` exit in time
-                respawn_task = asyncio.create_task(asyncio.sleep(self.__respawn_delay))
                 await asyncio.wait(
-                    [respawn_task, self.__shutdown_future],
-                    return_when=asyncio.FIRST_COMPLETED
+                    (self.__shutdown_future,),
+                    timeout=self.__respawn_delay
                 )
             if not self.__shutdown_future.done():
                 context.asyncio_loop.create_task(self.__execute_process(context))


### PR DESCRIPTION
Resolves a RHEL regression caused by #571

~~Blocked by #575~~

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15868)](http://ci.ros2.org/job/ci_linux/15868/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10545)](http://ci.ros2.org/job/ci_linux-aarch64/10545/)
* Linux-RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=171)](http://ci.ros2.org/job/ci_linux-rhel/171/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=13534)](http://ci.ros2.org/job/ci_osx/13534/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16166)](http://ci.ros2.org/job/ci_windows/16166/)