### PR TITLE
Remove unused variables.

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -20,7 +20,6 @@ import logging
 import os
 import platform
 import signal
-import threading
 import traceback
 from typing import Any  # noqa: F401
 from typing import Callable
@@ -74,9 +73,6 @@ from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
 from ..utilities.type_utils import normalize_typed_substitution
 from ..utilities.type_utils import perform_typed_substitution
-
-_global_process_counter_lock = threading.Lock()
-_global_process_counter = 0  # in Python3, this number is unbounded (no rollover)
 
 
 class ExecuteLocal(Action):

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -15,7 +15,6 @@
 """Module for the ExecuteProcess action."""
 
 import shlex
-import threading
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -30,9 +29,6 @@ from ..frontend import expose_action
 from ..frontend import Parser
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitutions import TextSubstitution
-
-_global_process_counter_lock = threading.Lock()
-_global_process_counter = 0  # in Python3, this number is unbounded (no rollover)
 
 
 @expose_action('executable')


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

They aren't used anywhere.  Based on this comment: https://github.com/ros2/launch/pull/454#discussion_r739260448 .  @ivanpauno FYI