### PR TITLE
Added case for instances of ExecuteLocal in resolveProcess function

### DIFF
--- a/launch_testing/launch_testing/util/proc_lookup.py
+++ b/launch_testing/launch_testing/util/proc_lookup.py
@@ -51,7 +51,11 @@ def _proc_to_name_and_args(proc):
         def perform_subs(subs):
             return ''.join([sub.perform(_fake_context()) for sub in subs])
         try:
-            cmd = [perform_subs(sub) for sub in proc.cmd]
+            cmd = []
+            if (isinstance(proc, launch.actions.ExecuteProcess)):
+                cmd = [perform_subs(sub) for sub in proc.cmd]
+            elif (isinstance(proc, launch.actions.ExecuteLocal)):
+                cmd = [perform_subs(sub) for sub in proc.process_description.cmd]
             return ' '.join(cmd)
         except _FakeContextException:
             return 'Unknown - Process not launched yet'

--- a/launch_testing/launch_testing/util/proc_lookup.py
+++ b/launch_testing/launch_testing/util/proc_lookup.py
@@ -104,7 +104,8 @@ def resolveProcesses(info_obj, *, process=None, cmd_args=None, strict_proc_match
             raise NoMatchingProcessException('No data recorded for any process')
         return all_procs
 
-    if isinstance(process, launch.actions.ExecuteProcess):
+    if (isinstance(process, launch.actions.ExecuteProcess) or
+       isinstance(process, launch.actions.ExecuteLocal)):
         # We want to search a specific process
         if process in info_obj.processes():
             return [process]

--- a/launch_testing/test/launch_testing/test_resolve_process.py
+++ b/launch_testing/test/launch_testing/test_resolve_process.py
@@ -32,6 +32,29 @@ class TestResolveProcess(unittest.TestCase):
     def test_unlaunched_process_lookup(self):
         info_obj = launch_testing.ProcInfoHandler()
 
+        lookup_obj = launch.actions.ExecuteLocal(
+            process_description=launch.descriptions.Executable(
+                cmd=[
+                    'python',
+                    '-c',
+                    '',
+                ]
+            )
+        )
+
+        with self.assertRaises(launch_testing.util.NoMatchingProcessException) as cm:
+            launch_testing.util.resolveProcesses(
+                info_obj,
+                process=lookup_obj
+            )
+
+        # We'll get a good error mesasge here because there were no substitutions in
+        # the execute process cmd - it's all text
+        self.assertIn('python -c', str(cm.exception))
+
+    def test_backward_compatible_unlaunched_process_lookup(self):
+        info_obj = launch_testing.ProcInfoHandler()
+
         lookup_obj = launch.actions.ExecuteProcess(
             cmd=[
                 'python',
@@ -51,6 +74,30 @@ class TestResolveProcess(unittest.TestCase):
         self.assertIn('python -c', str(cm.exception))
 
     def test_unlaunched_process_lookup_with_substitutions(self):
+        info_obj = launch_testing.ProcInfoHandler()
+
+        lookup_obj = launch.actions.ExecuteLocal(
+            process_description=launch.descriptions.Executable(
+                cmd=[
+                    launch.substitutions.LocalSubstitution('foo'),
+                    'python',
+                    '-c',
+                    '',
+                ]
+            )
+        )
+
+        with self.assertRaises(launch_testing.util.NoMatchingProcessException) as cm:
+            launch_testing.util.resolveProcesses(
+                info_obj,
+                process=lookup_obj
+            )
+
+        # Since the process wasn't launched yet, and it has substitutions that need to be
+        # resolved by the launch system, we won't be able to take a guess at the command
+        self.assertIn('Unknown', str(cm.exception))
+
+    def test_backward_compatible_unlaunched_process_lookup_with_substitutions(self):
         info_obj = launch_testing.ProcInfoHandler()
 
         lookup_obj = launch.actions.ExecuteProcess(


### PR DESCRIPTION
The resolveProcess function needs to allow cases where the process is launched via instances of ExecuteLocal. This will likely be revisited when ExecuteRemote is added since we'll probably want to generalize the base class, but for now this should let the tests for https://github.com/ros2/launch_ros/pull/215 pass so it can finally get merged.