### PR TITLE
ReadyToTest action timeout using decorator

### DIFF
--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -15,7 +15,8 @@
 from . import tools
 from .decorator import post_shutdown_test
 from .io_handler import ActiveIoHandler, IoHandler
-from .parametrize import parametrize, ready_to_test_action_timeout
+from .parametrize import parametrize
+from .ready_to_test_action_timeout import ready_to_test_action_timeout
 from .proc_info_handler import ActiveProcInfoHandler, ProcInfoHandler
 from .ready_aggregator import ReadyAggregator
 

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -15,7 +15,7 @@
 from . import tools
 from .decorator import post_shutdown_test
 from .io_handler import ActiveIoHandler, IoHandler
-from .parametrize import parametrize
+from .parametrize import parametrize, ready_to_test_action_timeout
 from .proc_info_handler import ActiveProcInfoHandler, ProcInfoHandler
 from .ready_aggregator import ReadyAggregator
 
@@ -27,6 +27,7 @@ __all__ = [
     # Functions
     'parametrize',
     'post_shutdown_test',
+    'ready_to_test_action_timeout',
 
     # Classes
     'ActiveIoHandler',

--- a/launch_testing/launch_testing/__init__.py
+++ b/launch_testing/launch_testing/__init__.py
@@ -16,9 +16,9 @@ from . import tools
 from .decorator import post_shutdown_test
 from .io_handler import ActiveIoHandler, IoHandler
 from .parametrize import parametrize
-from .ready_to_test_action_timeout import ready_to_test_action_timeout
 from .proc_info_handler import ActiveProcInfoHandler, ProcInfoHandler
 from .ready_aggregator import ReadyAggregator
+from .ready_to_test_action_timeout import ready_to_test_action_timeout
 
 
 __all__ = [

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -92,12 +92,15 @@ class TestRun:
 
         self.pre_shutdown_tests = pre_shutdown_tests
         self.post_shutdown_tests = post_shutdown_tests
-        self.timeout = None  # ReadyToTest action timeout
+
+        #  Duration for which the ReadyToTest action waits for the processes
+        #  to start up, 15 seconds by default
+        self.timeout = None
 
         if hasattr(test_description_function, '__ready_to_test_action_timeout__'):
             self.timeout = getattr(test_description_function, '__ready_to_test_action_timeout__')
 
-    # If we're parametrized, extend the test names so we can tell more easily what
+        # If we're parametrized, extend the test names so we can tell more easily what
         # params they were run with
         if self.param_args:
             for tc in itertools.chain(

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -92,11 +92,10 @@ class TestRun:
 
         self.pre_shutdown_tests = pre_shutdown_tests
         self.post_shutdown_tests = post_shutdown_tests
-        self.timeout = None
+        self.timeout = None  # ReadyToTest action timeout
 
         if hasattr(test_description_function, '__ready_to_test_action_timeout__'):
             self.timeout = getattr(test_description_function, '__ready_to_test_action_timeout__')
-            print("### self.timeout ### --> ", self.timeout)
 
     # If we're parametrized, extend the test names so we can tell more easily what
         # params they were run with
@@ -166,20 +165,12 @@ class TestRun:
 
 
 def LoadTestsFromPythonModule(module, *, name='launch_tests'):
-    print("## Entered LoadTestsFromPythonModule")
-
-    if hasattr(module.generate_test_description, '__ready_to_test_action_timeout__'):
-        print("### NICE !###")
+    if not hasattr(module.generate_test_description, '__parametrized__'):
         normalized_test_description_func = (
             lambda: [(module.generate_test_description, {})]
         )
-
-    # if not hasattr(module.generate_test_description, '__parametrized__'):
-    #     normalized_test_description_func = (
-    #         lambda: [(module.generate_test_description, {})]
-    #     )
-    # else:
-    #     normalized_test_description_func = module.generate_test_description
+    else:
+        normalized_test_description_func = module.generate_test_description
 
     # If our test description is parameterized, we'll load a set of tests for each
     # individual launch

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -95,7 +95,7 @@ class TestRun:
 
         #  Duration for which the ReadyToTest action waits for the processes
         #  to start up, 15 seconds by default
-        self.timeout = None
+        self.timeout = 15
 
         if hasattr(test_description_function, '__ready_to_test_action_timeout__'):
             self.timeout = getattr(test_description_function, '__ready_to_test_action_timeout__')

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -92,8 +92,13 @@ class TestRun:
 
         self.pre_shutdown_tests = pre_shutdown_tests
         self.post_shutdown_tests = post_shutdown_tests
+        self.timeout = None
 
-        # If we're parametrized, extend the test names so we can tell more easily what
+        if hasattr(test_description_function, '__ready_to_test_action_timeout__'):
+            self.timeout = getattr(test_description_function, '__ready_to_test_action_timeout__')
+            print("### self.timeout ### --> ", self.timeout)
+
+    # If we're parametrized, extend the test names so we can tell more easily what
         # params they were run with
         if self.param_args:
             for tc in itertools.chain(
@@ -161,12 +166,20 @@ class TestRun:
 
 
 def LoadTestsFromPythonModule(module, *, name='launch_tests'):
-    if not hasattr(module.generate_test_description, '__parametrized__'):
+    print("## Entered LoadTestsFromPythonModule")
+
+    if hasattr(module.generate_test_description, '__ready_to_test_action_timeout__'):
+        print("### NICE !###")
         normalized_test_description_func = (
             lambda: [(module.generate_test_description, {})]
         )
-    else:
-        normalized_test_description_func = module.generate_test_description
+
+    # if not hasattr(module.generate_test_description, '__parametrized__'):
+    #     normalized_test_description_func = (
+    #         lambda: [(module.generate_test_description, {})]
+    #     )
+    # else:
+    #     normalized_test_description_func = module.generate_test_description
 
     # If our test description is parameterized, we'll load a set of tests for each
     # individual launch

--- a/launch_testing/launch_testing/parametrize.py
+++ b/launch_testing/launch_testing/parametrize.py
@@ -44,7 +44,19 @@ def parametrize(argnames, argvalues):
                 partial = functools.partial(func, **partial_args)
                 functools.update_wrapper(partial, func)
                 yield partial, partial_args
+
         _wrapped.__parametrized__ = True
         return _wrapped
+
+    return _decorator
+
+
+def ready_to_test_action_timeout(timeout):
+    print("## ready_to_test_action_timeout")
+
+    def _decorator(func):
+        print("## ready_to_test_action_timeout: _decorator")
+        func.__ready_to_test_action_timeout__ = timeout
+        return func
 
     return _decorator

--- a/launch_testing/launch_testing/parametrize.py
+++ b/launch_testing/launch_testing/parametrize.py
@@ -53,6 +53,3 @@ def parametrize(argnames, argvalues):
         return _wrapped
 
     return _decorator
-
-
-

--- a/launch_testing/launch_testing/parametrize.py
+++ b/launch_testing/launch_testing/parametrize.py
@@ -46,16 +46,17 @@ def parametrize(argnames, argvalues):
                 yield partial, partial_args
 
         _wrapped.__parametrized__ = True
+        if hasattr(func, '__ready_to_test_action_timeout__'):
+            _wrapped.__ready_to_test_action_timeout__ = \
+                getattr(func, '__ready_to_test_action_timeout__')
+
         return _wrapped
 
     return _decorator
 
 
 def ready_to_test_action_timeout(timeout):
-    print("## ready_to_test_action_timeout")
-
     def _decorator(func):
-        print("## ready_to_test_action_timeout: _decorator")
         func.__ready_to_test_action_timeout__ = timeout
         return func
 

--- a/launch_testing/launch_testing/parametrize.py
+++ b/launch_testing/launch_testing/parametrize.py
@@ -55,17 +55,4 @@ def parametrize(argnames, argvalues):
     return _decorator
 
 
-def ready_to_test_action_timeout(timeout):
-    """
-    Decorate a test launch description in a way that it adds ReadyToTest action timeout
 
-    attribute to the function being decorated.
-
-    :param: timeout Duration for which the ReadyToTest action waits for processes to start up
-
-    """
-    def _decorator(func):
-        func.__ready_to_test_action_timeout__ = timeout
-        return func
-
-    return _decorator

--- a/launch_testing/launch_testing/parametrize.py
+++ b/launch_testing/launch_testing/parametrize.py
@@ -56,6 +56,14 @@ def parametrize(argnames, argvalues):
 
 
 def ready_to_test_action_timeout(timeout):
+    """
+    Decorate a test launch description in a way that it adds ReadyToTest action timeout
+
+    attribute to the function being decorated.
+
+    :param: timeout Duration for which the ReadyToTest action waits for processes to start up
+
+    """
     def _decorator(func):
         func.__ready_to_test_action_timeout__ = timeout
         return func

--- a/launch_testing/launch_testing/ready_to_test_action_timeout.py
+++ b/launch_testing/launch_testing/ready_to_test_action_timeout.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Apex.AI, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch_testing/launch_testing/ready_to_test_action_timeout.py
+++ b/launch_testing/launch_testing/ready_to_test_action_timeout.py
@@ -15,7 +15,7 @@
 
 def ready_to_test_action_timeout(timeout):
     """
-    Decorate a test launch description in a way that it adds ReadyToTest action timeout
+    Decorate a test launch description in a way that it adds ReadyToTest action timeout.
 
     attribute to the function being decorated.
 

--- a/launch_testing/launch_testing/ready_to_test_action_timeout.py
+++ b/launch_testing/launch_testing/ready_to_test_action_timeout.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def ready_to_test_action_timeout(timeout):
+    """
+    Decorate a test launch description in a way that it adds ReadyToTest action timeout
+
+    attribute to the function being decorated.
+
+    :param: timeout Duration for which the ReadyToTest action waits for processes to start up
+
+    """
+
+    def _decorator(func):
+        func.__ready_to_test_action_timeout__ = timeout
+        return func
+
+    return _decorator

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -50,7 +50,7 @@ class _RunnerWorker():
 
         #  Duration for which the ReadyToTest action waits for the processes
         #  to start up, 15 seconds by default
-        self.timeout = self._test_run.timeout if self._test_run.timeout is not None else 15
+        self.timeout = self._test_run.timeout
 
         # Can't run LaunchService.run on another thread :-(
         # See https://github.com/ros2/launch/issues/126

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -48,7 +48,8 @@ class _RunnerWorker():
         self._tests_completed = threading.Event()  # To signal when all the tests have finished
         self._launch_file_arguments = launch_file_arguments
 
-        # ReadyToTest action timeout, 15 sec by default
+        #  Duration for which the ReadyToTest action waits for the processes
+        #  to start up, 15 seconds by default
         self.timeout = 15 if self._test_run.timeout is None else self._test_run.timeout
 
         # Can't run LaunchService.run on another thread :-(

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -50,7 +50,7 @@ class _RunnerWorker():
 
         #  Duration for which the ReadyToTest action waits for the processes
         #  to start up, 15 seconds by default
-        self.timeout = 15 if self._test_run.timeout is None else self._test_run.timeout
+        self.timeout = self._test_run.timeout if self._test_run.timeout is not None else 15
 
         # Can't run LaunchService.run on another thread :-(
         # See https://github.com/ros2/launch/issues/126

--- a/launch_testing/launch_testing/test_runner.py
+++ b/launch_testing/launch_testing/test_runner.py
@@ -48,6 +48,9 @@ class _RunnerWorker():
         self._tests_completed = threading.Event()  # To signal when all the tests have finished
         self._launch_file_arguments = launch_file_arguments
 
+        # ReadyToTest action timeout, 15 sec by default
+        self.timeout = 15 if self._test_run.timeout is None else self._test_run.timeout
+
         # Can't run LaunchService.run on another thread :-(
         # See https://github.com/ros2/launch/issues/126
         #
@@ -181,7 +184,7 @@ class _RunnerWorker():
         # Waits for the DUT processes to start (signaled by the _processes_launched
         # event) and then runs the tests
 
-        if not self._processes_launched.wait(timeout=15):
+        if not self._processes_launched.wait(self.timeout):
             # Timed out waiting for the processes to start
             print('Timed out waiting for processes to start up')
             self._launch_service.shutdown()

--- a/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
+++ b/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import launch
 import launch_testing
 from launch.actions import TimerAction
@@ -20,11 +22,26 @@ from launch_testing.actions import ReadyToTest
 import pytest
 
 
+# The ReadyToTest action waits for 15 second by default for the processes to
+# start, if processes take more time an error is thrown. We use decorator here
+# to provide timeout duration of 20 second so that processes that take longer than
+# 15 seconds can start up.
+
 @pytest.mark.launch_test
 @launch_testing.ready_to_test_action_timeout(20)
 def generate_test_description():
-    # takes 5 sec for the TimerAction process to start
+    # takes 15 sec for the TimerAction process to start
     return launch.LaunchDescription([
         launch_testing.util.KeepAliveProc(),
-        TimerAction(period=16.0, actions=[ReadyToTest()]),
+        TimerAction(period=15.0, actions=[ReadyToTest()]),
     ])
+
+
+# the process should exit cleanly now since the process takes 15 second
+# to start and timeout duration of ReadyToTest action is 20 seconds.
+@launch_testing.post_shutdown_test()
+class TestHelloWorldShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
+++ b/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Apex.AI, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
+++ b/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
@@ -21,10 +21,10 @@ import pytest
 
 
 @pytest.mark.launch_test
-@launch_testing.ready_to_test_action_timeout(1)
+@launch_testing.ready_to_test_action_timeout(20)
 def generate_test_description():
     # takes 5 sec for the TimerAction process to start
     return launch.LaunchDescription([
         launch_testing.util.KeepAliveProc(),
-        TimerAction(period=2.0, actions=[ReadyToTest()]),
+        TimerAction(period=16.0, actions=[ReadyToTest()]),
     ])

--- a/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
+++ b/launch_testing/test/launch_testing/examples/ready_to_test_action_timeout_test.py
@@ -15,8 +15,8 @@
 import unittest
 
 import launch
-import launch_testing
 from launch.actions import TimerAction
+import launch_testing
 from launch_testing.actions import ReadyToTest
 
 import pytest

--- a/launch_testing/test/launch_testing/examples/test.py
+++ b/launch_testing/test/launch_testing/examples/test.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+import launch_testing
+from launch.actions import TimerAction
+from launch_testing.actions import ReadyToTest
+
+import pytest
+
+
+@pytest.mark.launch_test
+@launch_testing.ready_to_test_action_timeout(10.0)
+def generate_test_description():
+    # takes 5 sec for the TimerAction process to start
+    return launch.LaunchDescription([
+        launch_testing.util.KeepAliveProc(),
+        TimerAction(period=5.0, actions=[ReadyToTest()]),
+    ])

--- a/launch_testing/test/launch_testing/examples/test.py
+++ b/launch_testing/test/launch_testing/examples/test.py
@@ -21,10 +21,10 @@ import pytest
 
 
 @pytest.mark.launch_test
-@launch_testing.ready_to_test_action_timeout(10.0)
+@launch_testing.ready_to_test_action_timeout(1)
 def generate_test_description():
     # takes 5 sec for the TimerAction process to start
     return launch.LaunchDescription([
         launch_testing.util.KeepAliveProc(),
-        TimerAction(period=5.0, actions=[ReadyToTest()]),
+        TimerAction(period=2.0, actions=[ReadyToTest()]),
     ])

--- a/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
+++ b/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
@@ -47,4 +47,3 @@ def test_ready_to_test_action_and_parametrize_attribute():
     assert hasattr(fake_test_description, '__parametrized__')
     assert hasattr(fake_test_description, '__ready_to_test_action_timeout__')
     assert getattr(fake_test_description, '__ready_to_test_action_timeout__') == 10
-

--- a/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
+++ b/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
@@ -12,4 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO
+import launch_testing
+
+
+def test_ready_to_test_action_attribute():
+
+    @launch_testing.ready_to_test_action_timeout(10)
+    def fake_test_description(arg):
+        pass  # pragma: no cover
+
+    assert hasattr(fake_test_description, '__ready_to_test_action_timeout__')
+    assert getattr(fake_test_description, '__ready_to_test_action_timeout__') == 10
+
+
+def test_parametrize_and_ready_to_test_action_attribute():
+
+    @launch_testing.parametrize('val', [1, 2, 3])
+    @launch_testing.ready_to_test_action_timeout(10)
+    def fake_test_description(arg):
+        pass  # pragma: no cover
+
+    assert hasattr(fake_test_description, '__parametrized__')
+    assert hasattr(fake_test_description, '__ready_to_test_action_timeout__')
+    assert getattr(fake_test_description, '__ready_to_test_action_timeout__') == 10
+
+
+def test_ready_to_test_action_and_parametrize_attribute():
+
+    @launch_testing.ready_to_test_action_timeout(10)
+    @launch_testing.parametrize('val', [1, 2, 3])
+    def fake_test_description(arg):
+        pass  # pragma: no cover
+
+    assert hasattr(fake_test_description, '__parametrized__')
+    assert hasattr(fake_test_description, '__ready_to_test_action_timeout__')
+    assert getattr(fake_test_description, '__ready_to_test_action_timeout__') == 10
+

--- a/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
+++ b/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Apex.AI, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
+++ b/launch_testing/test/launch_testing/test_ready_to_test_action_decorator.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO


### PR DESCRIPTION
This PR is related to https://github.com/ros2/launch/issues/582

By default the `ReadyToTest` action waits for 15 sec for the processes to start up, which means the processes that takes longer to start up, won't be able to start up. This PR adds a configurable timeout duration for `ReadyToTest` action by supporting a new decorator namely `ready_to_test_action_timeout`

Some discussion here https://github.com/ros2/launch/pull/622

Signed-off-by: deepanshu [deepanshubansal01@gmail.com](mailto:deepanshubansal01@gmail.com)