### PR TITLE
[launch_testing] remove deprecated `ready_fn` feature

### DIFF
--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -44,21 +44,6 @@ The launch description needs to include a `ReadyToTest` action to signal to the 
 
 In the above example, there is no need to delay the start of the tests so the `ReadyToTest` action is a peer to the process under test and will signal to the framework that it's safe to start around the same time the `ExecuteProcess` action is run.
 
-In older style tests, a function called `ready_fn` is declared as an argument to `generate_test_description` and must be plumbed into the launch description with an `OpaqueFunction`.
-
-```python
-def generate_test_description(ready_fn):
-
-    return launch.LaunchDescription([
-        launch.actions.ExecuteProcess(
-            cmd=[path_to_process],
-        ),
-
-        # Start tests right away - no need to wait for anything in this example
-        launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
-    ])
-```
-
 #### Active Tests
 
 Any classes that inherit from `unittest.TestCase` and not decorated with the `post_shutdown_test` descriptor will be run concurrently with the proccess under test.

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -292,8 +292,6 @@ class LaunchTestRunner(object):
 
             # Check for extra args in generate_test_description
             for argname in base_args:
-                if argname == 'ready_fn':
-                    continue
                 if argname not in run.param_args.keys():
                     raise Exception(
                         "generate_test_description has unexpected extra argument '{}'".format(

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -34,9 +34,6 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
 
     def test_catches_bad_signature(self):
 
-        # A `generate_test_description` function without a ready_fn argument is allowed because
-        # it might be a new style function that uses a ReadyToTest action to signal when it's time
-        # for tests to start.
         # If there's no ReadyToTest action, we won't catch that until later because dut.validate()
         # doesn't actually invoke the function.
         # We will still expect to reject functions with wrong name arguments

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -47,18 +47,10 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
         with self.assertRaisesRegex(Exception, "unexpected extra argument 'misspelled_ready_fn'"):
             dut.validate()
 
-        dut = LaunchTestRunner(
-            make_test_run_for_dut(
-                lambda ready_fn: None
-            )
-        )
-
-        dut.validate()
-
     def test_too_many_arguments(self):
 
         dut = LaunchTestRunner(
-            make_test_run_for_dut(lambda ready_fn, extra_arg: None)
+            make_test_run_for_dut(lambda extra_arg: None)
         )
 
         with self.assertRaisesRegex(Exception, "unexpected extra argument 'extra_arg'"):
@@ -67,7 +59,7 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
     def test_bad_parametrization_argument(self):
 
         @launch_testing.parametrize('bad_argument', [1, 2, 3])
-        def bad_launch_description(ready_fn):
+        def bad_launch_description():
             pass  # pragma: no cover
 
         dut = LaunchTestRunner(


### PR DESCRIPTION
This feature was deprecated in https://github.com/ros2/launch/pull/346 (foxy) and should be removed by now, so we'll do it in Humble.

We realized this due to this pr (thanks for that btw): https://github.com/ros2/launch/pull/580

~~I'm opening in draft because I quickly did this in the browser and I'm not sure if the related `ReadyAggregator` class needs to be removed. So I'll let CI run first.~~

CI is good, but I'm still not sure about the `ReadyAggregator` class, looking for input on that.