### PR TITLE
Support scoping environment variables

### DIFF
--- a/launch/launch/actions/__init__.py
+++ b/launch/launch/actions/__init__.py
@@ -24,7 +24,9 @@ from .include_launch_description import IncludeLaunchDescription
 from .log_info import LogInfo
 from .opaque_coroutine import OpaqueCoroutine
 from .opaque_function import OpaqueFunction
+from .pop_environment import PopEnvironment
 from .pop_launch_configurations import PopLaunchConfigurations
+from .push_environment import PushEnvironment
 from .push_launch_configurations import PushLaunchConfigurations
 from .register_event_handler import RegisterEventHandler
 from .reset_launch_configurations import ResetLaunchConfigurations
@@ -47,7 +49,9 @@ __all__ = [
     'LogInfo',
     'OpaqueCoroutine',
     'OpaqueFunction',
+    'PopEnvironment',
     'PopLaunchConfigurations',
+    'PushEnvironment',
     'PushLaunchConfigurations',
     'ResetLaunchConfigurations',
     'RegisterEventHandler',

--- a/launch/launch/actions/__init__.py
+++ b/launch/launch/actions/__init__.py
@@ -29,6 +29,7 @@ from .pop_launch_configurations import PopLaunchConfigurations
 from .push_environment import PushEnvironment
 from .push_launch_configurations import PushLaunchConfigurations
 from .register_event_handler import RegisterEventHandler
+from .reset_environment import ResetEnvironment
 from .reset_launch_configurations import ResetLaunchConfigurations
 from .set_environment_variable import SetEnvironmentVariable
 from .set_launch_configuration import SetLaunchConfiguration
@@ -53,6 +54,7 @@ __all__ = [
     'PopLaunchConfigurations',
     'PushEnvironment',
     'PushLaunchConfigurations',
+    'ResetEnvironment',
     'ResetLaunchConfigurations',
     'RegisterEventHandler',
     'SetEnvironmentVariable',

--- a/launch/launch/actions/append_environment_variable.py
+++ b/launch/launch/actions/append_environment_variable.py
@@ -111,11 +111,11 @@ class AppendEnvironmentVariable(Action):
         value = perform_substitutions(context, self.value)
         prepend = perform_typed_substitution(context, self.prepend, bool)
         separator = perform_substitutions(context, self.separator)
-        if name in os.environ:
-            os.environ[name] = \
-                os.environ[name] + separator + value \
+        if name in context.environment:
+            context.environment[name] = \
+                context.environment[name] + separator + value \
                 if not prepend \
-                else value + separator + os.environ[name]
+                else value + separator + context.environment[name]
         else:
-            os.environ[name] = value
+            context.environment[name] = value
         return None

--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -19,7 +19,9 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 
+from .pop_environment import PopEnvironment
 from .pop_launch_configurations import PopLaunchConfigurations
+from .push_environment import PushEnvironment
 from .push_launch_configurations import PushLaunchConfigurations
 from .reset_launch_configurations import ResetLaunchConfigurations
 from .set_launch_configuration import SetLaunchConfiguration
@@ -35,22 +37,22 @@ from ..some_substitutions_type import SomeSubstitutionsType
 @expose_action('group')
 class GroupAction(Action):
     """
-    Action that yields other actions, optionally scoping and forwarding launch configurations.
+    Action that yields other actions.
 
     This action is used to nest other actions without including a separate
     launch description, while also optionally having a condition (like all
-    other actions), scoping launch configurations, forwarding launch
-    configurations, and/or declaring launch configurations for just the
+    other actions), scoping and forwarding launch configurations and
+    environment variables, and/or declaring launch configurations for just the
     group and its yielded actions.
 
-    When scoped=True, changes to launch configurations are limited to the
-    scope of actions in the group action.
+    When scoped=True, changes to launch configurations and environment
+    variables are limited to the scope of actions in the group action.
 
     When scoped=True and forwarding=True, all existing launch configurations
-    are available in the scoped context.
+    and environment variables are available in the scoped context.
 
     When scoped=True and forwarding=False, all existing launch configurations
-    are removed from the scoped context.
+    and environment variables are removed from the scoped context.
 
     Any launch configuration defined in the launch_configurations dictionary
     will be set in the current context.
@@ -115,15 +117,19 @@ class GroupAction(Action):
                 if self.__forwarding:
                     self.__actions_to_return = [
                         PushLaunchConfigurations(),
+                        PushEnvironment(),
                         *configuration_sets,
                         *self.__actions_to_return,
+                        PopEnvironment(),
                         PopLaunchConfigurations()
                     ]
                 else:
                     self.__actions_to_return = [
                         PushLaunchConfigurations(),
+                        PushEnvironment(),
                         ResetLaunchConfigurations(self.__launch_configurations),
                         *self.__actions_to_return,
+                        PopEnvironment(),
                         PopLaunchConfigurations()
                     ]
             else:

--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -23,6 +23,7 @@ from .pop_environment import PopEnvironment
 from .pop_launch_configurations import PopLaunchConfigurations
 from .push_environment import PushEnvironment
 from .push_launch_configurations import PushLaunchConfigurations
+from .reset_environment import ResetEnvironment
 from .reset_launch_configurations import ResetLaunchConfigurations
 from .set_launch_configuration import SetLaunchConfiguration
 from ..action import Action
@@ -127,6 +128,7 @@ class GroupAction(Action):
                     self.__actions_to_return = [
                         PushLaunchConfigurations(),
                         PushEnvironment(),
+                        ResetEnvironment(),
                         ResetLaunchConfigurations(self.__launch_configurations),
                         *self.__actions_to_return,
                         PopEnvironment(),

--- a/launch/launch/actions/pop_environment.py
+++ b/launch/launch/actions/pop_environment.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the PopEnvironment action."""
+
+from ..action import Action
+from ..launch_context import LaunchContext
+
+
+class PopEnvironment(Action):
+    """
+    Action that pops the state of environment variables from a stack.
+
+    The state can be stored initially by pushing onto the stack with the
+    :py:class:`launch.actions.PushEnvironment` action.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Create a PopEnvironment action."""
+        super().__init__(**kwargs)
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._pop_environment()

--- a/launch/launch/actions/push_environment.py
+++ b/launch/launch/actions/push_environment.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the PushEnvironment action."""
+
+from ..action import Action
+from ..launch_context import LaunchContext
+
+
+class PushEnvironment(Action):
+    """
+    Action that pushes the current environment to a stack.
+
+    The state can be restored by popping the stack with the
+    :py:class:`launch.actions.PopEnvironment` action.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Create a PushEnvironment action."""
+        super().__init__(**kwargs)
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._push_environment()

--- a/launch/launch/actions/reset_environment.py
+++ b/launch/launch/actions/reset_environment.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the ResetEnvironment action."""
+
+from ..action import Action
+from ..frontend import Entity
+from ..frontend import expose_action
+from ..frontend import Parser
+from ..launch_context import LaunchContext
+
+
+@expose_action('reset_env')
+class ResetEnvironment(Action):
+    """
+    Action that resets the environment in the current context.
+
+    Clears any changes made by previous actions to the context environment.
+    The environment is reset to the state it was in when the context was created,
+    i.e. the contents of ``os.environ``.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Create a ResetEnvironment action."""
+        super().__init__(**kwargs)
+
+    @classmethod
+    def parse(cls, entity: Entity, parser: Parser):
+        """Return ``ResetEnvironment`` action and kwargs for constructing it."""
+        _, kwargs = super().parse(entity, parser)
+        return cls, kwargs
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._reset_environment()

--- a/launch/launch/actions/set_environment_variable.py
+++ b/launch/launch/actions/set_environment_variable.py
@@ -14,7 +14,6 @@
 
 """Module for the SetEnvironmentVariable action."""
 
-import os
 from typing import List
 
 from ..action import Action
@@ -67,6 +66,6 @@ class SetEnvironmentVariable(Action):
 
     def execute(self, context: LaunchContext) -> None:
         """Execute the action."""
-        os.environ[perform_substitutions(context, self.name)] = \
+        context.environment[perform_substitutions(context, self.name)] = \
             perform_substitutions(context, self.value)
         return None

--- a/launch/launch/actions/unset_environment_variable.py
+++ b/launch/launch/actions/unset_environment_variable.py
@@ -14,8 +14,6 @@
 
 """Module for the UnsetEnvironmentVariable action."""
 
-import os
-
 from typing import List
 
 from ..action import Action
@@ -61,6 +59,6 @@ class UnsetEnvironmentVariable(Action):
     def execute(self, context: LaunchContext) -> None:
         """Execute the action."""
         name = perform_substitutions(context, self.name)
-        if name in os.environ:
-            del os.environ[name]
+        if name in context.environment:
+            del context.environment[name]
         return None

--- a/launch/launch/descriptions/executable.py
+++ b/launch/launch/descriptions/executable.py
@@ -17,6 +17,7 @@
 
 """Module for a description of an Executable."""
 
+import copy
 import os
 import re
 import shlex
@@ -68,7 +69,7 @@ class Executable:
             to be resolved at runtime, defaults to the basename of the executable
         :param cwd: The directory in which to run the executable
         :param env: Dictionary of environment variables to be used, starting from a clean
-            environment. If None, the current environment is used.
+            environment. If None, the current environment of the launch context is used.
         :param additional_env: Dictionary of environment variables to be added. If env was
             None, they are added to the current environment. If not, env is updated with
             additional_env.
@@ -191,15 +192,14 @@ class Executable:
         if self.__cwd is not None:
             cwd = ''.join([context.perform_substitution(x) for x in self.__cwd])
         self.__final_cwd = cwd
-        env = None
+        env = {}
         if self.__env is not None:
-            env = {}
             for key, value in self.__env:
                 env[''.join([context.perform_substitution(x) for x in key])] = \
                     ''.join([context.perform_substitution(x) for x in value])
+        else:
+            env = copy.deepcopy(context.environment)
         if self.__additional_env is not None:
-            if env is None:
-                env = dict(os.environ)
             for key, value in self.__additional_env:
                 env[''.join([context.perform_substitution(x) for x in key])] = \
                     ''.join([context.perform_substitution(x) for x in value])

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -63,7 +63,7 @@ class LaunchContext:
         self.__launch_configurations = {}  # type: Dict[Text, Text]
 
         self.__environment_stack = []  # type: List[Dict[Text, Text]]
-        self.__environment = dict(os.environ)  # type: Dict[Text, Text]
+        self._reset_environment()
 
         self.__is_shutdown = False
         self.__asyncio_loop = None  # type: Optional[asyncio.AbstractEventLoop]
@@ -168,6 +168,9 @@ class LaunchContext:
         if not self.__environment_stack:
             raise RuntimeError('environment stack unexpectedly empty')
         self.__environment = self.__environment_stack.pop()
+
+    def _reset_environment(self):
+        self.__environment = dict(os.environ)  # type: Dict[Text, Text]
 
     def _push_launch_configurations(self):
         self.__launch_configurations_stack.append(self.__launch_configurations.copy())

--- a/launch/launch/substitutions/environment_variable.py
+++ b/launch/launch/substitutions/environment_variable.py
@@ -14,7 +14,6 @@
 
 """Module for the EnvironmentVariable substitution."""
 
-import os
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -35,8 +34,8 @@ class EnvironmentVariable(Substitution):
     If the environment variable is not found, it returns empty string.
 
     Note that the environment variable is resolved based on the launch context's environment (i.e.,
-    `os.environ`) even though the substitution may be associated with an entity that might have a
-    different set of environment variables.
+    ``context.environment``) even though the substitution may be associated with an entity that
+    might have a different set of environment variables.
     """
 
     def __init__(
@@ -93,7 +92,7 @@ class EnvironmentVariable(Substitution):
         if default_value is not None:
             default_value = perform_substitutions(context, self.default_value)
         name = perform_substitutions(context, self.name)
-        value = os.environ.get(
+        value = context.environment.get(
             name,
             default_value
         )

--- a/launch/test/launch/actions/test_append_environment_variable.py
+++ b/launch/test/launch/actions/test_append_environment_variable.py
@@ -33,52 +33,45 @@ def test_append_environment_variable_constructor():
 
 def test_append_environment_variable_execute():
     """Test the execute() of the AppendEnvironmentVariable class."""
-    lc1 = LaunchContext()
+    context = LaunchContext()
 
     # Sets environment variable if it does not exist
-    if 'NONEXISTENT_KEY' in os.environ:
-        del os.environ['NONEXISTENT_KEY']
-    assert os.environ.get('NONEXISTENT_KEY') is None
-    AppendEnvironmentVariable('NONEXISTENT_KEY', 'value').visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == 'value'
+    assert context.environment.get('NONEXISTENT_KEY') is None
+    AppendEnvironmentVariable('NONEXISTENT_KEY', 'value').visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == 'value'
     # Same result if prepending is enabled
-    del os.environ['NONEXISTENT_KEY']
-    AppendEnvironmentVariable('NONEXISTENT_KEY', 'value', prepend=True).visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == 'value'
+    del context.environment['NONEXISTENT_KEY']
+    AppendEnvironmentVariable('NONEXISTENT_KEY', 'value', prepend=True).visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == 'value'
 
     # Appends to environment variable if it does exist
-    AppendEnvironmentVariable('NONEXISTENT_KEY', 'another value').visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == 'value' + os.pathsep + 'another value'
+    AppendEnvironmentVariable('NONEXISTENT_KEY', 'another value').visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == 'value' + os.pathsep + 'another value'
 
     # Prepends to environment variable if it does exist and option is enabled
-    AppendEnvironmentVariable('NONEXISTENT_KEY', 'some value', prepend=True).visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == \
+    AppendEnvironmentVariable('NONEXISTENT_KEY', 'some value', prepend=True).visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == \
         'some value' + os.pathsep + 'value' + os.pathsep + 'another value'
 
     # Can use an optional separator
-    AppendEnvironmentVariable('NONEXISTENT_KEY', 'other value', separator='|').visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == \
+    AppendEnvironmentVariable('NONEXISTENT_KEY', 'other value', separator='|').visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == \
         'some value' + os.pathsep + 'value' + os.pathsep + 'another value' + '|' + 'other value'
 
     # Appends/prepends with substitutions
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
     AppendEnvironmentVariable(
         'ANOTHER_NONEXISTENT_KEY',
         EnvironmentVariable('NONEXISTENT_KEY'),
-        prepend=TextSubstitution(text='false')).visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') == \
+        prepend=TextSubstitution(text='false')).visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') == \
         'some value' + os.pathsep + 'value' + os.pathsep + 'another value' + '|' + 'other value'
 
-    os.environ['ANOTHER_NONEXISTENT_KEY'] = 'abc'
-    os.environ['SOME_SEPARATOR'] = '//'
+    context.environment['ANOTHER_NONEXISTENT_KEY'] = 'abc'
+    context.environment['SOME_SEPARATOR'] = '//'
     AppendEnvironmentVariable(
         'ANOTHER_NONEXISTENT_KEY',
         TextSubstitution(text='def'),
         separator=EnvironmentVariable('SOME_SEPARATOR'),
-        prepend=TextSubstitution(text='yes')).visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') == 'def' + '//' + 'abc'
-
-    # Cleanup environment variables
-    del os.environ['NONEXISTENT_KEY']
-    del os.environ['ANOTHER_NONEXISTENT_KEY']
-    del os.environ['SOME_SEPARATOR']
+        prepend=TextSubstitution(text='yes')).visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') == 'def' + '//' + 'abc'

--- a/launch/test/launch/actions/test_push_and_pop_environment.py
+++ b/launch/test/launch/actions/test_push_and_pop_environment.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PopEnvironment and PushEnvironment action classes."""
+
+from launch import LaunchContext
+from launch.actions import PopEnvironment
+from launch.actions import PushEnvironment
+
+
+def test_push_and_pop_environment_constructors():
+    """Test the constructors for PopEnvironment and PushEnvironment classes."""
+    PopEnvironment()
+    PushEnvironment()
+
+
+def test_push_and_pop_environment_execute():
+    """Test the execute() of the PopEnvironment and PushEnvironment classes."""
+    context = LaunchContext()
+
+    # does not change empty state
+    context.environment.clear()
+    assert len(context.environment) == 0
+    PushEnvironment().visit(context)
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 0
+
+    # does not change single env
+    context.environment['foo'] = 'FOO'
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'
+    PushEnvironment().visit(context)
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'
+
+    # does scope additions
+    context = LaunchContext()
+    context.environment.clear()
+    assert len(context.environment) == 0
+    PushEnvironment().visit(context)
+    context.environment['foo'] = 'FOO'
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 0
+
+    # does scope modifications
+    context = LaunchContext()
+    context.environment.clear()
+    assert len(context.environment) == 0
+    context.environment['foo'] = 'FOO'
+    PushEnvironment().visit(context)
+    context.environment['foo'] = 'BAR'
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'
+
+    # does scope deletions
+    context = LaunchContext()
+    context.environment.clear()
+    assert len(context.environment) == 0
+    context.environment['foo'] = 'FOO'
+    PushEnvironment().visit(context)
+    del context.environment['foo']
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'

--- a/launch/test/launch/actions/test_set_and_unset_environment_variable.py
+++ b/launch/test/launch/actions/test_set_and_unset_environment_variable.py
@@ -14,8 +14,6 @@
 
 """Tests for the SetEnvironmentVariable and UnsetEnvironmentVariable action classes."""
 
-import os
-
 from launch import LaunchContext
 from launch.actions import SetEnvironmentVariable
 from launch.actions import UnsetEnvironmentVariable
@@ -30,44 +28,36 @@ def test_set_and_unset_environment_variable_constructors():
 
 def test_set_and_unset_environment_variable_execute():
     """Test the execute() of the SetEnvironmentVariable and UnsetEnvironmentVariable classes."""
-    lc1 = LaunchContext()
+    context = LaunchContext()
 
     # can set and overwrite environment variables
-    if 'NONEXISTENT_KEY' in os.environ:
-        del os.environ['NONEXISTENT_KEY']
-    assert os.environ.get('NONEXISTENT_KEY') is None
-    SetEnvironmentVariable('NONEXISTENT_KEY', 'value').visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == 'value'
-    SetEnvironmentVariable('NONEXISTENT_KEY', 'ANOTHER_NONEXISTENT_KEY').visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
+    assert context.environment.get('NONEXISTENT_KEY') is None
+    SetEnvironmentVariable('NONEXISTENT_KEY', 'value').visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == 'value'
+    SetEnvironmentVariable('NONEXISTENT_KEY', 'ANOTHER_NONEXISTENT_KEY').visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
 
     # can unset environment variables
-    if 'ANOTHER_NONEXISTENT_KEY' in os.environ:
-        del os.environ['ANOTHER_NONEXISTENT_KEY']
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
-    SetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY', 'some value').visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') == 'some value'
-    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
+    SetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY', 'some value').visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') == 'some value'
+    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
 
     # set and unset with substitutions
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
     SetEnvironmentVariable(
         'ANOTHER_NONEXISTENT_KEY',
-        EnvironmentVariable('NONEXISTENT_KEY')).visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
-    UnsetEnvironmentVariable(EnvironmentVariable('NONEXISTENT_KEY')).visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
-
-    # cleanup environment variables
-    if 'NONEXISTENT_KEY' in os.environ:
-        del os.environ['NONEXISTENT_KEY']
+        EnvironmentVariable('NONEXISTENT_KEY')).visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
+    UnsetEnvironmentVariable(EnvironmentVariable('NONEXISTENT_KEY')).visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
 
 
 def test_unset_nonexistent_key():
     """Test that the UnsetEnvironmentVariable class doesn't raise an exception."""
-    lc1 = LaunchContext()
+    context = LaunchContext()
 
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
-    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
+    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None

--- a/launch/test/launch/substitutions/test_environment_variable.py
+++ b/launch/test/launch/substitutions/test_environment_variable.py
@@ -43,4 +43,3 @@ def test_this_launch_file_path():
     assert 'SOME_VALUE' == sub1.perform(lc)
     assert 'SOME_VALUE' == sub2.perform(lc)
     assert 'SOME_VALUE' == sub3.perform(lc)
-    del os.environ['MY_ENVIRONMENT_VARIABLE']

--- a/launch/test/launch/test_launch_context.py
+++ b/launch/test/launch/test_launch_context.py
@@ -15,6 +15,7 @@
 """Tests for the LaunchContext class."""
 
 import asyncio
+import os
 
 from launch import LaunchContext
 
@@ -104,6 +105,18 @@ def test_launch_context_launch_configurations():
 
     with pytest.raises(RuntimeError):
         lc._pop_launch_configurations()
+
+
+def test_launch_context_environment():
+    """Test the environment feature of the LaunchContext class."""
+    # Inherits OS environ
+    os.environ['LAUNCH_TEST_ENV_PUSH_POP'] = 'FOO'
+    context = LaunchContext()
+    assert len(context.environment) > 0
+    assert 'LAUNCH_TEST_ENV_PUSH_POP' in context.environment
+    assert context.environment['LAUNCH_TEST_ENV_PUSH_POP'] == 'FOO'
+    # cleanup
+    del os.environ['LAUNCH_TEST_ENV_PUSH_POP']
 
 
 def test_launch_context_register_event_handlers():

--- a/launch/test/launch/test_launch_context.py
+++ b/launch/test/launch/test_launch_context.py
@@ -113,8 +113,7 @@ def test_launch_context_environment():
     os.environ['LAUNCH_TEST_ENV_PUSH_POP'] = 'FOO'
     context = LaunchContext()
     assert len(context.environment) > 0
-    assert 'LAUNCH_TEST_ENV_PUSH_POP' in context.environment
-    assert context.environment['LAUNCH_TEST_ENV_PUSH_POP'] == 'FOO'
+    assert context.environment == dict(os.environ)
     # cleanup
     del os.environ['LAUNCH_TEST_ENV_PUSH_POP']
 

--- a/launch_xml/test/launch_xml/test_group.py
+++ b/launch_xml/test/launch_xml/test_group.py
@@ -17,8 +17,13 @@
 import io
 import textwrap
 
-from launch.actions import GroupAction, PopLaunchConfigurations, PushLaunchConfigurations
-from launch.actions import ResetLaunchConfigurations, SetLaunchConfiguration
+from launch.actions import GroupAction
+from launch.actions import PopEnvironment
+from launch.actions import PopLaunchConfigurations
+from launch.actions import PushEnvironment
+from launch.actions import PushLaunchConfigurations
+from launch.actions import ResetLaunchConfigurations
+from launch.actions import SetLaunchConfiguration
 from launch.frontend import Parser
 from launch.launch_context import LaunchContext
 
@@ -55,22 +60,26 @@ def test_group():
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     actions = ld.entities[2].execute(lc)
-    assert 5 == len(actions)
+    assert 7 == len(actions)
     assert isinstance(actions[0], PushLaunchConfigurations)
-    assert isinstance(actions[1], ResetLaunchConfigurations)
-    assert isinstance(actions[2], SetLaunchConfiguration)
+    assert isinstance(actions[1], PushEnvironment)
+    assert isinstance(actions[2], ResetLaunchConfigurations)
     assert isinstance(actions[3], SetLaunchConfiguration)
-    assert isinstance(actions[4], PopLaunchConfigurations)
+    assert isinstance(actions[4], SetLaunchConfiguration)
+    assert isinstance(actions[5], PopEnvironment)
+    assert isinstance(actions[6], PopLaunchConfigurations)
     actions[0].visit(lc)
     actions[1].visit(lc)
+    actions[2].visit(lc)
     assert 'foo' not in lc.launch_configurations.keys()
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     assert 'baz' in lc.launch_configurations.keys()
     assert 'BAZ' == lc.launch_configurations['baz']
-    actions[2].visit(lc)
     actions[3].visit(lc)
     actions[4].visit(lc)
+    actions[5].visit(lc)
+    actions[6].visit(lc)
 
 
 if __name__ == '__main__':

--- a/launch_xml/test/launch_xml/test_group.py
+++ b/launch_xml/test/launch_xml/test_group.py
@@ -22,6 +22,7 @@ from launch.actions import PopEnvironment
 from launch.actions import PopLaunchConfigurations
 from launch.actions import PushEnvironment
 from launch.actions import PushLaunchConfigurations
+from launch.actions import ResetEnvironment
 from launch.actions import ResetLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
 from launch.frontend import Parser
@@ -60,26 +61,28 @@ def test_group():
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     actions = ld.entities[2].execute(lc)
-    assert 7 == len(actions)
+    assert 8 == len(actions)
     assert isinstance(actions[0], PushLaunchConfigurations)
     assert isinstance(actions[1], PushEnvironment)
-    assert isinstance(actions[2], ResetLaunchConfigurations)
-    assert isinstance(actions[3], SetLaunchConfiguration)
+    assert isinstance(actions[2], ResetEnvironment)
+    assert isinstance(actions[3], ResetLaunchConfigurations)
     assert isinstance(actions[4], SetLaunchConfiguration)
-    assert isinstance(actions[5], PopEnvironment)
-    assert isinstance(actions[6], PopLaunchConfigurations)
+    assert isinstance(actions[5], SetLaunchConfiguration)
+    assert isinstance(actions[6], PopEnvironment)
+    assert isinstance(actions[7], PopLaunchConfigurations)
     actions[0].visit(lc)
     actions[1].visit(lc)
     actions[2].visit(lc)
+    actions[3].visit(lc)
     assert 'foo' not in lc.launch_configurations.keys()
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     assert 'baz' in lc.launch_configurations.keys()
     assert 'BAZ' == lc.launch_configurations['baz']
-    actions[3].visit(lc)
     actions[4].visit(lc)
     actions[5].visit(lc)
     actions[6].visit(lc)
+    actions[7].visit(lc)
 
 
 if __name__ == '__main__':

--- a/launch_yaml/test/launch_yaml/test_group.py
+++ b/launch_yaml/test/launch_yaml/test_group.py
@@ -17,8 +17,13 @@
 import io
 import textwrap
 
-from launch.actions import GroupAction, PopLaunchConfigurations, PushLaunchConfigurations
-from launch.actions import ResetLaunchConfigurations, SetLaunchConfiguration
+from launch.actions import GroupAction
+from launch.actions import PopEnvironment
+from launch.actions import PopLaunchConfigurations
+from launch.actions import PushEnvironment
+from launch.actions import PushLaunchConfigurations
+from launch.actions import ResetLaunchConfigurations
+from launch.actions import SetLaunchConfiguration
 from launch.frontend import Parser
 from launch.launch_context import LaunchContext
 
@@ -67,22 +72,26 @@ def test_group():
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     actions = ld.entities[2].execute(lc)
-    assert 5 == len(actions)
+    assert 7 == len(actions)
     assert isinstance(actions[0], PushLaunchConfigurations)
-    assert isinstance(actions[1], ResetLaunchConfigurations)
-    assert isinstance(actions[2], SetLaunchConfiguration)
+    assert isinstance(actions[1], PushEnvironment)
+    assert isinstance(actions[2], ResetLaunchConfigurations)
     assert isinstance(actions[3], SetLaunchConfiguration)
-    assert isinstance(actions[4], PopLaunchConfigurations)
+    assert isinstance(actions[4], SetLaunchConfiguration)
+    assert isinstance(actions[5], PopEnvironment)
+    assert isinstance(actions[6], PopLaunchConfigurations)
     actions[0].visit(lc)
     actions[1].visit(lc)
+    actions[2].visit(lc)
     assert 'foo' not in lc.launch_configurations.keys()
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     assert 'baz' in lc.launch_configurations.keys()
     assert 'BAZ' == lc.launch_configurations['baz']
-    actions[2].visit(lc)
     actions[3].visit(lc)
     actions[4].visit(lc)
+    actions[5].visit(lc)
+    actions[6].visit(lc)
 
 
 if __name__ == '__main__':

--- a/launch_yaml/test/launch_yaml/test_group.py
+++ b/launch_yaml/test/launch_yaml/test_group.py
@@ -22,6 +22,7 @@ from launch.actions import PopEnvironment
 from launch.actions import PopLaunchConfigurations
 from launch.actions import PushEnvironment
 from launch.actions import PushLaunchConfigurations
+from launch.actions import ResetEnvironment
 from launch.actions import ResetLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
 from launch.frontend import Parser
@@ -72,26 +73,28 @@ def test_group():
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     actions = ld.entities[2].execute(lc)
-    assert 7 == len(actions)
+    assert 8 == len(actions)
     assert isinstance(actions[0], PushLaunchConfigurations)
     assert isinstance(actions[1], PushEnvironment)
-    assert isinstance(actions[2], ResetLaunchConfigurations)
-    assert isinstance(actions[3], SetLaunchConfiguration)
+    assert isinstance(actions[2], ResetEnvironment)
+    assert isinstance(actions[3], ResetLaunchConfigurations)
     assert isinstance(actions[4], SetLaunchConfiguration)
-    assert isinstance(actions[5], PopEnvironment)
-    assert isinstance(actions[6], PopLaunchConfigurations)
+    assert isinstance(actions[5], SetLaunchConfiguration)
+    assert isinstance(actions[6], PopEnvironment)
+    assert isinstance(actions[7], PopLaunchConfigurations)
     actions[0].visit(lc)
     actions[1].visit(lc)
     actions[2].visit(lc)
+    actions[3].visit(lc)
     assert 'foo' not in lc.launch_configurations.keys()
     assert 'bar' in lc.launch_configurations.keys()
     assert 'BAR' == lc.launch_configurations['bar']
     assert 'baz' in lc.launch_configurations.keys()
     assert 'BAZ' == lc.launch_configurations['baz']
-    actions[3].visit(lc)
     actions[4].visit(lc)
     actions[5].visit(lc)
     actions[6].visit(lc)
+    actions[7].visit(lc)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #597

Wherever actions were previously using os.environ, now get environment variables from the launch
context. There are a few exceptions where os.environ is still used since a launch context is not
available (e.g. [logging directory](https://github.com/ros2/launch/blob/7d0d4b41208b5f3d3d6d45f3297c37e7382f83dc/launch/launch/logging/__init__.py#L59-L61) and [overriding launch process output](https://github.com/ros2/launch/blob/7d0d4b41208b5f3d3d6d45f3297c37e7382f83dc/launch/launch/actions/execute_local.py#L194)).

Maintain a stack of environment variables in the launch context, similar to launch configurations.
Add new actions PushEnvironment and PopEnvironment to interact with the stack.
Push and pop the environment inside the GroupAction to support scoping.

Add a new ResetEnvironment action that sets the contexts environment
back to it's initial state (os.environ).
Return ResetEnvironment as part of GroupAction when forwarding=False.