### PR TITLE
Fix awaiting shutdown in launch context

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -399,11 +399,7 @@ class LaunchService:
                 self.__context.emit_event_sync(shutdown_event)
             elif self.__loop_from_run_thread == asyncio_event_loop:
                 # If in the thread of the loop.
-                async def emit_event_async():
-                    nonlocal shutdown_event
-                    return await self.__context.emit_event(shutdown_event)
-
-                return emit_event_async
+                retval = self.__context.emit_event(shutdown_event)
             else:
                 # Otherwise in a different thread, so use the thread-safe method.
                 self.emit_event(shutdown_event)

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -290,7 +290,10 @@ class LaunchService:
                     # the queue
                     is_idle = self._is_idle()  # self._entity_future_pairs is pruned here
                     if not self.__shutting_down and shutdown_when_idle and is_idle:
-                        ret = await self._shutdown(reason='idle', due_to_sigint=False)
+                        coroutine = self._shutdown(reason='idle', due_to_sigint=False)
+                        ret = None
+                        if coroutine is not None:
+                            ret = await coroutine()
                         assert ret is None, ret
                         continue
 
@@ -343,7 +346,10 @@ class LaunchService:
                     msg = 'Caught exception in launch (see debug for traceback): {}'.format(exc)
                     self.__logger.debug(traceback.format_exc())
                     self.__logger.error(msg)
-                    ret = await self._shutdown(reason=msg, due_to_sigint=False)
+                    coroutine = self._shutdown(reason=msg, due_to_sigint=False)
+                    ret = None
+                    if coroutine is not None:
+                        ret = await coroutine()
                     assert ret is None, ret
                     return_code = 1
                     # keep running to let things shutdown properly

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -399,7 +399,11 @@ class LaunchService:
                 self.__context.emit_event_sync(shutdown_event)
             elif self.__loop_from_run_thread == asyncio_event_loop:
                 # If in the thread of the loop.
-                retval = self.__context.emit_event(shutdown_event)
+                async def emit_event_async():
+                    nonlocal shutdown_event
+                    return await self.__context.emit_event(shutdown_event)
+
+                return emit_event_async
             else:
                 # Otherwise in a different thread, so use the thread-safe method.
                 self.emit_event(shutdown_event)

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -290,10 +290,9 @@ class LaunchService:
                     # the queue
                     is_idle = self._is_idle()  # self._entity_future_pairs is pruned here
                     if not self.__shutting_down and shutdown_when_idle and is_idle:
-                        coroutine = self._shutdown(reason='idle', due_to_sigint=False)
-                        ret = None
-                        if coroutine is not None:
-                            ret = await coroutine()
+                        ret = self._shutdown(reason='idle', due_to_sigint=False)
+                        if ret is not None:
+                            ret = await ret
                         assert ret is None, ret
                         continue
 
@@ -346,10 +345,9 @@ class LaunchService:
                     msg = 'Caught exception in launch (see debug for traceback): {}'.format(exc)
                     self.__logger.debug(traceback.format_exc())
                     self.__logger.error(msg)
-                    coroutine = self._shutdown(reason=msg, due_to_sigint=False)
-                    ret = None
-                    if coroutine is not None:
-                        ret = await coroutine()
+                    ret = self._shutdown(reason=msg, due_to_sigint=False)
+                    if ret is not None:
+                        ret = await ret
                     assert ret is None, ret
                     return_code = 1
                     # keep running to let things shutdown properly


### PR DESCRIPTION
The method '_shutdown' is not a coroutine, and optionally returns a coroutine.
Guard against the case where it returns None, otherwise we can get the following error from launch:

    TypeError: object NoneType can't be used in 'await' expression

I noticed this error when a launch action raises an error during shutdown.