### PR TITLE
Start Python faster in test_execute_processs_shutdown to avoid flaky failures

### DIFF
--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -105,7 +105,7 @@ def test_execute_process_shutdown():
 
     def generate_launch_description():
         process_action = ExecuteProcess(
-            cmd=[sys.executable, '-c', 'import signal; signal.pause()'],
+            cmd=[sys.executable, '-S', '-c', 'input()'],
             sigterm_timeout='1',  # shorten timeouts
             on_exit=on_exit
         )


### PR DESCRIPTION
Fixes #503 

With this PR I can't reproduce the failure even when running

```
stress --cpu `nproc`
```

I noticed when the test failed on CI and locally it was because the helper process in this test got the signal during  `importlib._bootstrap`. I don't know all the details, but I suspect CPython exits differently when receiving a signal during startup.

<details><summary>Output from CI</summary>

```
[python-17] Fatal Python error: init_import_size: Failed to import the site module
[python-17] Python runtime state: initialized
[DEBUG] [launch.launch_context]: emitting event synchronously: 'launch.events.process.ProcessStderr'
[DEBUG] [launch]: processing event: '<launch.events.process.process_stderr.ProcessStderr object at 0x10e525fd0>'
[DEBUG] [launch]: processing event: '<launch.events.process.process_stderr.ProcessStderr object at 0x10e525fd0>' ✓ '<launch.event_handlers.on_process_io.OnProcessIO object at 0x10e2286a0>'
[python-17] Traceback (most recent call last):
[python-17]   File "/Users/osrf/jenkins-agent/workspace/nightly_osx_repeated/venv/bin/../lib/python3.8/site.py", line 769, in <module>
[python-17]     main()
[python-17]   File "/Users/osrf/jenkins-agent/workspace/nightly_osx_repeated/venv/bin/../lib/python3.8/site.py", line 759, in main
[python-17]     execsitecustomize()
[python-17]   File "/Users/osrf/jenkins-agent/workspace/nightly_osx_repeated/venv/bin/../lib/python3.8/site.py", line 550, in execsitecustomize
[python-17]     import sitecustomize
[python-17]   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
[python-17]   File "<frozen importlib._bootstrap>", line 971, in _find_and_load_unlocked
[python-17]   File "<frozen importlib._bootstrap>", line 914, in _find_spec
[python-17]   File "<frozen importlib._bootstrap_external>", line 1342, in find_spec
[python-17]   File "<frozen importlib._bootstrap_external>", line 1314, in _get_spec
[python-17]   File "<frozen importlib._bootstrap_external>", line 1443, in find_spec
[python-17]   File "<frozen importlib._bootstrap_external>", line 1483, in _fill_cache
```
</details>

I'm guessing when the test is flakey it's because the Python process didn't start all the way up before the signal was received. This PR resolves it by making the Python process startup faster. First it uses `-S` to get rid of the implicit `import site`, and then it uses `input()` to pause the process instead of `signal.pause()` to avoid `import signal`.

I'm curious about the existing `signal.pause()`, as the [docs say it's not supported on Windows](https://docs.python.org/3/library/signal.html#signal.pause).  The test has a special exception for the return code on windows that I wonder if it no longer applies with this PR.