### PR TITLE
Improve launch file parsing error messages

### DIFF
--- a/launch/launch/invalid_launch_file_error.py
+++ b/launch/launch/invalid_launch_file_error.py
@@ -30,7 +30,7 @@ class InvalidLaunchFileError(Exception):
             self._error_message = (
                 'Caught {} when trying to load file of format [{}]:'
             ).format('multiple exceptions' if len(self._likely_errors) > 1 else 'exception',
-                      self._extension)
+                     self._extension)
             for error in self._likely_errors:
                 self._error_message += '\n - {}'.format(error)
 

--- a/launch/launch/invalid_launch_file_error.py
+++ b/launch/launch/invalid_launch_file_error.py
@@ -27,9 +27,17 @@ class InvalidLaunchFileError(Exception):
                 'The launch file may have a syntax error, or its format is unknown'
             )
         else:
-            self._error_message = (
-                'Caught exception when trying to load file of format [{}]: {}'
-            ).format(self._extension, self._likely_errors[0])
+            if len(self._likely_errors) == 1:
+                self._error_message = (
+                    'Caught exception when trying to load file of format [{}]: {}'
+                ).format(self._extension, self._likely_errors[0])
+            else:
+                self._error_message = (
+                    'Caught multiple exceptions when trying to load file of format [{}]:'
+                ).format(self._extension)
+                for error in self._likely_errors:
+                    self._error_message += '\n - {}'.format(error)
+
             self.__cause__ = self._likely_errors[0]
 
     def __str__(self):

--- a/launch/launch/invalid_launch_file_error.py
+++ b/launch/launch/invalid_launch_file_error.py
@@ -27,16 +27,12 @@ class InvalidLaunchFileError(Exception):
                 'The launch file may have a syntax error, or its format is unknown'
             )
         else:
-            if len(self._likely_errors) == 1:
-                self._error_message = (
-                    'Caught exception when trying to load file of format [{}]: {}'
-                ).format(self._extension, self._likely_errors[0])
-            else:
-                self._error_message = (
-                    'Caught multiple exceptions when trying to load file of format [{}]:'
-                ).format(self._extension)
-                for error in self._likely_errors:
-                    self._error_message += '\n - {}'.format(error)
+            self._error_message = (
+                'Caught {} when trying to load file of format [{}]:'
+            ).format('multiple exceptions' if len(self._likely_errors) > 1 else 'exception',
+                      self._extension)
+            for error in self._likely_errors:
+                self._error_message += '\n - {}'.format(error)
 
             self.__cause__ = self._likely_errors[0]
 

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -91,7 +91,7 @@ class Entity(BaseEntity):
         If coercion fails, `ValueError` will be raised.
         """
         attr_error = AttributeError(
-            'Attribute `{}` of type `{}` not found in Entity `{}`'.format(
+            "Attribute '{}' of type '{}' not found in Entity '{}'".format(
                 name, data_type, self.type_name
             )
         )
@@ -123,8 +123,8 @@ class Entity(BaseEntity):
             value = get_typed_value(value, data_type, can_be_str=can_be_str)
         except ValueError:
             raise TypeError(
-                'Attribute `{}` of Entity `{}` expected to be of type `{}`.'
-                '`{}` can not be converted to one of those types'.format(
+                "Attribute '{}' of Entity '{}' expected to be of type '{}'."
+                "'{}' can not be converted to one of those types".format(
                     name, self.type_name, data_type, value
                 )
             )

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -91,7 +91,7 @@ class Entity(BaseEntity):
         If coercion fails, `ValueError` will be raised.
         """
         attr_error = AttributeError(
-            'Attribute {} of type {} not found in Entity {}'.format(
+            'Attribute `{}` of type `{}` not found in Entity `{}`'.format(
                 name, data_type, self.type_name
             )
         )
@@ -123,7 +123,7 @@ class Entity(BaseEntity):
             value = get_typed_value(value, data_type, can_be_str=can_be_str)
         except ValueError:
             raise TypeError(
-                'Attribute {} of Entity {} expected to be of type {}.'
+                'Attribute `{}` of Entity `{}` expected to be of type `{}`.'
                 '`{}` can not be converted to one of those types'.format(
                     name, self.type_name, data_type, value
                 )

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -116,7 +116,7 @@ class Entity(BaseEntity):
         if name not in self.__element:
             if not optional:
                 raise AttributeError(
-                    'Can not find attribute {} in Entity {}'.format(
+                    'Can not find attribute `{}` in Entity `{}`'.format(
                         name, self.type_name))
             else:
                 return None
@@ -126,13 +126,13 @@ class Entity(BaseEntity):
             if isinstance(data, list) and isinstance(data[0], dict):
                 return [Entity(child, name) for child in data]
             raise TypeError(
-                'Attribute {} of Entity {} expected to be a list of dictionaries.'.format(
+                'Attribute `{}` of Entity `{}` expected to be a list of dictionaries.'.format(
                     name, self.type_name
                 )
             )
         if not is_instance_of(data, data_type, can_be_str=can_be_str):
             raise TypeError(
-                'Attribute {} of Entity {} expected to be of type {}, got {}'.format(
+                'Attribute `{}` of Entity `{}` expected to be of type `{}`, got `{}`'.format(
                     name, self.type_name, data_type, type(data)
                 )
             )

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -116,7 +116,7 @@ class Entity(BaseEntity):
         if name not in self.__element:
             if not optional:
                 raise AttributeError(
-                    'Can not find attribute `{}` in Entity `{}`'.format(
+                    "Can not find attribute '{}' in Entity '{}'".format(
                         name, self.type_name))
             else:
                 return None
@@ -126,13 +126,13 @@ class Entity(BaseEntity):
             if isinstance(data, list) and isinstance(data[0], dict):
                 return [Entity(child, name) for child in data]
             raise TypeError(
-                'Attribute `{}` of Entity `{}` expected to be a list of dictionaries.'.format(
+                "Attribute '{}' of Entity '{}' expected to be a list of dictionaries.".format(
                     name, self.type_name
                 )
             )
         if not is_instance_of(data, data_type, can_be_str=can_be_str):
             raise TypeError(
-                'Attribute `{}` of Entity `{}` expected to be of type `{}`, got `{}`'.format(
+                "Attribute '{}' of Entity '{}' expected to be of type '{}', got '{}'".format(
                     name, self.type_name, data_type, type(data)
                 )
             )


### PR DESCRIPTION
This pull request improves the parsing error messages for launch files in two ways:
1. Parser errors clearly show that values are substituted and not part of the error message itself. I was recently confused by a message `Attribute value of type <class 'str'> not found in Entity let`, not realizing that the attribute "value" was missing and not some kind of "attribute value".
2. On an InvalidLaunchFileError, all parsing errors are logged.