### PR TITLE
Expose shutdown action to xml frontend

### DIFF
--- a/launch/launch/actions/shutdown_action.py
+++ b/launch/launch/actions/shutdown_action.py
@@ -40,7 +40,7 @@ class Shutdown(EmitEvent):
     def parse(cls, entity: Entity, parser: Parser):
         """Return `Shutdown` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
-        reason = entity.get_attr('reason', optional= True)
+        reason = entity.get_attr('reason', optional=True)
         if reason:
             kwargs['reason'] = parser.parse_substitution(reason)
         return cls, kwargs

--- a/launch/launch/actions/shutdown_action.py
+++ b/launch/launch/actions/shutdown_action.py
@@ -17,6 +17,10 @@
 import logging
 from typing import Text
 
+from launch.frontend import Entity
+from launch.frontend import expose_action
+from launch.frontend import Parser
+
 from .emit_event import EmitEvent
 from ..events import Shutdown as ShutdownEvent
 from ..events.process import ProcessExited
@@ -25,11 +29,21 @@ from ..launch_context import LaunchContext
 _logger = logging.getLogger(name='launch')
 
 
+@expose_action('shutdown')
 class Shutdown(EmitEvent):
     """Action that shuts down a launched system by emitting Shutdown when executed."""
 
     def __init__(self, *, reason: Text = 'reason not given', **kwargs):
         super().__init__(event=ShutdownEvent(reason=reason), **kwargs)
+
+    @classmethod
+    def parse(cls, entity: Entity, parser: Parser):
+        """Return `Shutdown` action and kwargs for constructing it."""
+        _, kwargs = super().parse(entity, parser)
+        reason = entity.get_attr('reason', optional= True)
+        if reason:
+            kwargs['reason'] = parser.parse_substitution(reason)
+        return cls, kwargs
 
     def execute(self, context: LaunchContext):
         """Execute the action."""


### PR DESCRIPTION
## Description
This PR exposes the ``Shutdown`` action to xml frontend.

## Example usage
The following two launch snippets in python and xml should work equivalently.
Python :
```
import launch
import launch.actions
import launch_ros.actions

def generate_launch_description():
    return launch.LaunchDescription([
        launch_ros.actions.Node(
            executable='talker',
            package='demo_nodes_cpp',
            name='demo_node'
        ),
        launch.actions.TimerAction(
            period=5.0,
            actions=[
                launch.actions.Shutdown()
        ]),
    ])
```

xml : 

```
<launch>
        <node pkg="demo_nodes_cpp" exec="talker" name="demo_node"/>
        <timer period='5'>
                <shutdown/>
        </timer>
</launch>
```

Signed-off-by: Aditya <aditya050995@gmail.com>
