### PR TITLE
Fix sphinx directive to cross-ref Launch method

### DIFF
--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -86,7 +86,7 @@ class Entity(BaseEntity):
         """
         Access an attribute of the entity.
 
-        See :ref:meth:`launch.frontend.Entity.get_attr`.
+        See :py:meth:`launch.frontend.Entity.get_attr`.
         `launch_xml` uses type coercion.
         If coercion fails, `ValueError` will be raised.
         """

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -109,7 +109,7 @@ class Entity(BaseEntity):
         """
         Access an attribute of the entity.
 
-        See :ref:meth:`launch.frontend.Entity.get_attr`.
+        See :py:meth:`launch.frontend.Entity.get_attr`.
         `launch_yaml` does not apply type coercion,
         it only checks if the read value is of the correct type.
         """


### PR DESCRIPTION
This PR is required for a clean rosdoc2 build of launch_yaml and
launch_xml.

`:ref:meth:` is not a valid Sphinx directive to cross-reference python
methods. This has been replaced with `:py:meth:`, as suggested in the
Sphinx documentation. Reference:
https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#role-py-meth

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>