### PR TITLE
Addresses issue #588, allowing dict for 'output'

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -190,7 +190,8 @@ class ExecuteLocal(Action):
         self.__sigkill_timeout = normalize_to_list_of_substitutions(sigkill_timeout)
         self.__emulate_tty = emulate_tty
         self.__output = os.environ.get('OVERRIDE_LAUNCH_PROCESS_OUTPUT', output)
-        self.__output = normalize_to_list_of_substitutions(self.__output)
+        if not isinstance(self.__output, dict):
+            self.__output = normalize_to_list_of_substitutions(self.__output)
         self.__output_format = output_format
 
         self.__log_cmd = log_cmd
@@ -667,7 +668,8 @@ class ExecuteLocal(Action):
             self.__completed_future = create_future(context.asyncio_loop)
             self.__shutdown_future = create_future(context.asyncio_loop)
             self.__logger = launch.logging.get_logger(name)
-            self.__output = perform_substitutions(context, self.__output)
+            if not isinstance(self.__output, dict):
+                self.__output = perform_substitutions(context, self.__output)
             self.__stdout_logger, self.__stderr_logger = \
                 launch.logging.get_output_loggers(name, self.__output)
             context.asyncio_loop.create_task(self.__execute_process(context))

--- a/launch/test/launch/test_execute_local.py
+++ b/launch/test/launch/test_execute_local.py
@@ -124,3 +124,17 @@ def test_execute_process_with_respawn():
     ls.include_launch_description(generate_launch_description())
     assert 0 == ls.run()
     assert expected_called_count == on_exit_callback.called_count
+
+
+def test_execute_process_with_output_dictionary():
+    """Test launching a process works when output is specified as a dictionary."""
+    executable = ExecuteLocal(
+        process_description=Executable(
+            cmd=[sys.executable, '-c', "pass"]
+        ),
+        output={'stdout': 'screen', 'stderr': 'screen'}
+    )
+    ld = LaunchDescription([executable])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()

--- a/launch/test/launch/test_execute_local.py
+++ b/launch/test/launch/test_execute_local.py
@@ -130,7 +130,7 @@ def test_execute_process_with_output_dictionary():
     """Test launching a process works when output is specified as a dictionary."""
     executable = ExecuteLocal(
         process_description=Executable(
-            cmd=[sys.executable, '-c', "pass"]
+            cmd=[sys.executable, '-c', 'pass']
         ),
         output={'stdout': 'screen', 'stderr': 'screen'}
     )


### PR DESCRIPTION
Here is one approach to fixing #588.

I didn't add a test but I'm happy to work on one if someone could point me in the right direction (e.g., where to put the test and what test file I can model it off of). 

In issue #577 , the 'output' option for logging in launch files was not participating in $(var) expansion (e.g., in
xml launch files).

The fix for this issue (commit 8006dfadc) appears to have broken the use-case where the 'output' is specified
as a dictionary (e.g., in python launch files).

This commit only performs the command expansion if the 'output' value is not a dict(), otherwise the dict() is passed through directly.

The 'output' value ultimately is passed to launch/launch/logging/__init__.py: get_output_loggers()
which can accept either a string or a dict to specify the outputs

Signed-off-by: Matthew Elwin <elwin@northwestern.edu>