### PR TITLE
Skip warning test if warning already happend

### DIFF
--- a/launch/test/launch/frontend/test_parser.py
+++ b/launch/test/launch/frontend/test_parser.py
@@ -17,11 +17,12 @@
 from unittest.mock import patch
 import warnings
 
+import launch.frontend.parser
 from launch.frontend.parser import importlib_metadata
 from launch.frontend.parser import Parser
-import launch.frontend.parser
 
 import pytest
+
 
 class InvalidEntryPoint:
 
@@ -36,7 +37,7 @@ def skip_if_warned_already(warn_text):
     if hasattr(launch.frontend.parser, '__warningregistry__'):
         for key in launch.frontend.parser.__warningregistry__.keys():
             if warn_text in key[0]:
-                pytest.skip("Skip because warnings can only be raised once")
+                pytest.skip('Skip because warnings can only be raised once')
 
 
 def test_invalid_launch_extension():

--- a/launch/test/launch/frontend/test_parser.py
+++ b/launch/test/launch/frontend/test_parser.py
@@ -14,11 +14,13 @@
 
 """Test the abstract Parser class."""
 
+import pytest
 from unittest.mock import patch
-import warnings  # noqa: F401
+import warnings
 
 from launch.frontend.parser import importlib_metadata
 from launch.frontend.parser import Parser
+import launch.frontend.parser
 
 
 class InvalidEntryPoint:
@@ -29,29 +31,34 @@ class InvalidEntryPoint:
         raise ValueError('I dont want to load!')
 
 
+def skip_if_warned_already(warn_text):
+    # TODO(sloretz) clear warning registry instead of skipping
+    if hasattr(launch.frontend.parser, '__warningregistry__'):
+        for key in launch.frontend.parser.__warningregistry__.keys():
+            if warn_text in key[0]:
+                pytest.skip("Skip because warnings can only be raised once")
+
+
 def test_invalid_launch_extension():
-    with patch('warnings.warn') as mock_warn, \
-            patch(importlib_metadata.__name__ + '.entry_points') as mock_ep:
+    skip_if_warned_already('Failed to load the launch')
+    with patch(importlib_metadata.__name__ + '.entry_points') as mock_ep:
         mock_ep.return_value = {
             'launch.frontend.launch_extension': [InvalidEntryPoint()]
         }
-
-        Parser.load_launch_extensions()
-
-        assert mock_ep.called
-        assert mock_warn.call_args
-        assert mock_warn.call_args[0][0].startswith('Failed to load')
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            Parser.load_launch_extensions()
+            assert(caught_warnings)
+            assert('Failed to load the launch' in str(caught_warnings[0]))
 
 
 def test_invalid_parser_implementations():
-    with patch('warnings.warn') as mock_warn, \
-            patch(importlib_metadata.__name__ + '.entry_points') as mock_ep:
+    skip_if_warned_already('Failed to load the parser')
+    with patch(importlib_metadata.__name__ + '.entry_points') as mock_ep:
         mock_ep.return_value = {
             'launch.frontend.parser': [InvalidEntryPoint()]
         }
 
-        Parser.load_parser_implementations()
-
-        assert mock_ep.called
-        assert mock_warn.call_args
-        assert mock_warn.call_args[0][0].startswith('Failed to load')
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            Parser.load_parser_implementations()
+            assert(caught_warnings)
+            assert('Failed to load the parser' in str(caught_warnings[0]))

--- a/launch/test/launch/frontend/test_parser.py
+++ b/launch/test/launch/frontend/test_parser.py
@@ -14,7 +14,6 @@
 
 """Test the abstract Parser class."""
 
-import pytest
 from unittest.mock import patch
 import warnings
 
@@ -22,6 +21,7 @@ from launch.frontend.parser import importlib_metadata
 from launch.frontend.parser import Parser
 import launch.frontend.parser
 
+import pytest
 
 class InvalidEntryPoint:
 


### PR DESCRIPTION
Resolves https://github.com/ros2/launch/issues/583

The problem is colcon uses `pytest-repeat` to implement `--retest-until-fail` with Python packages, and that repeats the test in the same pytest invocation. The first run through the test passes, but every subsequent run fails because the warning is only ever shown once.

According to [the Python warnings module documentation](https://docs.python.org/3/library/warnings.html#testing-warnings), it should be possible to make the same warning appear every time by calling `warnings.simplefilter("always")` inside of a `catch_warnings` context manager before the warning is every warned. I tried this, and still the warnings only happened once. It should also be possible to make the same warning appear every time by clearing the warning registry. I tried multiple ways of doing that: deleting the keys/value pairs inside the warning registry, replacing the whole registry with an empty dictionary, `del`ing the `__warningregistry__` attribue off of the module, and still each warning was only ever shown on the first test.

I don't know what else to try, so this PR skips the test if the warning it is looking for is already in the registry.

