### PR TITLE
Mention that ready_fn in generate_test_description is deprecated

### DIFF
--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -44,7 +44,7 @@ The launch description needs to include a `ReadyToTest` action to signal to the 
 
 In the above example, there is no need to delay the start of the tests so the `ReadyToTest` action is a peer to the process under test and will signal to the framework that it's safe to start around the same time the `ExecuteProcess` action is run.
 
-In older style tests, a function called `ready_fn` is declared as an argument to `generate_test_description` and must be plumbed into the launch description with an `OpaqueFunction`.
+In older style tests, a function called `ready_fn` is declared as an argument to `generate_test_description` and must be plumbed into the launch description with an `OpaqueFunction`. This method has been fully replaced by the `ReadyToTest` action and is therefore deprecated.
 
 ```python
 def generate_test_description(ready_fn):

--- a/launch_testing/README.md
+++ b/launch_testing/README.md
@@ -44,7 +44,8 @@ The launch description needs to include a `ReadyToTest` action to signal to the 
 
 In the above example, there is no need to delay the start of the tests so the `ReadyToTest` action is a peer to the process under test and will signal to the framework that it's safe to start around the same time the `ExecuteProcess` action is run.
 
-In older style tests, a function called `ready_fn` is declared as an argument to `generate_test_description` and must be plumbed into the launch description with an `OpaqueFunction`. This method has been fully replaced by the `ReadyToTest` action and is therefore deprecated.
+In older style tests, a function called `ready_fn` is declared as an argument to `generate_test_description` and must be plumbed into the launch description with an `OpaqueFunction`.
+This method has been fully replaced by the `ReadyToTest` action and is therefore deprecated.
 
 ```python
 def generate_test_description(ready_fn):


### PR DESCRIPTION
Foxy already shows:
Warning: Passing ready_fn as an argument to generate_test_description
will be removed in a future release.  Include a
launch_testing.actions.ReadyToTest action in the LaunchDescription instead.

see https://github.com/ros2/launch/pull/346

-> re-targeted version of https://github.com/ros2/launch/pull/580