### PR TITLE
Revert "Validate unparsed attributes and subentities in launch_xml and launch_yaml (#468) (#567)"

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -377,12 +377,12 @@ class ExecuteProcess(Action):
             # `unset_enviroment_variable` actions should be used.
             env = entity.get_attr('env', data_type=List[Entity], optional=True)
             if env is not None:
-                kwargs['additional_env'] = {
+                env = {
                     tuple(parser.parse_substitution(e.get_attr('name'))):
                     parser.parse_substitution(e.get_attr('value')) for e in env
                 }
-                for e in env:
-                    e.assert_entity_completely_parsed()
+                kwargs['additional_env'] = env
+
         return cls, kwargs
 
     @property

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -93,8 +93,6 @@ class IncludeLaunchDescription(Action):
                 )
                 for e in args
             ]
-            for e in args:
-                e.assert_entity_completely_parsed()
         return cls, kwargs
 
     @property

--- a/launch/launch/frontend/entity.py
+++ b/launch/launch/frontend/entity.py
@@ -82,12 +82,3 @@ class Entity:
             Only happens in frontend implementations that do type coercion.
         """
         raise NotImplementedError()
-
-    def assert_entity_completely_parsed(self):
-        """
-        Assert that all attributes and children of the entity were parsed.
-
-        This function is automatically called after the `parse(entity, parser)`
-        function completed.
-        """
-        raise NotImplementedError()

--- a/launch/launch/frontend/expose.py
+++ b/launch/launch/frontend/expose.py
@@ -14,7 +14,6 @@
 
 """Module which adds methods for exposing parsing methods."""
 
-import functools
 import inspect
 from typing import Iterable
 from typing import Optional
@@ -71,6 +70,7 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
         method in the dictionary.
     :param parse_methods_map: a dict where the parsing method will be stored.
     :param exposed_type: A string specifing the parsing function type.
+        Only used for having clearer error log messages.
     """
     # TODO(ivanpauno): Check signature of the registered method/parsing function.
     # TODO(ivanpauno): Infer a parsing function from the constructor annotations.
@@ -98,16 +98,7 @@ def __expose_impl(name: Text, parse_methods_map: dict, exposed_type: Text):
                     name
                 )
             )
-        if exposed_type == 'action':
-            # For actions, validate that the user didn't provide unknown attributes or children
-            @functools.wraps(found_parse_method)
-            def wrapper(entity, parser):
-                ret = found_parse_method(entity, parser)
-                entity.assert_entity_completely_parsed()
-                return ret
-            parse_methods_map[name] = wrapper
-        else:
-            parse_methods_map[name] = found_parse_method
+        parse_methods_map[name] = found_parse_method
         return exposed
     return expose_impl_decorator
 

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -39,8 +39,6 @@ class Entity(BaseEntity):
         """Construnctor."""
         self.__xml_element = xml_element
         self.__parent = parent
-        self.__read_attributes = set()
-        self.__read_children = set()
 
     @property
     def type_name(self) -> Text:
@@ -55,22 +53,7 @@ class Entity(BaseEntity):
     @property
     def children(self) -> List['Entity']:
         """Get the Entity's children."""
-        self.__read_children = {item.tag for item in self.__xml_element}
         return [Entity(item) for item in self.__xml_element]
-
-    def assert_entity_completely_parsed(self):
-        unparsed_nested_tags = {item.tag for item in self.__xml_element} - self.__read_children
-        if unparsed_nested_tags:
-            raise ValueError(
-                f'Unexpected nested tag(s) found in `{self.__xml_element.tag}`: '
-                f'{unparsed_nested_tags}'
-            )
-        unparsed_attributes = set(self.__xml_element.attrib.keys()) - self.__read_attributes
-        if unparsed_attributes:
-            raise ValueError(
-                f'Unexpected attribute(s) found in `{self.__xml_element.tag}`: '
-                f'{unparsed_attributes}'
-            )
 
     def get_attr(
         self,
@@ -96,13 +79,12 @@ class Entity(BaseEntity):
             )
         )
         if check_is_list_entity(data_type):
-            return_list = [x for x in self.__xml_element if x.tag == name]
+            return_list = filter(lambda x: x.tag == name, self.__xml_element)
             if not return_list:
                 if optional:
                     return None
                 else:
                     raise attr_error
-            self.__read_children.add(return_list[0].tag)
             return [Entity(item) for item in return_list]
         value = None
         if name in self.__xml_element.attrib:
@@ -110,10 +92,8 @@ class Entity(BaseEntity):
             if name_sep not in self.__xml_element.attrib:
                 value = self.__xml_element.attrib[name]
             else:
-                self.__read_attributes.add(name_sep)
                 sep = self.__xml_element.attrib[name_sep]
                 value = self.__xml_element.attrib[name].split(sep)
-            self.__read_attributes.add(name)
         if value is None:
             if not optional:
                 raise attr_error

--- a/launch_xml/test/launch_xml/test_arg.py
+++ b/launch_xml/test/launch_xml/test_arg.py
@@ -19,8 +19,6 @@ import textwrap
 
 from launch.frontend import Parser
 
-import pytest
-
 
 def test_arg():
     xml_file = \
@@ -36,35 +34,3 @@ def test_arg():
     assert 'my_arg' == arg.name
     assert 'asd' == ''.join([x.perform(None) for x in arg.default_value])
     assert 'something' == arg.description
-
-
-def test_arg_wrong_attribute():
-    xml_file = \
-        """\
-        <launch>
-            <arg name="my_arg" whats_this="hello" default="asd" description="something"/>
-        </launch>
-        """
-    xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
-    with pytest.raises(ValueError) as excinfo:
-        parser.parse_description(root_entity)
-    assert '`arg`' in str(excinfo.value)
-    assert 'whats_this' in str(excinfo.value)
-
-
-def test_arg_with_subtag():
-    xml_file = \
-        """\
-        <launch>
-            <arg name="my_arg" default="asd" description="something">
-                <whats_this/>
-            </arg>
-        </launch>
-        """
-    xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
-    with pytest.raises(ValueError) as excinfo:
-        parser.parse_description(root_entity)
-    assert '`arg`' in str(excinfo.value)
-    assert 'whats_this' in str(excinfo.value)

--- a/launch_xml/test/launch_xml/test_executable.py
+++ b/launch_xml/test/launch_xml/test_executable.py
@@ -14,14 +14,10 @@
 
 """Test parsing an executable action."""
 
-import io
 from pathlib import Path
-import textwrap
 
 from launch import LaunchService
 from launch.frontend import Parser
-
-import pytest
 
 
 def test_executable():
@@ -44,24 +40,6 @@ def test_executable():
     ls = LaunchService()
     ls.include_launch_description(ld)
     assert 0 == ls.run()
-
-
-def test_executable_wrong_subtag():
-    xml_file = \
-        """\
-        <launch>
-            <executable cmd="ls -l -a -s" cwd="/" name="my_ls" shell="true" output="log" launch-prefix="$(env LAUNCH_PREFIX '')">
-                <env name="var" value="1"/>
-                <whats_this/>
-            </executable>
-        </launch>
-        """  # noqa, line too long
-    xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
-    with pytest.raises(ValueError) as excinfo:
-        parser.parse_description(root_entity)
-    assert '`executable`' in str(excinfo.value)
-    assert 'whats_this' in str(excinfo.value)
 
 
 if __name__ == '__main__':

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -40,8 +40,6 @@ class Entity(BaseEntity):
         self.__type_name = type_name
         self.__element = element
         self.__parent = parent
-        self.__read_keys = set()
-        self.__children_called = False
 
     @property
     def type_name(self) -> Text:
@@ -56,44 +54,23 @@ class Entity(BaseEntity):
     @property
     def children(self) -> List['Entity']:
         """Get the Entity's children."""
-        self.__children_called = True
-        if not isinstance(self.__element, (dict, list)):
-            raise TypeError(
-                f'Expected a dict or list, got {type(self.element)}:'
-                f'\n---\n{self.__element}\n---'
-            )
+        if not type(self.__element) in (dict, list):
+            raise TypeError('Expected a dict or list, got {}'.format(type(self.element)))
         if isinstance(self.__element, dict):
             if 'children' not in self.__element:
-                raise ValueError(
-                    f'Expected entity `{self.__type_name}` to have children entities.'
-                    f'That can be a list of subentities or a dictionary with a `children` '
-                    'list element')
-            self.__read_keys.add('children')
+                raise KeyError('Missing `children` key in Entity {}'.format(self.__type_name))
             children = self.__element['children']
         else:
             children = self.__element
+        if not isinstance(children, list):
+            raise TypeError('children should be a list')
         entities = []
         for child in children:
             if len(child) != 1:
-                raise RuntimeError(
-                    'Subentities must be a dictionary with only one key'
-                    ', which is the entity type')
+                raise RuntimeError('Expected one root per child')
             type_name = list(child.keys())[0]
             entities.append(Entity(child[type_name], type_name))
         return entities
-
-    def assert_entity_completely_parsed(self):
-        if isinstance(self.__element, list):
-            if not self.__children_called:
-                raise ValueError(
-                    f'Unexpected nested entity(ies) found in `{self.__type_name}`: '
-                    f'{self.__element}')
-            return
-        unparsed_keys = set(self.__element.keys()) - self.__read_keys
-        if unparsed_keys:
-            raise ValueError(
-                f'Unexpected key(s) found in `{self.__type_name}`: {unparsed_keys}'
-            )
 
     def get_attr(
         self,
@@ -120,7 +97,6 @@ class Entity(BaseEntity):
                         name, self.type_name))
             else:
                 return None
-        self.__read_keys.add(name)
         data = self.__element[name]
         if check_is_list_entity(data_type):
             if isinstance(data, list) and isinstance(data[0], dict):

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -32,7 +32,7 @@ def test_executable():
                 name: my_ls
                 shell: true
                 output: log
-                'launch-prefix': $(env LAUNCH_PREFIX '')
+                launch_prefix: $(env LAUNCH_PREFIX)
                 env:
                     -   name: var
                         value: '1'


### PR DESCRIPTION
Revert #567 because it breaks behavior in Foxy.