### PR TITLE
[foxy] Support scoping environment variables (#601)

### DIFF
--- a/launch/launch/actions/__init__.py
+++ b/launch/launch/actions/__init__.py
@@ -22,9 +22,12 @@ from .include_launch_description import IncludeLaunchDescription
 from .log_info import LogInfo
 from .opaque_coroutine import OpaqueCoroutine
 from .opaque_function import OpaqueFunction
+from .pop_environment import PopEnvironment
 from .pop_launch_configurations import PopLaunchConfigurations
+from .push_environment import PushEnvironment
 from .push_launch_configurations import PushLaunchConfigurations
 from .register_event_handler import RegisterEventHandler
+from .reset_environment import ResetEnvironment
 from .set_environment_variable import SetEnvironmentVariable
 from .set_launch_configuration import SetLaunchConfiguration
 from .shutdown_action import Shutdown
@@ -42,8 +45,11 @@ __all__ = [
     'LogInfo',
     'OpaqueCoroutine',
     'OpaqueFunction',
+    'PopEnvironment',
     'PopLaunchConfigurations',
+    'PushEnvironment',
     'PushLaunchConfigurations',
+    'ResetEnvironment',
     'RegisterEventHandler',
     'SetEnvironmentVariable',
     'SetLaunchConfiguration',

--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -19,7 +19,9 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 
+from .pop_environment import PopEnvironment
 from .pop_launch_configurations import PopLaunchConfigurations
+from .push_environment import PushEnvironment
 from .push_launch_configurations import PushLaunchConfigurations
 from .set_launch_configuration import SetLaunchConfiguration
 from ..action import Action
@@ -34,12 +36,13 @@ from ..some_substitutions_type import SomeSubstitutionsType
 @expose_action('group')
 class GroupAction(Action):
     """
-    Action that yields other actions, optionally scoping launch configurations.
+    Action that yields other actions.
 
     This action is used to nest other actions without including a separate
     launch description, while also optionally having a condition (like all
-    other actions), scoping launch configurations, and/or declaring launch
-    configurations for just the group and its yielded actions.
+    other actions), scoping launch configurations and environment variables,
+    and/or declaring launch  configurations for just the group and its yielded
+    actions.
     """
 
     def __init__(
@@ -81,7 +84,9 @@ class GroupAction(Action):
             if self.__scoped:
                 self.__actions_to_return = [
                     PushLaunchConfigurations(),
+                    PushEnvironment(),
                     *self.__actions_to_return,
+                    PopEnvironment(),
                     PopLaunchConfigurations()
                 ]
         return self.__actions_to_return

--- a/launch/launch/actions/pop_environment.py
+++ b/launch/launch/actions/pop_environment.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the PopEnvironment action."""
+
+from ..action import Action
+from ..launch_context import LaunchContext
+
+
+class PopEnvironment(Action):
+    """
+    Action that pops the state of environment variables from a stack.
+
+    The state can be stored initially by pushing onto the stack with the
+    :py:class:`launch.actions.PushEnvironment` action.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Create a PopEnvironment action."""
+        super().__init__(**kwargs)
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._pop_environment()

--- a/launch/launch/actions/push_environment.py
+++ b/launch/launch/actions/push_environment.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the PushEnvironment action."""
+
+from ..action import Action
+from ..launch_context import LaunchContext
+
+
+class PushEnvironment(Action):
+    """
+    Action that pushes the current environment to a stack.
+
+    The state can be restored by popping the stack with the
+    :py:class:`launch.actions.PopEnvironment` action.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Create a PushEnvironment action."""
+        super().__init__(**kwargs)
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._push_environment()

--- a/launch/launch/actions/reset_environment.py
+++ b/launch/launch/actions/reset_environment.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the ResetEnvironment action."""
+
+from ..action import Action
+from ..frontend import Entity
+from ..frontend import expose_action
+from ..frontend import Parser
+from ..launch_context import LaunchContext
+
+
+@expose_action('reset_env')
+class ResetEnvironment(Action):
+    """
+    Action that resets the environment in the current context.
+
+    Clears any changes made by previous actions to the context environment.
+    The environment is reset to the state it was in when the context was created,
+    i.e. the contents of ``os.environ``.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Create a ResetEnvironment action."""
+        super().__init__(**kwargs)
+
+    @classmethod
+    def parse(cls, entity: Entity, parser: Parser):
+        """Return ``ResetEnvironment`` action and kwargs for constructing it."""
+        _, kwargs = super().parse(entity, parser)
+        return cls, kwargs
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        context._reset_environment()

--- a/launch/launch/actions/set_environment_variable.py
+++ b/launch/launch/actions/set_environment_variable.py
@@ -14,7 +14,6 @@
 
 """Module for the SetEnvironmentVariable action."""
 
-import os
 from typing import List
 
 from ..action import Action
@@ -67,6 +66,6 @@ class SetEnvironmentVariable(Action):
 
     def execute(self, context: LaunchContext) -> None:
         """Execute the action."""
-        os.environ[perform_substitutions(context, self.name)] = \
+        context.environment[perform_substitutions(context, self.name)] = \
             perform_substitutions(context, self.value)
         return None

--- a/launch/launch/actions/unset_environment_variable.py
+++ b/launch/launch/actions/unset_environment_variable.py
@@ -14,8 +14,6 @@
 
 """Module for the UnsetEnvironmentVariable action."""
 
-import os
-
 from typing import List
 
 from ..action import Action
@@ -61,6 +59,6 @@ class UnsetEnvironmentVariable(Action):
     def execute(self, context: LaunchContext) -> None:
         """Execute the action."""
         name = perform_substitutions(context, self.name)
-        if name in os.environ:
-            del os.environ[name]
+        if name in context.environment:
+            del context.environment[name]
         return None

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -16,10 +16,12 @@
 
 import asyncio
 import collections
+import os
 from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List  # noqa: F401
+from typing import Mapping
 from typing import Optional
 from typing import Text
 
@@ -60,6 +62,10 @@ class LaunchContext:
 
         self.__launch_configurations_stack = []  # type: List[Dict[Text, Text]]
         self.__launch_configurations = {}  # type: Dict[Text, Text]
+
+        self.__environment_stack = []  # type: List[Mapping[Text, Text]]
+        # We will reset to this copy when "reset_environment" is called
+        self.__environment_reset = os.environ.copy()  # type: Mapping[Text, Text]
 
         self.__is_shutdown = False
         self.__asyncio_loop = None  # type: Optional[asyncio.AbstractEventLoop]
@@ -157,8 +163,19 @@ class LaunchContext:
 
         return AttributeDict(self._get_combined_locals())
 
+    def _push_environment(self):
+        self.__environment_stack.append(os.environ.copy())
+
+    def _pop_environment(self):
+        if not self.__environment_stack:
+            raise RuntimeError('environment stack unexpectedly empty')
+        os.environ = self.__environment_stack.pop()
+
+    def _reset_environment(self):
+        os.environ = self.__environment_reset.copy()
+
     def _push_launch_configurations(self):
-        self.__launch_configurations_stack.append(dict(self.__launch_configurations))
+        self.__launch_configurations_stack.append(self.__launch_configurations.copy())
 
     def _pop_launch_configurations(self):
         if not self.__launch_configurations_stack:
@@ -169,6 +186,11 @@ class LaunchContext:
     def launch_configurations(self) -> Dict[Text, Text]:
         """Getter for launch_configurations dictionary."""
         return self.__launch_configurations
+
+    @property
+    def environment(self) -> Mapping[Text, Text]:
+        """Getter for environment variables dictionary."""
+        return os.environ
 
     def would_handle_event(self, event: Event) -> bool:
         """Check whether an event would be handled or not."""

--- a/launch/launch/substitutions/environment_variable.py
+++ b/launch/launch/substitutions/environment_variable.py
@@ -14,7 +14,6 @@
 
 """Module for the EnvironmentVariable substitution."""
 
-import os
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -33,6 +32,10 @@ class EnvironmentVariable(Substitution):
     Substitution that gets an environment variable value as a string.
 
     If the environment variable is not found, it returns empty string.
+
+    Note that the environment variable is resolved based on the launch context's environment (i.e.,
+    ``context.environment``) even though the substitution may be associated with an entity that
+    might have a different set of environment variables.
     """
 
     def __init__(
@@ -89,7 +92,7 @@ class EnvironmentVariable(Substitution):
         if default_value is not None:
             default_value = perform_substitutions(context, self.default_value)
         name = perform_substitutions(context, self.name)
-        value = os.environ.get(
+        value = context.environment.get(
             name,
             default_value
         )

--- a/launch/test/launch/actions/test_push_and_pop_environment.py
+++ b/launch/test/launch/actions/test_push_and_pop_environment.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PopEnvironment and PushEnvironment action classes."""
+
+from launch import LaunchContext
+from launch.actions import PopEnvironment
+from launch.actions import PushEnvironment
+
+
+def test_push_and_pop_environment_constructors():
+    """Test the constructors for PopEnvironment and PushEnvironment classes."""
+    PopEnvironment()
+    PushEnvironment()
+
+
+def test_push_and_pop_environment_execute():
+    """Test the execute() of the PopEnvironment and PushEnvironment classes."""
+    context = LaunchContext()
+
+    # does not change empty state
+    context.environment.clear()
+    assert len(context.environment) == 0
+    PushEnvironment().visit(context)
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 0
+
+    # does not change single env
+    context.environment['foo'] = 'FOO'
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'
+    PushEnvironment().visit(context)
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'
+
+    # does scope additions
+    context = LaunchContext()
+    context.environment.clear()
+    assert len(context.environment) == 0
+    PushEnvironment().visit(context)
+    context.environment['foo'] = 'FOO'
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 0
+
+    # does scope modifications
+    context = LaunchContext()
+    context.environment.clear()
+    assert len(context.environment) == 0
+    context.environment['foo'] = 'FOO'
+    PushEnvironment().visit(context)
+    context.environment['foo'] = 'BAR'
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'
+
+    # does scope deletions
+    context = LaunchContext()
+    context.environment.clear()
+    assert len(context.environment) == 0
+    context.environment['foo'] = 'FOO'
+    PushEnvironment().visit(context)
+    del context.environment['foo']
+    PopEnvironment().visit(context)
+    assert len(context.environment) == 1
+    assert 'foo' in context.environment
+    assert context.environment['foo'] == 'FOO'

--- a/launch/test/launch/actions/test_set_and_unset_environment_variable.py
+++ b/launch/test/launch/actions/test_set_and_unset_environment_variable.py
@@ -14,8 +14,6 @@
 
 """Tests for the SetEnvironmentVariable and UnsetEnvironmentVariable action classes."""
 
-import os
-
 from launch import LaunchContext
 from launch.actions import SetEnvironmentVariable
 from launch.actions import UnsetEnvironmentVariable
@@ -30,44 +28,36 @@ def test_set_and_unset_environment_variable_constructors():
 
 def test_set_and_unset_environment_variable_execute():
     """Test the execute() of the SetEnvironmentVariable and UnsetEnvironmentVariable classes."""
-    lc1 = LaunchContext()
+    context = LaunchContext()
 
     # can set and overwrite environment variables
-    if 'NONEXISTENT_KEY' in os.environ:
-        del os.environ['NONEXISTENT_KEY']
-    assert os.environ.get('NONEXISTENT_KEY') is None
-    SetEnvironmentVariable('NONEXISTENT_KEY', 'value').visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == 'value'
-    SetEnvironmentVariable('NONEXISTENT_KEY', 'ANOTHER_NONEXISTENT_KEY').visit(lc1)
-    assert os.environ.get('NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
+    assert context.environment.get('NONEXISTENT_KEY') is None
+    SetEnvironmentVariable('NONEXISTENT_KEY', 'value').visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == 'value'
+    SetEnvironmentVariable('NONEXISTENT_KEY', 'ANOTHER_NONEXISTENT_KEY').visit(context)
+    assert context.environment.get('NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
 
     # can unset environment variables
-    if 'ANOTHER_NONEXISTENT_KEY' in os.environ:
-        del os.environ['ANOTHER_NONEXISTENT_KEY']
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
-    SetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY', 'some value').visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') == 'some value'
-    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
+    SetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY', 'some value').visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') == 'some value'
+    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
 
     # set and unset with substitutions
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
     SetEnvironmentVariable(
         'ANOTHER_NONEXISTENT_KEY',
-        EnvironmentVariable('NONEXISTENT_KEY')).visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
-    UnsetEnvironmentVariable(EnvironmentVariable('NONEXISTENT_KEY')).visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
-
-    # cleanup environment variables
-    if 'NONEXISTENT_KEY' in os.environ:
-        del os.environ['NONEXISTENT_KEY']
+        EnvironmentVariable('NONEXISTENT_KEY')).visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') == 'ANOTHER_NONEXISTENT_KEY'
+    UnsetEnvironmentVariable(EnvironmentVariable('NONEXISTENT_KEY')).visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
 
 
 def test_unset_nonexistent_key():
     """Test that the UnsetEnvironmentVariable class doesn't raise an exception."""
-    lc1 = LaunchContext()
+    context = LaunchContext()
 
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
-    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(lc1)
-    assert os.environ.get('ANOTHER_NONEXISTENT_KEY') is None
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None
+    UnsetEnvironmentVariable('ANOTHER_NONEXISTENT_KEY').visit(context)
+    assert context.environment.get('ANOTHER_NONEXISTENT_KEY') is None

--- a/launch/test/launch/substitutions/test_environment_variable.py
+++ b/launch/test/launch/substitutions/test_environment_variable.py
@@ -43,4 +43,3 @@ def test_this_launch_file_path():
     assert 'SOME_VALUE' == sub1.perform(lc)
     assert 'SOME_VALUE' == sub2.perform(lc)
     assert 'SOME_VALUE' == sub3.perform(lc)
-    del os.environ['MY_ENVIRONMENT_VARIABLE']

--- a/launch/test/launch/test_launch_context.py
+++ b/launch/test/launch/test_launch_context.py
@@ -15,6 +15,7 @@
 """Tests for the LaunchContext class."""
 
 import asyncio
+import os
 
 from launch import LaunchContext
 
@@ -104,6 +105,17 @@ def test_launch_context_launch_configurations():
 
     with pytest.raises(RuntimeError):
         lc._pop_launch_configurations()
+
+
+def test_launch_context_environment():
+    """Test the environment feature of the LaunchContext class."""
+    # Inherits OS environ
+    os.environ['LAUNCH_TEST_ENV_PUSH_POP'] = 'FOO'
+    context = LaunchContext()
+    assert len(context.environment) > 0
+    assert context.environment == dict(os.environ)
+    # cleanup
+    del os.environ['LAUNCH_TEST_ENV_PUSH_POP']
 
 
 def test_launch_context_register_event_handlers():

--- a/launch_xml/test/launch_xml/test_group.py
+++ b/launch_xml/test/launch_xml/test_group.py
@@ -17,6 +17,10 @@
 import io
 import textwrap
 
+from launch.actions import PopEnvironment
+from launch.actions import PopLaunchConfigurations
+from launch.actions import PushEnvironment
+from launch.actions import PushLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
 from launch.frontend import Parser
 
@@ -39,6 +43,30 @@ def test_group():
     assert 2 == len(actions)
     assert isinstance(actions[0], SetLaunchConfiguration)
     assert isinstance(actions[1], SetLaunchConfiguration)
+
+
+def test_group_scoped():
+    xml_file = \
+        """\
+        <launch>
+            <group scoped="True">
+                <let name="var1" value="asd"/>
+                <let name="var2" value="asd"/>
+            </group>
+        </launch>
+        """  # noqa: E501
+    xml_file = textwrap.dedent(xml_file)
+    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    ld = parser.parse_description(root_entity)
+    group = ld.entities[0]
+    actions = group.execute(None)
+    assert 6 == len(actions)
+    assert isinstance(actions[0], PushLaunchConfigurations)
+    assert isinstance(actions[1], PushEnvironment)
+    assert isinstance(actions[2], SetLaunchConfiguration)
+    assert isinstance(actions[3], SetLaunchConfiguration)
+    assert isinstance(actions[4], PopEnvironment)
+    assert isinstance(actions[5], PopLaunchConfigurations)
 
 
 if __name__ == '__main__':

--- a/launch_yaml/test/launch_yaml/test_group.py
+++ b/launch_yaml/test/launch_yaml/test_group.py
@@ -17,6 +17,10 @@
 import io
 import textwrap
 
+from launch.actions import PopEnvironment
+from launch.actions import PopLaunchConfigurations
+from launch.actions import PushEnvironment
+from launch.actions import PushLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
 from launch.frontend import Parser
 
@@ -43,6 +47,35 @@ def test_group():
     assert 2 == len(actions)
     assert isinstance(actions[0], SetLaunchConfiguration)
     assert isinstance(actions[1], SetLaunchConfiguration)
+
+
+def test_group_scoped():
+    yaml_file = \
+        """\
+        launch:
+            - group:
+                scoped: True
+                children:
+                    - let:
+                        name: 'var1'
+                        value: 'asd'
+                    - let:
+                        name: 'var2'
+                        value: 'asd'
+        """  # noqa: E501
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    ld = parser.parse_description(root_entity)
+    group = ld.entities[0]
+    actions = group.execute(None)
+    assert 6 == len(actions)
+
+    assert isinstance(actions[0], PushLaunchConfigurations)
+    assert isinstance(actions[1], PushEnvironment)
+    assert isinstance(actions[2], SetLaunchConfiguration)
+    assert isinstance(actions[3], SetLaunchConfiguration)
+    assert isinstance(actions[4], PopEnvironment)
+    assert isinstance(actions[5], PopLaunchConfigurations)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backport #601 to Foxy.

Resolves https://github.com/ros2/ros2/issues/1244

This is a partial backport, since Foxy does not support the `forwarding` option of `GroupAction`. Therefore, we're not actually using the new `ResetEnvironment` action, but I don't think it hurts to include it here in case users want to leverage it.