### PR TITLE
Add in pytest 7 compatibility.

### DIFF
--- a/launch_testing/launch_testing/pytest/hooks.py
+++ b/launch_testing/launch_testing/pytest/hooks.py
@@ -206,18 +206,9 @@ else:
             if module is not None:
                 return module
         if path.basename == '__init__.py':
-            try:
-                # since https://docs.pytest.org/en/latest/changelog.html#deprecations
-                # todo: remove fallback once all platforms use pytest >=5.4
-                return pytest.Package.from_parent(parent, path=module_path)
-            except AttributeError:
-                return pytest.Package(path, parent)
-        try:
-            # since https://docs.pytest.org/en/latest/changelog.html#deprecations
-            # todo: remove fallback once all platforms use pytest >=5.4
-            return pytest.Module.from_parent(parent, path=module_path)
-        except AttributeError:
-            return pytest.Module(path, parent)
+            return pytest.Package.from_parent(parent, path=module_path)
+
+        return pytest.Module.from_parent(parent, path=module_path)
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
In pytest 7, a bunch of APIs around hooks were deprecated.
Since we use those APIs, we are getting warnings every time
we invoke the APIs in question.  This commit adds in a compatibility
layer so that we can support pytest from 4.6.9 (which is in
Ubuntu 20.04), up to pytest 7.0.0 (which is what is currently
in pip).

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Closes #590

You may notice that I have done some serious hackery in here.  In particular, I now have a global `pytest_major` where I parse out the pytest major version from the `pytest.__version__` string, and then use that to figure out which signature of `pytest_pycollect_makemodule` to overload.  That works, and is ugly, but I didn't know a better way to do this without resorting to `ast` hackery or similar.  I'm open to other ways to do that if someone gives me a pointer.

Also, I've currently only tested this on the `launch_testing` module; I need to do a more full-fledged test before I consider it ready for review.  Still, I wanted to open it now to get some feedback.