### PR TITLE
Sandbox environment in tests to fix repeated job failures

### DIFF
--- a/launch/test/launch/actions/test_append_environment_variable.py
+++ b/launch/test/launch/actions/test_append_environment_variable.py
@@ -21,7 +21,10 @@ from launch.actions import AppendEnvironmentVariable
 from launch.substitutions import EnvironmentVariable
 from launch.substitutions import TextSubstitution
 
+from temporary_environment import sandbox_environment_variables
 
+
+@sandbox_environment_variables
 def test_append_environment_variable_constructor():
     """Test the constructor for the AppendEnvironmentVariable class."""
     AppendEnvironmentVariable('name', 'value')
@@ -31,6 +34,7 @@ def test_append_environment_variable_constructor():
     AppendEnvironmentVariable('name', 'value', prepend=True, separator='|')
 
 
+@sandbox_environment_variables
 def test_append_environment_variable_execute():
     """Test the execute() of the AppendEnvironmentVariable class."""
     context = LaunchContext()

--- a/launch/test/launch/actions/test_group_action.py
+++ b/launch/test/launch/actions/test_group_action.py
@@ -26,6 +26,8 @@ from launch.actions import ResetLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
 from launch.substitutions import LaunchConfiguration
 
+from temporary_environment import sandbox_environment_variables
+
 
 def test_group_action_constructors():
     """Test the constructors for the GroupAction class."""
@@ -36,6 +38,7 @@ def test_group_action_constructors():
     GroupAction([Action()], scoped=False, forwarding=False, launch_configurations={'foo': 'FOO'})
 
 
+@sandbox_environment_variables
 def test_group_action_execute():
     """Test the execute() of the the GroupAction class."""
     lc1 = LaunchContext()

--- a/launch/test/launch/actions/test_set_and_unset_environment_variable.py
+++ b/launch/test/launch/actions/test_set_and_unset_environment_variable.py
@@ -19,13 +19,17 @@ from launch.actions import SetEnvironmentVariable
 from launch.actions import UnsetEnvironmentVariable
 from launch.substitutions import EnvironmentVariable
 
+from temporary_environment import sandbox_environment_variables
 
+
+@sandbox_environment_variables
 def test_set_and_unset_environment_variable_constructors():
     """Test the constructor for SetEnvironmentVariable and UnsetEnvironmentVariable classes."""
     SetEnvironmentVariable('name', 'value')
     UnsetEnvironmentVariable('name')
 
 
+@sandbox_environment_variables
 def test_set_and_unset_environment_variable_execute():
     """Test the execute() of the SetEnvironmentVariable and UnsetEnvironmentVariable classes."""
     context = LaunchContext()

--- a/launch/test/temporary_environment.py
+++ b/launch/test/temporary_environment.py
@@ -1,0 +1,49 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import os
+
+
+class TemporaryEnvironment:
+    """Allow temporary changes to environment variables."""
+
+    def __init__(self):
+        self.__old_env = None
+
+    def __enter__(self):
+        self.__old_env = os.environ.copy()
+        return self
+
+    def __exit__(self, t, v, tb):
+        # Update keys manually to make sure putenv gets called
+        for key, value in self.__old_env.items():
+            os.environ[key] = value
+        # Remove added keys
+        env_keys = tuple(os.environ)
+        for key in env_keys:
+            if key not in self.__old_env:
+                del os.environ[key]
+        self.__old_env = None
+
+
+def sandbox_environment_variables(func):
+    """Decorate a function to give it a temporary environment."""
+
+    @functools.wraps(func)
+    def wrapper_func(*args, **kwargs):
+        with TemporaryEnvironment():
+            func(*args, **kwargs)
+
+    return wrapper_func


### PR DESCRIPTION
#601 added tests that modify environment variables, and expect some environment variables to not be set at the beginning of tests that are set later. This causes test failures on the repeated jobs because of how they're run.

[launch.test.launch.actions.test_append_environment_variable.test_append_environment_variable_execute[2-3]](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/2616/testReport/junit/launch.test.launch.actions/test_append_environment_variable/test_append_environment_variable_execute_2_3_/)
[launch.test.launch.actions.test_append_environment_variable.test_append_environment_variable_execute[3-3]](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/2616/testReport/junit/launch.test.launch.actions/test_append_environment_variable/test_append_environment_variable_execute_3_3_/)
[launch.test.launch.actions.test_group_action.test_group_action_execute[2-3]](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/2616/testReport/junit/launch.test.launch.actions/test_group_action/test_group_action_execute_2_3_/)
[launch.test.launch.actions.test_group_action.test_group_action_execute[3-3]](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/2616/testReport/junit/launch.test.launch.actions/test_group_action/test_group_action_execute_3_3_/)
[launch.test.launch.actions.test_set_and_unset_environment_variable.test_set_and_unset_environment_variable_execute[2-3]](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/2616/testReport/junit/launch.test.launch.actions/test_set_and_unset_environment_variable/test_set_and_unset_environment_variable_execute_2_3_/)
[launch.test.launch.actions.test_set_and_unset_environment_variable.test_set_and_unset_environment_variable_execute[3-3]](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/2616/testReport/junit/launch.test.launch.actions/test_set_and_unset_environment_variable/test_set_and_unset_environment_variable_execute_3_3_/)


[Colcon uses](https://github.com/colcon/colcon-core/blob/64f06cf523cf211934ee608d0c986774b5997349/colcon_core/task/python/test/pytest.py#L113) the [`pytest-repeat`](https://github.com/pytest-dev/pytest-repeat) library to implement `--retest-until-fail`. That extension re-runs the tests in the same process, so any environment variable changes made by the previous run of the test are still present. This PR fixes by sandboxing `os.environ` in each test that modifies environment variables. With this PR I'm not able to reproduce any test failures running:

```
colcon test --event-handlers console_direct+ --packages-select launch --retest-until-fail 2
```