### PR TITLE
Switch to using a comprehension for process_names.

### DIFF
--- a/launch_testing/launch_testing/proc_info_handler.py
+++ b/launch_testing/launch_testing/proc_info_handler.py
@@ -47,10 +47,7 @@ class ProcInfoHandler:
 
     def process_names(self):
         """Get the name of all recorded processes."""
-        return map(
-            lambda x: x.process_details['name'],
-            self._proc_info.keys()
-        )
+        return [x.process_details['name'] for x in self._proc_info.keys()]
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
Newer versions of flake8-comprehenstion complain about this
usage, and the new code should be backwards compatible and
faster to boot.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>