### PR TITLE
Add boolean substitutions

### DIFF
--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -15,6 +15,9 @@
 """Package for substitutions."""
 
 from .anon_name import AnonName
+from .boolean_substitution import AndSubstitution
+from .boolean_substitution import NotSubstitution
+from .boolean_substitution import OrSubstitution
 from .command import Command
 from .environment_variable import EnvironmentVariable
 from .find_executable import FindExecutable
@@ -28,12 +31,15 @@ from .this_launch_file import ThisLaunchFile
 from .this_launch_file_dir import ThisLaunchFileDir
 
 __all__ = [
+    'AndSubstitution',
     'AnonName',
     'Command',
     'EnvironmentVariable',
     'FindExecutable',
     'LaunchConfiguration',
     'LocalSubstitution',
+    'NotSubstitution',
+    'OrSubstitution',
     'PathJoinSubstitution',
     'PythonExpression',
     'SubstitutionFailure',

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -1,0 +1,171 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for boolean substitutions."""
+
+from typing import Iterable
+from typing import Text
+
+from .substitution_failure import SubstitutionFailure
+from ..conditions import evaluate_condition_expression
+from ..conditions import InvalidConditionExpressionError
+from ..frontend import expose_substitution
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+from ..utilities import normalize_to_list_of_substitutions
+from ..utilities import perform_substitutions
+
+
+@expose_substitution('not')
+class NotSubstitution(Substitution):
+    """Substitution that returns 'not' of the input boolean value."""
+
+    def __init__(self, value: SomeSubstitutionsType) -> None:
+        """Create a NotSubstitution substitution."""
+        super().__init__()
+
+        self.__value = normalize_to_list_of_substitutions(value)
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `NotSubstitution` substitution."""
+        if len(data) != 1:
+            raise TypeError('not substitution expects 1 argument')
+        return cls, {'value': data[0]}
+
+    @property
+    def value(self) -> Substitution:
+        """Getter for value."""
+        return self.__value
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'NotSubstitution({self.value})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        try:
+            condition_expression = normalize_to_list_of_substitutions(
+                perform_substitutions(context, self.value)
+            )
+            condition = evaluate_condition_expression(context, condition_expression)
+        except InvalidConditionExpressionError:
+            raise SubstitutionFailure(f'invalid condition expression: {self.value}')
+
+        return str(not condition)
+
+
+@expose_substitution('and')
+class AndSubstitution(Substitution):
+    """Substitution that returns 'and' of the input boolean values."""
+
+    def __init__(self, left: SomeSubstitutionsType, right: SomeSubstitutionsType) -> None:
+        """Create a AndSubstitution substitution."""
+        super().__init__()
+
+        self.__left = normalize_to_list_of_substitutions(left)
+        self.__right = normalize_to_list_of_substitutions(right)
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `AndSubstitution` substitution."""
+        if len(data) != 2:
+            raise TypeError('and substitution expects 2 arguments')
+        return cls, {'left': data[0], 'right': data[1]}
+
+    @property
+    def left(self) -> Substitution:
+        """Getter for left."""
+        return self.__left
+
+    @property
+    def right(self) -> Substitution:
+        """Getter for right."""
+        return self.__right
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'AndSubstitution({self.left} {self.right})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        try:
+            condition_expression = normalize_to_list_of_substitutions(
+                perform_substitutions(context, self.left)
+            )
+            left_condition = evaluate_condition_expression(context, condition_expression)
+        except InvalidConditionExpressionError:
+            raise SubstitutionFailure(f'invalid condition expression: {self.left}')
+        try:
+            condition_expression = normalize_to_list_of_substitutions(
+                perform_substitutions(context, self.right)
+            )
+            right_condition = evaluate_condition_expression(context, condition_expression)
+        except InvalidConditionExpressionError:
+            raise SubstitutionFailure(f'invalid condition expression: {self.right}')
+
+        return str(left_condition and right_condition)
+
+
+@expose_substitution('or')
+class OrSubstitution(Substitution):
+    """Substitution that returns 'or' of the input boolean values."""
+
+    def __init__(self, left: SomeSubstitutionsType, right: SomeSubstitutionsType) -> None:
+        """Create a AndSubstitution substitution."""
+        super().__init__()
+
+        self.__left = normalize_to_list_of_substitutions(left)
+        self.__right = normalize_to_list_of_substitutions(right)
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `AndSubstitution` substitution."""
+        if len(data) != 2:
+            raise TypeError('and substitution expects 2 arguments')
+        return cls, {'left': data[0], 'right': data[1]}
+
+    @property
+    def left(self) -> Substitution:
+        """Getter for left."""
+        return self.__left
+
+    @property
+    def right(self) -> Substitution:
+        """Getter for right."""
+        return self.__right
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'AndSubstitution({self.left} {self.right})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        try:
+            condition_expression = normalize_to_list_of_substitutions(
+                perform_substitutions(context, self.left)
+            )
+            left_condition = evaluate_condition_expression(context, condition_expression)
+        except InvalidConditionExpressionError:
+            raise SubstitutionFailure(f'invalid condition expression: {self.left}')
+        try:
+            condition_expression = normalize_to_list_of_substitutions(
+                perform_substitutions(context, self.right)
+            )
+            right_condition = evaluate_condition_expression(context, condition_expression)
+        except InvalidConditionExpressionError:
+            raise SubstitutionFailure(f'invalid condition expression: {self.right}')
+
+        return str(left_condition or right_condition)

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -18,14 +18,11 @@ from typing import Iterable
 from typing import Text
 
 from .substitution_failure import SubstitutionFailure
-from ..conditions import evaluate_condition_expression
-from ..conditions import InvalidConditionExpressionError
 from ..frontend import expose_substitution
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
-from ..utilities import perform_substitutions
 from ..utilities.type_utils import perform_typed_substitution
 
 

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -17,6 +17,7 @@
 from typing import Iterable
 from typing import Text
 
+from .launch_configuration import LaunchConfiguration
 from .substitution_failure import SubstitutionFailure
 from ..frontend import expose_substitution
 from ..launch_context import LaunchContext
@@ -55,7 +56,9 @@ class NotSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            condition = perform_typed_substitution(context, self.value, bool)
+            value = LaunchConfiguration(self.value, default=self.value).perform(context)
+            condition = perform_typed_substitution(
+                context, normalize_to_list_of_substitutions(value), bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
 
@@ -97,11 +100,15 @@ class AndSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            left_condition = perform_typed_substitution(context, self.left, bool)
+            value = LaunchConfiguration(self.left, default=self.left).perform(context)
+            left_condition = perform_typed_substitution(
+                context, normalize_to_list_of_substitutions(value), bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
         try:
-            right_condition = perform_typed_substitution(context, self.right, bool)
+            value = LaunchConfiguration(self.right, default=self.right).perform(context)
+            right_condition = perform_typed_substitution(
+                context, normalize_to_list_of_substitutions(value), bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
 
@@ -143,11 +150,15 @@ class OrSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            left_condition = perform_typed_substitution(context, self.left, bool)
+            value = LaunchConfiguration(self.left, default=self.left).perform(context)
+            left_condition = perform_typed_substitution(
+                context, normalize_to_list_of_substitutions(value), bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
         try:
-            right_condition = perform_typed_substitution(context, self.right, bool)
+            value = LaunchConfiguration(self.right, default=self.right).perform(context)
+            right_condition = perform_typed_substitution(
+                context, normalize_to_list_of_substitutions(value), bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
 

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -17,7 +17,6 @@
 from typing import Iterable
 from typing import Text
 
-from .launch_configuration import LaunchConfiguration
 from .substitution_failure import SubstitutionFailure
 from ..frontend import expose_substitution
 from ..launch_context import LaunchContext
@@ -56,9 +55,7 @@ class NotSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            value = LaunchConfiguration(self.value, default=self.value).perform(context)
-            condition = perform_typed_substitution(
-                context, normalize_to_list_of_substitutions(value), bool)
+            condition = perform_typed_substitution(context, self.value, bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
 
@@ -100,15 +97,11 @@ class AndSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            value = LaunchConfiguration(self.left, default=self.left).perform(context)
-            left_condition = perform_typed_substitution(
-                context, normalize_to_list_of_substitutions(value), bool)
+            left_condition = perform_typed_substitution(context, self.left, bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
         try:
-            value = LaunchConfiguration(self.right, default=self.right).perform(context)
-            right_condition = perform_typed_substitution(
-                context, normalize_to_list_of_substitutions(value), bool)
+            right_condition = perform_typed_substitution(context, self.right, bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
 
@@ -150,15 +143,11 @@ class OrSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            value = LaunchConfiguration(self.left, default=self.left).perform(context)
-            left_condition = perform_typed_substitution(
-                context, normalize_to_list_of_substitutions(value), bool)
+            left_condition = perform_typed_substitution(context, self.left, bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
         try:
-            value = LaunchConfiguration(self.right, default=self.right).perform(context)
-            right_condition = perform_typed_substitution(
-                context, normalize_to_list_of_substitutions(value), bool)
+            right_condition = perform_typed_substitution(context, self.right, bool)
         except (TypeError, ValueError) as e:
             raise SubstitutionFailure(e)
 

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -26,6 +26,7 @@ from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
+from ..utilities.type_utils import perform_typed_substitution
 
 
 @expose_substitution('not')
@@ -57,12 +58,9 @@ class NotSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            condition_expression = normalize_to_list_of_substitutions(
-                perform_substitutions(context, self.value)
-            )
-            condition = evaluate_condition_expression(context, condition_expression)
-        except InvalidConditionExpressionError:
-            raise SubstitutionFailure(f'invalid condition expression: {self.value}')
+            condition = perform_typed_substitution(context, self.value, bool)
+        except (TypeError, ValueError) as e:
+            raise SubstitutionFailure(e)
 
         return str(not condition).lower()
 
@@ -102,19 +100,13 @@ class AndSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            condition_expression = normalize_to_list_of_substitutions(
-                perform_substitutions(context, self.left)
-            )
-            left_condition = evaluate_condition_expression(context, condition_expression)
-        except InvalidConditionExpressionError:
-            raise SubstitutionFailure(f'invalid condition expression: {self.left}')
+            left_condition = perform_typed_substitution(context, self.left, bool)
+        except (TypeError, ValueError) as e:
+            raise SubstitutionFailure(e)
         try:
-            condition_expression = normalize_to_list_of_substitutions(
-                perform_substitutions(context, self.right)
-            )
-            right_condition = evaluate_condition_expression(context, condition_expression)
-        except InvalidConditionExpressionError:
-            raise SubstitutionFailure(f'invalid condition expression: {self.right}')
+            right_condition = perform_typed_substitution(context, self.right, bool)
+        except (TypeError, ValueError) as e:
+            raise SubstitutionFailure(e)
 
         return str(left_condition and right_condition).lower()
 
@@ -154,18 +146,12 @@ class OrSubstitution(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         try:
-            condition_expression = normalize_to_list_of_substitutions(
-                perform_substitutions(context, self.left)
-            )
-            left_condition = evaluate_condition_expression(context, condition_expression)
-        except InvalidConditionExpressionError:
-            raise SubstitutionFailure(f'invalid condition expression: {self.left}')
+            left_condition = perform_typed_substitution(context, self.left, bool)
+        except (TypeError, ValueError) as e:
+            raise SubstitutionFailure(e)
         try:
-            condition_expression = normalize_to_list_of_substitutions(
-                perform_substitutions(context, self.right)
-            )
-            right_condition = evaluate_condition_expression(context, condition_expression)
-        except InvalidConditionExpressionError:
-            raise SubstitutionFailure(f'invalid condition expression: {self.right}')
+            right_condition = perform_typed_substitution(context, self.right, bool)
+        except (TypeError, ValueError) as e:
+            raise SubstitutionFailure(e)
 
         return str(left_condition or right_condition).lower()

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -64,7 +64,7 @@ class NotSubstitution(Substitution):
         except InvalidConditionExpressionError:
             raise SubstitutionFailure(f'invalid condition expression: {self.value}')
 
-        return str(not condition)
+        return str(not condition).lower()
 
 
 @expose_substitution('and')
@@ -116,7 +116,7 @@ class AndSubstitution(Substitution):
         except InvalidConditionExpressionError:
             raise SubstitutionFailure(f'invalid condition expression: {self.right}')
 
-        return str(left_condition and right_condition)
+        return str(left_condition and right_condition).lower()
 
 
 @expose_substitution('or')
@@ -168,4 +168,4 @@ class OrSubstitution(Substitution):
         except InvalidConditionExpressionError:
             raise SubstitutionFailure(f'invalid condition expression: {self.right}')
 
-        return str(left_condition or right_condition)
+        return str(left_condition or right_condition).lower()

--- a/launch/test/launch/frontend/test_boolean_substitution_frontend.py
+++ b/launch/test/launch/frontend/test_boolean_substitution_frontend.py
@@ -96,15 +96,15 @@ def check_boolean_substitution(file):
     or_false_true = sub_entries[10]
     or_false_false = sub_entries[11]
 
-    assert perform(not_true.value) == 'False'
-    assert perform(not_false.value) == 'True'
+    assert perform(not_true.value) == 'false'
+    assert perform(not_false.value) == 'true'
 
-    assert perform(and_true_true.value) == 'True'
-    assert perform(and_true_false.value) == 'False'
-    assert perform(and_false_true.value) == 'False'
-    assert perform(and_false_false.value) == 'False'
+    assert perform(and_true_true.value) == 'true'
+    assert perform(and_true_false.value) == 'false'
+    assert perform(and_false_true.value) == 'false'
+    assert perform(and_false_false.value) == 'false'
 
-    assert perform(or_true_true.value) == 'True'
-    assert perform(or_true_false.value) == 'True'
-    assert perform(or_false_true.value) == 'True'
-    assert perform(or_false_false.value) == 'False'
+    assert perform(or_true_true.value) == 'true'
+    assert perform(or_true_false.value) == 'true'
+    assert perform(or_false_true.value) == 'true'
+    assert perform(or_false_false.value) == 'false'

--- a/launch/test/launch/frontend/test_boolean_substitution_frontend.py
+++ b/launch/test/launch/frontend/test_boolean_substitution_frontend.py
@@ -1,0 +1,110 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import textwrap
+
+from launch import LaunchService
+from launch.frontend import Parser
+from launch.utilities import perform_substitutions
+
+
+def test_boolean_substitution_yaml():
+    yaml_file = textwrap.dedent(
+        r"""
+        launch:
+            - let: { name: true_value, value: "true" }
+            - let: { name: false_value, value: "false" }
+
+            - let: { name: not_true, value: "$(not $(var true_value))" }
+            - let: { name: not_false, value: "$(not $(var false_value))" }
+
+            - let: { name: and_true_true, value: "$(and $(var true_value) $(var true_value))" }
+            - let: { name: and_true_false, value: "$(and $(var true_value) $(var false_value))" }
+            - let: { name: and_false_true, value: "$(and $(var false_value) $(var true_value))" }
+            - let: { name: and_false_false, value: "$(and $(var false_value) $(var false_value))" }
+
+            - let: { name: or_true_true, value: "$(or $(var true_value) $(var true_value))" }
+            - let: { name: or_true_false, value: "$(or $(var true_value) $(var false_value))" }
+            - let: { name: or_false_true, value: "$(or $(var false_value) $(var true_value))" }
+            - let: { name: or_false_false, value: "$(or $(var false_value) $(var false_value))" }
+        """
+    )
+    with io.StringIO(yaml_file) as f:
+        check_boolean_substitution(f)
+
+
+def test_boolean_substitution_xml():
+    xml_file = textwrap.dedent(
+        r"""
+        <launch>
+            <let name="true_value" value="true" />
+            <let name="false_value" value="false" />
+
+            <let name="not_true" value="$(not $(var true_value))" />
+            <let name="not_false" value="$(not $(var false_value))" />
+
+            <let name="and_true_true" value="$(and $(var true_value) $(var true_value))" />
+            <let name="and_true_false" value="$(and $(var true_value) $(var false_value))" />
+            <let name="and_false_true" value="$(and $(var false_value) $(var true_value))" />
+            <let name="and_false_false" value="$(and $(var false_value) $(var false_value))" />
+
+            <let name="or_true_true" value="$(or $(var true_value) $(var true_value))" />
+            <let name="or_true_false" value="$(or $(var true_value) $(var false_value))" />
+            <let name="or_false_true" value="$(or $(var false_value) $(var true_value))" />
+            <let name="or_false_false" value="$(or $(var false_value) $(var false_value))" />
+        </launch>
+        """
+    )
+    with io.StringIO(xml_file) as f:
+        check_boolean_substitution(f)
+
+
+def check_boolean_substitution(file):
+    root_entity, parser = Parser.load(file)
+    ld = parser.parse_description(root_entity)
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+
+    def perform(substitution):
+        return perform_substitutions(ls.context, substitution)
+
+    sub_entries = ld.describe_sub_entities()
+
+    not_true = sub_entries[2]
+    not_false = sub_entries[3]
+
+    and_true_true = sub_entries[4]
+    and_true_false = sub_entries[5]
+    and_false_true = sub_entries[6]
+    and_false_false = sub_entries[7]
+
+    or_true_true = sub_entries[8]
+    or_true_false = sub_entries[9]
+    or_false_true = sub_entries[10]
+    or_false_false = sub_entries[11]
+
+    assert perform(not_true.value) == 'False'
+    assert perform(not_false.value) == 'True'
+
+    assert perform(and_true_true.value) == 'True'
+    assert perform(and_true_false.value) == 'False'
+    assert perform(and_false_true.value) == 'False'
+    assert perform(and_false_false.value) == 'False'
+
+    assert perform(or_true_true.value) == 'True'
+    assert perform(or_true_false.value) == 'True'
+    assert perform(or_false_true.value) == 'True'
+    assert perform(or_false_false.value) == 'False'

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -24,90 +24,31 @@ from launch.substitutions.substitution_failure import SubstitutionFailure
 import pytest
 
 
-@pytest.mark.parametrize('value', ['True', 'true', '1'])
-def test_not_substitution_true(value):
+def test_not_substitution():
     lc = LaunchContext()
-    assert NotSubstitution(value).perform(lc) == 'false'
-
-
-@pytest.mark.parametrize('value', ['False', 'false', '0'])
-def test_not_substitution_false(value):
-    lc = LaunchContext()
-    assert NotSubstitution(value).perform(lc) == 'true'
-
-
-def test_not_substitution_invalid():
-    lc = LaunchContext()
+    assert NotSubstitution('true').perform(lc) == 'false'
+    assert NotSubstitution('false').perform(lc) == 'true'
     with pytest.raises(SubstitutionFailure):
         NotSubstitution('not-condition-expression').perform(lc)
 
-
-@pytest.mark.parametrize('left', ['True', 'true', '1'])
-@pytest.mark.parametrize('right', ['True', 'true', '1'])
-def test_and_substitution_both_true(left, right):
+def test_and_substitution():
     lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'true'
-
-
-@pytest.mark.parametrize('left', ['True', 'true', '1'])
-@pytest.mark.parametrize('right', ['False', 'false', '0'])
-def test_and_substitution_left_true(left, right):
-    lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'false'
-
-
-@pytest.mark.parametrize('left', ['False', 'false', '0'])
-@pytest.mark.parametrize('right', ['True', 'true', '1'])
-def test_and_substitution_right_true(left, right):
-    lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'false'
-
-
-@pytest.mark.parametrize('left', ['False', 'false', '0'])
-@pytest.mark.parametrize('right', ['False', 'false', '0'])
-def test_and_substitution_both_false(left, right):
-    lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'false'
-
-
-def test_and_substitution_invalid():
-    lc = LaunchContext()
+    assert AndSubstitution('true', 'true').perform(lc) == 'true'
+    assert AndSubstitution('true', 'false').perform(lc) == 'false'
+    assert AndSubstitution('false', 'true').perform(lc) == 'false'
+    assert AndSubstitution('false', 'false').perform(lc) == 'false'
     with pytest.raises(SubstitutionFailure):
         AndSubstitution('not-condition-expression', 'True').perform(lc)
     with pytest.raises(SubstitutionFailure):
         AndSubstitution('True', 'not-condition-expression').perform(lc)
 
 
-@pytest.mark.parametrize('left', ['True', 'true', '1'])
-@pytest.mark.parametrize('right', ['True', 'true', '1'])
-def test_or_substitution_both_true(left, right):
+def test_or_substitution():
     lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'true'
-
-
-@pytest.mark.parametrize('left', ['True', 'true', '1'])
-@pytest.mark.parametrize('right', ['False', 'false', '0'])
-def test_or_substitution_left_true(left, right):
-    lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'true'
-
-
-@pytest.mark.parametrize('left', ['False', 'false', '0'])
-@pytest.mark.parametrize('right', ['True', 'true', '1'])
-def test_or_substitution_right_true(left, right):
-    lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'true'
-
-
-@pytest.mark.parametrize('left', ['False', 'false', '0'])
-@pytest.mark.parametrize('right', ['False', 'false', '0'])
-def test_or_substitution_both_false(left, right):
-    lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'false'
-
-
-def test_or_substitution_invalid():
-    lc = LaunchContext()
+    assert OrSubstitution('true', 'true').perform(lc) == 'true'
+    assert OrSubstitution('true', 'false').perform(lc) == 'true'
+    assert OrSubstitution('false', 'true').perform(lc) == 'true'
+    assert OrSubstitution('false', 'false').perform(lc) == 'false'
     with pytest.raises(SubstitutionFailure):
         OrSubstitution('not-condition-expression', 'True').perform(lc)
     with pytest.raises(SubstitutionFailure):

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -27,13 +27,13 @@ import pytest
 @pytest.mark.parametrize('value', ['True', 'true', '1'])
 def test_not_substitution_true(value):
     lc = LaunchContext()
-    assert NotSubstitution(value).perform(lc) == 'False'
+    assert NotSubstitution(value).perform(lc) == 'false'
 
 
 @pytest.mark.parametrize('value', ['False', 'false', '0'])
 def test_not_substitution_false(value):
     lc = LaunchContext()
-    assert NotSubstitution(value).perform(lc) == 'True'
+    assert NotSubstitution(value).perform(lc) == 'true'
 
 
 def test_not_substitution_invalid():
@@ -46,28 +46,28 @@ def test_not_substitution_invalid():
 @pytest.mark.parametrize('right', ['True', 'true', '1'])
 def test_and_substitution_both_true(left, right):
     lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'True'
+    assert AndSubstitution(left, right).perform(lc) == 'true'
 
 
 @pytest.mark.parametrize('left', ['True', 'true', '1'])
 @pytest.mark.parametrize('right', ['False', 'false', '0'])
 def test_and_substitution_left_true(left, right):
     lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'False'
+    assert AndSubstitution(left, right).perform(lc) == 'false'
 
 
 @pytest.mark.parametrize('left', ['False', 'false', '0'])
 @pytest.mark.parametrize('right', ['True', 'true', '1'])
 def test_and_substitution_right_true(left, right):
     lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'False'
+    assert AndSubstitution(left, right).perform(lc) == 'false'
 
 
 @pytest.mark.parametrize('left', ['False', 'false', '0'])
 @pytest.mark.parametrize('right', ['False', 'false', '0'])
 def test_and_substitution_both_false(left, right):
     lc = LaunchContext()
-    assert AndSubstitution(left, right).perform(lc) == 'False'
+    assert AndSubstitution(left, right).perform(lc) == 'false'
 
 
 def test_and_substitution_invalid():
@@ -82,28 +82,28 @@ def test_and_substitution_invalid():
 @pytest.mark.parametrize('right', ['True', 'true', '1'])
 def test_or_substitution_both_true(left, right):
     lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'True'
+    assert OrSubstitution(left, right).perform(lc) == 'true'
 
 
 @pytest.mark.parametrize('left', ['True', 'true', '1'])
 @pytest.mark.parametrize('right', ['False', 'false', '0'])
 def test_or_substitution_left_true(left, right):
     lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'True'
+    assert OrSubstitution(left, right).perform(lc) == 'true'
 
 
 @pytest.mark.parametrize('left', ['False', 'false', '0'])
 @pytest.mark.parametrize('right', ['True', 'true', '1'])
 def test_or_substitution_right_true(left, right):
     lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'True'
+    assert OrSubstitution(left, right).perform(lc) == 'true'
 
 
 @pytest.mark.parametrize('left', ['False', 'false', '0'])
 @pytest.mark.parametrize('right', ['False', 'false', '0'])
 def test_or_substitution_both_false(left, right):
     lc = LaunchContext()
-    assert OrSubstitution(left, right).perform(lc) == 'False'
+    assert OrSubstitution(left, right).perform(lc) == 'false'
 
 
 def test_or_substitution_invalid():

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -31,6 +31,7 @@ def test_not_substitution():
     with pytest.raises(SubstitutionFailure):
         NotSubstitution('not-condition-expression').perform(lc)
 
+
 def test_and_substitution():
     lc = LaunchContext()
     assert AndSubstitution('true', 'true').perform(lc) == 'true'

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the AnonName substitution class."""
+"""Tests for the boolean substitution classes."""
 
 from launch import LaunchContext
 

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -39,9 +39,9 @@ def test_and_substitution():
     assert AndSubstitution('false', 'true').perform(lc) == 'false'
     assert AndSubstitution('false', 'false').perform(lc) == 'false'
     with pytest.raises(SubstitutionFailure):
-        AndSubstitution('not-condition-expression', 'True').perform(lc)
+        AndSubstitution('not-condition-expression', 'true').perform(lc)
     with pytest.raises(SubstitutionFailure):
-        AndSubstitution('True', 'not-condition-expression').perform(lc)
+        AndSubstitution('true', 'not-condition-expression').perform(lc)
 
 
 def test_or_substitution():
@@ -51,6 +51,6 @@ def test_or_substitution():
     assert OrSubstitution('false', 'true').perform(lc) == 'true'
     assert OrSubstitution('false', 'false').perform(lc) == 'false'
     with pytest.raises(SubstitutionFailure):
-        OrSubstitution('not-condition-expression', 'True').perform(lc)
+        OrSubstitution('not-condition-expression', 'true').perform(lc)
     with pytest.raises(SubstitutionFailure):
-        OrSubstitution('True', 'not-condition-expression').perform(lc)
+        OrSubstitution('true', 'not-condition-expression').perform(lc)

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -1,0 +1,114 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the AnonName substitution class."""
+
+from launch import LaunchContext
+
+from launch.substitutions import AndSubstitution
+from launch.substitutions import NotSubstitution
+from launch.substitutions import OrSubstitution
+from launch.substitutions.substitution_failure import SubstitutionFailure
+
+import pytest
+
+
+@pytest.mark.parametrize('value', ['True', 'true', '1'])
+def test_not_substitution_true(value):
+    lc = LaunchContext()
+    assert NotSubstitution(value).perform(lc) == 'False'
+
+
+@pytest.mark.parametrize('value', ['False', 'false', '0'])
+def test_not_substitution_false(value):
+    lc = LaunchContext()
+    assert NotSubstitution(value).perform(lc) == 'True'
+
+
+def test_not_substitution_invalid():
+    lc = LaunchContext()
+    with pytest.raises(SubstitutionFailure):
+        NotSubstitution('not-condition-expression').perform(lc)
+
+
+@pytest.mark.parametrize('left', ['True', 'true', '1'])
+@pytest.mark.parametrize('right', ['True', 'true', '1'])
+def test_and_substitution_both_true(left, right):
+    lc = LaunchContext()
+    assert AndSubstitution(left, right).perform(lc) == 'True'
+
+
+@pytest.mark.parametrize('left', ['True', 'true', '1'])
+@pytest.mark.parametrize('right', ['False', 'false', '0'])
+def test_and_substitution_left_true(left, right):
+    lc = LaunchContext()
+    assert AndSubstitution(left, right).perform(lc) == 'False'
+
+
+@pytest.mark.parametrize('left', ['False', 'false', '0'])
+@pytest.mark.parametrize('right', ['True', 'true', '1'])
+def test_and_substitution_right_true(left, right):
+    lc = LaunchContext()
+    assert AndSubstitution(left, right).perform(lc) == 'False'
+
+
+@pytest.mark.parametrize('left', ['False', 'false', '0'])
+@pytest.mark.parametrize('right', ['False', 'false', '0'])
+def test_and_substitution_both_false(left, right):
+    lc = LaunchContext()
+    assert AndSubstitution(left, right).perform(lc) == 'False'
+
+
+def test_and_substitution_invalid():
+    lc = LaunchContext()
+    with pytest.raises(SubstitutionFailure):
+        AndSubstitution('not-condition-expression', 'True').perform(lc)
+    with pytest.raises(SubstitutionFailure):
+        AndSubstitution('True', 'not-condition-expression').perform(lc)
+
+
+@pytest.mark.parametrize('left', ['True', 'true', '1'])
+@pytest.mark.parametrize('right', ['True', 'true', '1'])
+def test_or_substitution_both_true(left, right):
+    lc = LaunchContext()
+    assert OrSubstitution(left, right).perform(lc) == 'True'
+
+
+@pytest.mark.parametrize('left', ['True', 'true', '1'])
+@pytest.mark.parametrize('right', ['False', 'false', '0'])
+def test_or_substitution_left_true(left, right):
+    lc = LaunchContext()
+    assert OrSubstitution(left, right).perform(lc) == 'True'
+
+
+@pytest.mark.parametrize('left', ['False', 'false', '0'])
+@pytest.mark.parametrize('right', ['True', 'true', '1'])
+def test_or_substitution_right_true(left, right):
+    lc = LaunchContext()
+    assert OrSubstitution(left, right).perform(lc) == 'True'
+
+
+@pytest.mark.parametrize('left', ['False', 'false', '0'])
+@pytest.mark.parametrize('right', ['False', 'false', '0'])
+def test_or_substitution_both_false(left, right):
+    lc = LaunchContext()
+    assert OrSubstitution(left, right).perform(lc) == 'False'
+
+
+def test_or_substitution_invalid():
+    lc = LaunchContext()
+    with pytest.raises(SubstitutionFailure):
+        OrSubstitution('not-condition-expression', 'True').perform(lc)
+    with pytest.raises(SubstitutionFailure):
+        OrSubstitution('True', 'not-condition-expression').perform(lc)

--- a/launch_xml/test/launch_xml/test_boolean_substitution.py
+++ b/launch_xml/test/launch_xml/test_boolean_substitution.py
@@ -20,7 +20,7 @@ from launch.frontend import Parser
 from launch.utilities import perform_substitutions
 
 
-def test_boolean_substitution():
+def test_boolean_substitution_xml():
     xml_file = textwrap.dedent(
         r"""
         <launch>
@@ -39,32 +39,6 @@ def test_boolean_substitution():
             <let name="or_true_false" value="$(or $(var true_value) $(var false_value))" />
             <let name="or_false_true" value="$(or $(var false_value) $(var true_value))" />
             <let name="or_false_false" value="$(or $(var false_value) $(var false_value))" />
-        </launch>
-        """
-    )
-    with io.StringIO(xml_file) as f:
-        check_boolean_substitution(f)
-
-
-def test_boolean_substitution_no_var():
-    xml_file = textwrap.dedent(
-        r"""
-        <launch>
-            <let name="true_value" value="true" />
-            <let name="false_value" value="false" />
-
-            <let name="not_true" value="$(not true_value)" />
-            <let name="not_false" value="$(not false_value)" />
-
-            <let name="and_true_true" value="$(and true_value true_value)" />
-            <let name="and_true_false" value="$(and true_value false_value)" />
-            <let name="and_false_true" value="$(and false_value true_value)" />
-            <let name="and_false_false" value="$(and false_value false_value)" />
-
-            <let name="or_true_true" value="$(or true_value true_value)" />
-            <let name="or_true_false" value="$(or true_value false_value)" />
-            <let name="or_false_true" value="$(or false_value true_value)" />
-            <let name="or_false_false" value="$(or false_value false_value)" />
         </launch>
         """
     )

--- a/launch_xml/test/launch_xml/test_boolean_substitution.py
+++ b/launch_xml/test/launch_xml/test_boolean_substitution.py
@@ -20,7 +20,7 @@ from launch.frontend import Parser
 from launch.utilities import perform_substitutions
 
 
-def test_boolean_substitution_xml():
+def test_boolean_substitution():
     xml_file = textwrap.dedent(
         r"""
         <launch>
@@ -39,6 +39,32 @@ def test_boolean_substitution_xml():
             <let name="or_true_false" value="$(or $(var true_value) $(var false_value))" />
             <let name="or_false_true" value="$(or $(var false_value) $(var true_value))" />
             <let name="or_false_false" value="$(or $(var false_value) $(var false_value))" />
+        </launch>
+        """
+    )
+    with io.StringIO(xml_file) as f:
+        check_boolean_substitution(f)
+
+
+def test_boolean_substitution_no_var():
+    xml_file = textwrap.dedent(
+        r"""
+        <launch>
+            <let name="true_value" value="true" />
+            <let name="false_value" value="false" />
+
+            <let name="not_true" value="$(not true_value)" />
+            <let name="not_false" value="$(not false_value)" />
+
+            <let name="and_true_true" value="$(and true_value true_value)" />
+            <let name="and_true_false" value="$(and true_value false_value)" />
+            <let name="and_false_true" value="$(and false_value true_value)" />
+            <let name="and_false_false" value="$(and false_value false_value)" />
+
+            <let name="or_true_true" value="$(or true_value true_value)" />
+            <let name="or_true_false" value="$(or true_value false_value)" />
+            <let name="or_false_true" value="$(or false_value true_value)" />
+            <let name="or_false_false" value="$(or false_value false_value)" />
         </launch>
         """
     )

--- a/launch_xml/test/launch_xml/test_boolean_substitution.py
+++ b/launch_xml/test/launch_xml/test_boolean_substitution.py
@@ -20,31 +20,6 @@ from launch.frontend import Parser
 from launch.utilities import perform_substitutions
 
 
-def test_boolean_substitution_yaml():
-    yaml_file = textwrap.dedent(
-        r"""
-        launch:
-            - let: { name: true_value, value: "true" }
-            - let: { name: false_value, value: "false" }
-
-            - let: { name: not_true, value: "$(not $(var true_value))" }
-            - let: { name: not_false, value: "$(not $(var false_value))" }
-
-            - let: { name: and_true_true, value: "$(and $(var true_value) $(var true_value))" }
-            - let: { name: and_true_false, value: "$(and $(var true_value) $(var false_value))" }
-            - let: { name: and_false_true, value: "$(and $(var false_value) $(var true_value))" }
-            - let: { name: and_false_false, value: "$(and $(var false_value) $(var false_value))" }
-
-            - let: { name: or_true_true, value: "$(or $(var true_value) $(var true_value))" }
-            - let: { name: or_true_false, value: "$(or $(var true_value) $(var false_value))" }
-            - let: { name: or_false_true, value: "$(or $(var false_value) $(var true_value))" }
-            - let: { name: or_false_false, value: "$(or $(var false_value) $(var false_value))" }
-        """
-    )
-    with io.StringIO(yaml_file) as f:
-        check_boolean_substitution(f)
-
-
 def test_boolean_substitution_xml():
     xml_file = textwrap.dedent(
         r"""

--- a/launch_yaml/test/launch_yaml/test_boolean_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_boolean_substitution.py
@@ -1,0 +1,84 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import textwrap
+
+from launch import LaunchService
+from launch.frontend import Parser
+from launch.utilities import perform_substitutions
+
+
+def test_boolean_substitution_yaml():
+    yaml_file = textwrap.dedent(
+        r"""
+        launch:
+            - let: { name: true_value, value: "true" }
+            - let: { name: false_value, value: "false" }
+
+            - let: { name: not_true, value: "$(not $(var true_value))" }
+            - let: { name: not_false, value: "$(not $(var false_value))" }
+
+            - let: { name: and_true_true, value: "$(and $(var true_value) $(var true_value))" }
+            - let: { name: and_true_false, value: "$(and $(var true_value) $(var false_value))" }
+            - let: { name: and_false_true, value: "$(and $(var false_value) $(var true_value))" }
+            - let: { name: and_false_false, value: "$(and $(var false_value) $(var false_value))" }
+
+            - let: { name: or_true_true, value: "$(or $(var true_value) $(var true_value))" }
+            - let: { name: or_true_false, value: "$(or $(var true_value) $(var false_value))" }
+            - let: { name: or_false_true, value: "$(or $(var false_value) $(var true_value))" }
+            - let: { name: or_false_false, value: "$(or $(var false_value) $(var false_value))" }
+        """
+    )
+    with io.StringIO(yaml_file) as f:
+        check_boolean_substitution(f)
+
+
+def check_boolean_substitution(file):
+    root_entity, parser = Parser.load(file)
+    ld = parser.parse_description(root_entity)
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+
+    def perform(substitution):
+        return perform_substitutions(ls.context, substitution)
+
+    sub_entries = ld.describe_sub_entities()
+
+    not_true = sub_entries[2]
+    not_false = sub_entries[3]
+
+    and_true_true = sub_entries[4]
+    and_true_false = sub_entries[5]
+    and_false_true = sub_entries[6]
+    and_false_false = sub_entries[7]
+
+    or_true_true = sub_entries[8]
+    or_true_false = sub_entries[9]
+    or_false_true = sub_entries[10]
+    or_false_false = sub_entries[11]
+
+    assert perform(not_true.value) == 'false'
+    assert perform(not_false.value) == 'true'
+
+    assert perform(and_true_true.value) == 'true'
+    assert perform(and_true_false.value) == 'false'
+    assert perform(and_false_true.value) == 'false'
+    assert perform(and_false_false.value) == 'false'
+
+    assert perform(or_true_true.value) == 'true'
+    assert perform(or_true_false.value) == 'true'
+    assert perform(or_false_true.value) == 'true'
+    assert perform(or_false_false.value) == 'false'


### PR DESCRIPTION
Considering the following use cases, I think it's useful to add boolean substitutions.

```xml
<launch>
  <arg name="condition_1" />
  <arg name="condition_2" />

  <!-- Without this PR (if I understand correctly) -->
  <let name="and" value="$(eval '\'$(var condition_1)\' and \'$(var condition_2)\'')" />
  <group if="$(var and)">
    <log message="do something" />
  </group>

  <!-- With this PR -->
  <group if="$(and $(var condition_1) $(var condition_2))">
    <log message="do something" />
  </group>
</launch>
```

Of course, in this case we can change the arg like this:

```xml
<launch>
  <arg name="condition_1_and_condition_2" />

  <group if="$(var condition_1_and_condition_2)">
    <log message="do something" />
  </group>
</launch>
```

However, I think it doesn't work with the following case:

```xml
// caller.launch.xml
<launch>
  <arg name="condition_1" />
  <arg name="condition_2" />

  <group if="$(var condition_1)">
    <log message="do something 1" />
  </group>

  <group if="$(var condition_2)">
    <log message="do something 2" />
  </group>

  <let name="and" value="$(eval '\'$(var condition_1)\' and \'$(var condition_2)\'')" />
  <include file="called.launch.xml">
    <arg name="do_something" value="$(var and)" />
  <include />
</launch>

// called.launch.xml
<launch>
  <arg name="do_something" />

  <group if="$(var do_something)">
    <log message="do something in called.launch.xml" />
  </group>
</launch>
```