### PR TITLE
Implement Any, All, Equals, and NotEquals substitutions

### DIFF
--- a/launch/launch/conditions/launch_configuration_equals.py
+++ b/launch/launch/conditions/launch_configuration_equals.py
@@ -16,6 +16,7 @@
 
 from typing import Optional
 from typing import Text
+import warnings
 
 from ..condition import Condition
 from ..launch_context import LaunchContext
@@ -43,6 +44,16 @@ class LaunchConfigurationEquals(Condition):
         launch_configuration_name: Text,
         expected_value: Optional[SomeSubstitutionsType]
     ) -> None:
+        warnings.warn(
+            "The 'LaunchConfigurationEquals' and 'LaunchConfigurationNotEquals' Conditions are "
+            " deprecated. Use the 'EqualsSubstitution' and 'NotEqualsSubstitution' substitutions "
+            "instead! E.g.:\n"
+            "  IfCondition(\n  "
+            "\tEqualsSubstitution(LaunchConfiguration('some_launch_arg'), \"some_equality_check\")"
+            "\n  )",
+            UserWarning
+        )
+
         self.__launch_configuration_name = launch_configuration_name
         if expected_value is not None:
             self.__expected_value = normalize_to_list_of_substitutions(expected_value)

--- a/launch/launch/conditions/launch_configuration_equals.py
+++ b/launch/launch/conditions/launch_configuration_equals.py
@@ -51,10 +51,10 @@ class LaunchConfigurationEquals(Condition):
         warnings.warn(
             "The 'LaunchConfigurationEquals' and 'LaunchConfigurationNotEquals' Conditions are "
             " deprecated. Use the 'EqualsSubstitution' and 'NotEqualsSubstitution' substitutions "
-            "instead! E.g.:\n"
-            "  IfCondition(\n  "
+            'instead! E.g.:\n'
+            '  IfCondition(\n  '
             "\tEqualsSubstitution(LaunchConfiguration('some_launch_arg'), \"some_equality_check\")"
-            "\n  )",
+            '\n  )',
             UserWarning
         )
 

--- a/launch/launch/conditions/launch_configuration_equals.py
+++ b/launch/launch/conditions/launch_configuration_equals.py
@@ -37,6 +37,10 @@ class LaunchConfigurationEquals(Condition):
 
     If ``None`` is provided instead of a string expression, then the condition
     evaluates to ``True`` if the launch configuration is not set.
+
+    .. deprecated:: 1.1.0
+       Replaced by the more universally usable substitutions:
+       'EqualsSubstitution' and 'NotEqualsSubstitution'
     """
 
     def __init__(

--- a/launch/launch/conditions/launch_configuration_not_equals.py
+++ b/launch/launch/conditions/launch_configuration_not_equals.py
@@ -34,6 +34,10 @@ class LaunchConfigurationNotEquals(LaunchConfigurationEquals):
 
     If ``None`` is provided instead of a string expression, then the condition
     evaluates to ``True`` if the launch configuration is set.
+
+    .. deprecated:: 1.1.0
+       Replaced by the more universally usable substitutions:
+       'EqualsSubstitution' and 'NotEqualsSubstitution'
     """
 
     def __init__(

--- a/launch/launch/conditions/launch_configuration_not_equals.py
+++ b/launch/launch/conditions/launch_configuration_not_equals.py
@@ -41,6 +41,7 @@ class LaunchConfigurationNotEquals(LaunchConfigurationEquals):
         launch_configuration_name: Text,
         expected_value: Optional[SomeSubstitutionsType]
     ) -> None:
+        # This is deprecated! Use `NotEqualsSubstitution` instead!
         super().__init__(launch_configuration_name, expected_value)
 
     def _predicate_func(self, context: LaunchContext) -> bool:

--- a/launch/launch/some_substitutions_type.py
+++ b/launch/launch/some_substitutions_type.py
@@ -34,21 +34,3 @@ SomeSubstitutionsType_types_tuple = (
     Substitution,
     collections.abc.Iterable,
 )
-
-
-def is_some_substitutions_type(input: Optional[Union[Any, Iterable[Any]]]) -> bool:
-    """
-    Check if input is instance of members of SomeSubstitutionsType.
-
-    It is not possible to do a direct comparison, and typing.get_args() doesn't seem to work, so
-    we're forced to use this very inelegant solution...
-    """
-    if isinstance(input, Iterable):
-        return all(
-            (isinstance(i, Substitution) or isinstance(i, Text)) for i in input
-        )
-    else:
-        return any([
-            isinstance(input, Substitution),
-            isinstance(input, Text)
-        ])

--- a/launch/launch/some_substitutions_type.py
+++ b/launch/launch/some_substitutions_type.py
@@ -15,7 +15,9 @@
 """Module for SomeSubstitutionsType type."""
 
 import collections.abc
+from typing import Any
 from typing import Iterable
+from typing import Optional
 from typing import Text
 from typing import Union
 
@@ -32,3 +34,21 @@ SomeSubstitutionsType_types_tuple = (
     Substitution,
     collections.abc.Iterable,
 )
+
+
+def is_some_substitutions_type(input: Optional[Union[Any, Iterable[Any]]]) -> bool:
+    """
+    Check if input is instance of members of SomeSubstitutionsType.
+
+    It is not possible to do a direct comparison, and typing.get_args() doesn't seem to work, so
+    we're forced to use this very inelegant solution...
+    """
+    if isinstance(input, Iterable):
+        return all(
+            (isinstance(i, Substitution) or isinstance(i, Text)) for i in input
+        )
+    else:
+        return any([
+            isinstance(input, Substitution),
+            isinstance(input, Text)
+        ])

--- a/launch/launch/some_substitutions_type.py
+++ b/launch/launch/some_substitutions_type.py
@@ -15,9 +15,7 @@
 """Module for SomeSubstitutionsType type."""
 
 import collections.abc
-from typing import Any
 from typing import Iterable
-from typing import Optional
 from typing import Text
 from typing import Union
 

--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -22,9 +22,11 @@ from .boolean_substitution import NotSubstitution
 from .boolean_substitution import OrSubstitution
 from .command import Command
 from .environment_variable import EnvironmentVariable
+from .equals_substitution import EqualsSubstitution
 from .find_executable import FindExecutable
 from .launch_configuration import LaunchConfiguration
 from .local_substitution import LocalSubstitution
+from .not_equals_substitution import NotEqualsSubstitution
 from .path_join_substitution import PathJoinSubstitution
 from .python_expression import PythonExpression
 from .substitution_failure import SubstitutionFailure
@@ -38,11 +40,13 @@ __all__ = [
     'AnySubstitution',
     'AnonName',
     'Command',
+    'EqualsSubstitution',
     'EnvironmentVariable',
     'FindExecutable',
     'LaunchConfiguration',
     'LocalSubstitution',
     'NotSubstitution',
+    'NotEqualsSubstitution',
     'OrSubstitution',
     'PathJoinSubstitution',
     'PythonExpression',

--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -15,7 +15,9 @@
 """Package for substitutions."""
 
 from .anon_name import AnonName
+from .boolean_substitution import AllSubstitution
 from .boolean_substitution import AndSubstitution
+from .boolean_substitution import AnySubstitution
 from .boolean_substitution import NotSubstitution
 from .boolean_substitution import OrSubstitution
 from .command import Command
@@ -31,7 +33,9 @@ from .this_launch_file import ThisLaunchFile
 from .this_launch_file_dir import ThisLaunchFileDir
 
 __all__ = [
+    'AllSubstitution',
     'AndSubstitution',
+    'AnySubstitution',
     'AnonName',
     'Command',
     'EnvironmentVariable',

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -184,7 +184,7 @@ class AnySubstitution(Substitution):
 
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
-        return f'AndSubstitution({" ".join(self.args)})'
+        return f'AnySubstitution({" ".join(self.args)})'
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -67,7 +67,7 @@ class AndSubstitution(Substitution):
     """Substitution that returns 'and' of the input boolean values."""
 
     def __init__(self, left: SomeSubstitutionsType, right: SomeSubstitutionsType) -> None:
-        """Create a AndSubstitution substitution."""
+        """Create an AndSubstitution substitution."""
         super().__init__()
 
         self.__left = normalize_to_list_of_substitutions(left)
@@ -113,7 +113,7 @@ class OrSubstitution(Substitution):
     """Substitution that returns 'or' of the input boolean values."""
 
     def __init__(self, left: SomeSubstitutionsType, right: SomeSubstitutionsType) -> None:
-        """Create a AndSubstitution substitution."""
+        """Create an OrSubstitution substitution."""
         super().__init__()
 
         self.__left = normalize_to_list_of_substitutions(left)
@@ -121,7 +121,7 @@ class OrSubstitution(Substitution):
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
-        """Parse `AndSubstitution` substitution."""
+        """Parse `OrSubstitution` substitution."""
         if len(data) != 2:
             raise TypeError('and substitution expects 2 arguments')
         return cls, {'left': data[0], 'right': data[1]}
@@ -152,3 +152,77 @@ class OrSubstitution(Substitution):
             raise SubstitutionFailure(e)
 
         return str(left_condition or right_condition).lower()
+
+
+@expose_substitution('any')
+class AnySubstitution(Substitution):
+    """Substitution that returns 'any' of the input boolean values."""
+
+    def __init__(self, *args: SomeSubstitutionsType) -> None:
+        """Create an AnySubstitution substitution."""
+        super().__init__()
+
+        self.__args = [normalize_to_list_of_substitutions(arg) for arg in args]
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `AnySubstitution` substitution."""
+        return cls, {'args': data}
+
+    @property
+    def args(self) -> Substitution:
+        """Getter for args."""
+        return self.__args
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'AndSubstitution({" ".join(self.args)})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        substituted_conditions = []
+        for arg in self.args:
+            try:
+                arg_condition = perform_typed_substitution(context, arg, bool)
+                substituted_conditions.append(arg_condition)
+            except (TypeError, ValueError) as e:
+                raise SubstitutionFailure(e)
+
+        return str(any(substituted_conditions)).lower()
+
+
+@expose_substitution('all')
+class AllSubstitution(Substitution):
+    """Substitution that returns 'all' of the input boolean values."""
+
+    def __init__(self, *args: SomeSubstitutionsType) -> None:
+        """Create an AllSubstitution substitution."""
+        super().__init__()
+
+        self.__args = [normalize_to_list_of_substitutions(arg) for arg in args]
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `AllSubstitution` substitution."""
+        return cls, {'args': data}
+
+    @property
+    def args(self) -> Substitution:
+        """Getter for args."""
+        return self.__args
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'AllSubstitution({" ".join(self.args)})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        substituted_conditions = []
+        for arg in self.args:
+            try:
+                arg_condition = perform_typed_substitution(context, arg, bool)
+                substituted_conditions.append(arg_condition)
+            except (TypeError, ValueError) as e:
+                raise SubstitutionFailure(e)
+
+        return str(all(substituted_conditions)).lower()

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -156,10 +156,18 @@ class OrSubstitution(Substitution):
 
 @expose_substitution('any')
 class AnySubstitution(Substitution):
-    """Substitution that returns 'any' of the input boolean values."""
+    """
+    Substitutes to the string 'true' if at least one of the input arguments evaluates to true.
+
+    If none of the arguments evaluate to true, then this substitution returns the string 'false'.
+    """
 
     def __init__(self, *args: SomeSubstitutionsType) -> None:
-        """Create an AnySubstitution substitution."""
+        """
+        Create an AnySubstitution substitution.
+
+        The following string arguments evaluate to true: '1', 'true', 'True', 'on'
+        """
         super().__init__()
 
         self.__args = [normalize_to_list_of_substitutions(arg) for arg in args]
@@ -193,10 +201,19 @@ class AnySubstitution(Substitution):
 
 @expose_substitution('all')
 class AllSubstitution(Substitution):
-    """Substitution that returns 'all' of the input boolean values."""
+    """
+    Substitutes to the string 'true' if all of the input arguments evaluate to true.
+
+    If any of the arguments evaluates to false, then this substitution returns the string 'false'.
+    """
 
     def __init__(self, *args: SomeSubstitutionsType) -> None:
-        """Create an AllSubstitution substitution."""
+        """
+        Create an AllSubstitution substitution.
+
+        The following string arguments evaluate to true: '1', 'true', 'True', 'on'
+        The following string arguments evaluate to false: '0', 'false', 'False', 'off'
+        """
         super().__init__()
 
         self.__args = [normalize_to_list_of_substitutions(arg) for arg in args]

--- a/launch/launch/substitutions/equals_substitution.py
+++ b/launch/launch/substitutions/equals_substitution.py
@@ -1,0 +1,87 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the EqualsSubstitution substitution."""
+
+from typing import Any
+from typing import Iterable
+from typing import Optional
+from typing import Text
+from typing import Union
+
+from ..frontend import expose_substitution
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import is_some_substitutions_type
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+from ..utilities import normalize_to_list_of_substitutions
+from ..utilities.type_utils import perform_substitutions
+
+
+@expose_substitution('equals')
+class EqualsSubstitution(Substitution):
+    """Substitution that checks if two inputs are equal."""
+
+    def __init__(
+        self,
+        left: Optional[Union[Any, Iterable[Any]]],
+        right: Optional[Union[Any, Iterable[Any]]]
+    ) -> None:
+        """Create an EqualsSubstitution substitution."""
+        super().__init__()
+
+        if is_some_substitutions_type(left):
+            self.__left = normalize_to_list_of_substitutions(left)
+        else:
+            self.__left = left
+
+        if is_some_substitutions_type(right):
+            self.__right = normalize_to_list_of_substitutions(right)
+        else:
+            self.__right = right
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `EqualsSubstitution` substitution."""
+        if len(data) != 2:
+            raise TypeError('and substitution expects 2 arguments')
+        return cls, {'left': data[0], 'right': data[1]}
+
+    @property
+    def left(self) -> Substitution:
+        """Getter for left."""
+        return self.__left
+
+    @property
+    def right(self) -> Substitution:
+        """Getter for right."""
+        return self.__right
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'EqualsSubstitution({self.left} {self.right})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        if is_some_substitutions_type(self.left):
+            left = perform_substitutions(context, self.left)
+        else:
+            left = self.left
+
+        if is_some_substitutions_type(self.right):
+            right = perform_substitutions(context, self.right)
+        else:
+            right = self.right
+
+        return str(left == right).lower()

--- a/launch/launch/substitutions/equals_substitution.py
+++ b/launch/launch/substitutions/equals_substitution.py
@@ -27,21 +27,21 @@ from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
-from ..utilities.type_utils import perform_substitutions, is_substitution
+from ..utilities.type_utils import is_substitution, perform_substitutions
 
 
-def _str_is_bool(input: Text) -> bool:
+def _str_is_bool(input_str: Text) -> bool:
     """Check if string input is convertible to a boolean."""
-    if not isinstance(input, Text):
+    if not isinstance(input_str, Text):
         return False
     else:
-        return input.lower() in ('true', 'false', '1', '0')
+        return input_str.lower() in ('true', 'false', '1', '0')
 
 
-def _str_is_float(input: Text) -> bool:
+def _str_is_float(input_str: Text) -> bool:
     """Check if string input is convertible to a float."""
     try:
-        float(input)
+        float(input_str)
         return True
     except ValueError:
         return False

--- a/launch/launch/substitutions/equals_substitution.py
+++ b/launch/launch/substitutions/equals_substitution.py
@@ -116,7 +116,7 @@ class EqualsSubstitution(Substitution):
             right = self.right
 
         if _str_is_bool(left) and _str_is_bool(right):
-            return str(left in ('true', '1') == right in ('true', '1')).lower()
+            return str((left.lower() in ('true', '1')) == (right.lower() in ('true', '1'))).lower()
         elif _str_is_float(left) and _str_is_float(right):
             return str(math.isclose(float(left), float(right))).lower()
         else:

--- a/launch/launch/substitutions/not_equals_substitution.py
+++ b/launch/launch/substitutions/not_equals_substitution.py
@@ -27,7 +27,11 @@ from ..launch_context import LaunchContext
 
 @expose_substitution('not-equals')
 class NotEqualsSubstitution(EqualsSubstitution):
-    """Substitution that checks if two inputs are not equal."""
+    """
+    Substitution that checks if two inputs are not equal.
+
+    Returns 'true' or 'false' strings depending on the result.
+    """
 
     def __init__(
         self,
@@ -43,9 +47,4 @@ class NotEqualsSubstitution(EqualsSubstitution):
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
-        result = super().perform(context)
-
-        if result == 'true':
-            return 'false'
-        else:
-            return 'true'
+        return str(not super().perform(context) == 'true').lower()

--- a/launch/launch/substitutions/not_equals_substitution.py
+++ b/launch/launch/substitutions/not_equals_substitution.py
@@ -47,4 +47,4 @@ class NotEqualsSubstitution(EqualsSubstitution):
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
-        return str(not super().perform(context) == 'true').lower()
+        return str(not (super().perform(context) == 'true')).lower()

--- a/launch/launch/substitutions/not_equals_substitution.py
+++ b/launch/launch/substitutions/not_equals_substitution.py
@@ -1,0 +1,51 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the NotEqualsSubstitution substitution."""
+
+from typing import Any
+from typing import Iterable
+from typing import Optional
+from typing import Text
+from typing import Union
+
+from .equals_substitution import EqualsSubstitution
+from ..frontend import expose_substitution
+from ..launch_context import LaunchContext
+
+
+@expose_substitution('not-equals')
+class NotEqualsSubstitution(EqualsSubstitution):
+    """Substitution that checks if two inputs are not equal."""
+
+    def __init__(
+        self,
+        left: Optional[Union[Any, Iterable[Any]]],
+        right: Optional[Union[Any, Iterable[Any]]]
+    ) -> None:
+        """Create a NotEqualsSubstitution substitution."""
+        super().__init__(left, right)
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'NotEqualsSubstitution({self.left} {self.right})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        result = super().perform(context)
+
+        if result == 'true':
+            return 'false'
+        else:
+            return 'true'

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -104,6 +104,18 @@ def test_any_substitution():
     assert AnySubstitution('true', 'true', 'true').perform(lc) == 'true'
     assert AnySubstitution('true', 'true', 'false').perform(lc) == 'true'
     assert AnySubstitution('false', 'false', 'false').perform(lc) == 'false'
+
+    assert AnySubstitution('1').perform(lc) == 'true'
+    assert AnySubstitution('0').perform(lc) == 'false'
+    assert AnySubstitution('1', 'true').perform(lc) == 'true'
+    assert AnySubstitution('1', 'false').perform(lc) == 'true'
+    assert AnySubstitution('0', 'true').perform(lc) == 'true'
+    assert AnySubstitution('0', 'false').perform(lc) == 'false'
+    assert AnySubstitution('1', 'true', 'true').perform(lc) == 'true'
+    assert AnySubstitution('1', 'true', 'false').perform(lc) == 'true'
+    assert AnySubstitution('true', 'true', '0').perform(lc) == 'true'
+    assert AnySubstitution('0', 'false', 'false').perform(lc) == 'false'
+
     with pytest.raises(SubstitutionFailure):
         AnySubstitution('not-condition-expression', 'true').perform(lc)
     with pytest.raises(SubstitutionFailure):
@@ -122,6 +134,18 @@ def test_all_substitution():
     assert AllSubstitution('true', 'true', 'true').perform(lc) == 'true'
     assert AllSubstitution('true', 'true', 'false').perform(lc) == 'false'
     assert AllSubstitution('false', 'false', 'false').perform(lc) == 'false'
+
+    assert AllSubstitution('1').perform(lc) == 'true'
+    assert AllSubstitution('0').perform(lc) == 'false'
+    assert AllSubstitution('1', 'true').perform(lc) == 'true'
+    assert AllSubstitution('1', 'false').perform(lc) == 'false'
+    assert AllSubstitution('0', 'true').perform(lc) == 'false'
+    assert AllSubstitution('0', 'false').perform(lc) == 'false'
+    assert AllSubstitution('1', 'true', 'true').perform(lc) == 'true'
+    assert AllSubstitution('1', 'true', 'false').perform(lc) == 'false'
+    assert AllSubstitution('true', 'true', '0').perform(lc) == 'false'
+    assert AllSubstitution('0', 'false', 'false').perform(lc) == 'false'
+
     with pytest.raises(SubstitutionFailure):
         AllSubstitution('not-condition-expression', 'true').perform(lc)
     with pytest.raises(SubstitutionFailure):

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -16,11 +16,11 @@
 
 from launch import LaunchContext
 
+from launch.substitutions import AllSubstitution
 from launch.substitutions import AndSubstitution
+from launch.substitutions import AnySubstitution
 from launch.substitutions import NotSubstitution
 from launch.substitutions import OrSubstitution
-from launch.substitutions import AnySubstitution
-from launch.substitutions import AllSubstitution
 from launch.substitutions.substitution_failure import SubstitutionFailure
 
 import pytest

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -19,6 +19,8 @@ from launch import LaunchContext
 from launch.substitutions import AndSubstitution
 from launch.substitutions import NotSubstitution
 from launch.substitutions import OrSubstitution
+from launch.substitutions import AnySubstitution
+from launch.substitutions import AllSubstitution
 from launch.substitutions.substitution_failure import SubstitutionFailure
 
 import pytest
@@ -88,3 +90,39 @@ def test_or_substitution():
         OrSubstitution('not-condition-expression', 'true').perform(lc)
     with pytest.raises(SubstitutionFailure):
         OrSubstitution('true', 'not-condition-expression').perform(lc)
+
+
+def test_any_substitution():
+    lc = LaunchContext()
+    assert AnySubstitution().perform(lc) == 'false'
+    assert AnySubstitution('true').perform(lc) == 'true'
+    assert AnySubstitution('false').perform(lc) == 'false'
+    assert AnySubstitution('true', 'true').perform(lc) == 'true'
+    assert AnySubstitution('true', 'false').perform(lc) == 'true'
+    assert AnySubstitution('false', 'true').perform(lc) == 'true'
+    assert AnySubstitution('false', 'false').perform(lc) == 'false'
+    assert AnySubstitution('true', 'true', 'true').perform(lc) == 'true'
+    assert AnySubstitution('true', 'true', 'false').perform(lc) == 'true'
+    assert AnySubstitution('false', 'false', 'false').perform(lc) == 'false'
+    with pytest.raises(SubstitutionFailure):
+        AnySubstitution('not-condition-expression', 'true').perform(lc)
+    with pytest.raises(SubstitutionFailure):
+        AnySubstitution('true', 'not-condition-expression').perform(lc)
+
+
+def test_all_substitution():
+    lc = LaunchContext()
+    assert AllSubstitution().perform(lc) == 'true'
+    assert AllSubstitution('true').perform(lc) == 'true'
+    assert AllSubstitution('false').perform(lc) == 'false'
+    assert AllSubstitution('true', 'true').perform(lc) == 'true'
+    assert AllSubstitution('true', 'false').perform(lc) == 'false'
+    assert AllSubstitution('false', 'true').perform(lc) == 'false'
+    assert AllSubstitution('false', 'false').perform(lc) == 'false'
+    assert AllSubstitution('true', 'true', 'true').perform(lc) == 'true'
+    assert AllSubstitution('true', 'true', 'false').perform(lc) == 'false'
+    assert AllSubstitution('false', 'false', 'false').perform(lc) == 'false'
+    with pytest.raises(SubstitutionFailure):
+        AllSubstitution('not-condition-expression', 'true').perform(lc)
+    with pytest.raises(SubstitutionFailure):
+        AllSubstitution('true', 'not-condition-expression').perform(lc)

--- a/launch/test/launch/substitutions/test_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_equals_substitution.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the EqualsSubstitution class."""
+
+from launch import LaunchContext
+
+from launch.substitutions import EqualsSubstitution
+from launch.substitutions import PathJoinSubstitution
+
+import os
+
+
+def test_equals_substitution():
+    lc = LaunchContext()
+    assert EqualsSubstitution(None, None).perform(lc) == 'true'
+    assert EqualsSubstitution(None, "something").perform(lc) == 'false'
+    assert EqualsSubstitution(True, True).perform(lc) == 'true'
+    assert EqualsSubstitution(False, False).perform(lc) == 'true'
+    assert EqualsSubstitution(True, False).perform(lc) == 'false'
+    assert EqualsSubstitution(1, True).perform(lc) == 'true'
+    assert EqualsSubstitution(1, 1).perform(lc) == 'true'
+    assert EqualsSubstitution(1, 0).perform(lc) == 'false'
+    assert EqualsSubstitution(1, "1").perform(lc) == 'false'
+    assert EqualsSubstitution("1", "1").perform(lc) == 'true'
+
+    path = ['asd', 'bsd', 'cds']
+    sub = PathJoinSubstitution(path)
+    assert EqualsSubstitution(sub, os.path.join(*path)).perform(lc) == 'true'

--- a/launch/test/launch/substitutions/test_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_equals_substitution.py
@@ -31,43 +31,43 @@ def test_equals_substitution():
 
     # NoneType
     _permute_assertion(None, None, lc, 'true')
-    _permute_assertion(None, "", lc, 'true')
-    _permute_assertion(None, "something", lc, 'false')
+    _permute_assertion(None, '', lc, 'true')
+    _permute_assertion(None, 'something', lc, 'false')
 
     # Booleans
     _permute_assertion(True, True, lc, 'true')
     _permute_assertion(False, False, lc, 'true')
     _permute_assertion(True, False, lc, 'false')
 
-    _permute_assertion(True, "true", lc, 'true')
-    _permute_assertion(True, "True", lc, 'true')
-    _permute_assertion(False, "false", lc, 'true')
-    _permute_assertion(False, "False", lc, 'true')
-    _permute_assertion(True, "False", lc, 'false')
+    _permute_assertion(True, 'true', lc, 'true')
+    _permute_assertion(True, 'True', lc, 'true')
+    _permute_assertion(False, 'false', lc, 'true')
+    _permute_assertion(False, 'False', lc, 'true')
+    _permute_assertion(True, 'False', lc, 'false')
 
     _permute_assertion(True, 1, lc, 'true')
-    _permute_assertion(True, "1", lc, 'true')
+    _permute_assertion(True, '1', lc, 'true')
     _permute_assertion(True, 0, lc, 'false')
-    _permute_assertion(True, "0", lc, 'false')
-    _permute_assertion(True, "10", lc, 'false')
-    _permute_assertion(True, "-1", lc, 'false')
+    _permute_assertion(True, '0', lc, 'false')
+    _permute_assertion(True, '10', lc, 'false')
+    _permute_assertion(True, '-1', lc, 'false')
 
     _permute_assertion(False, 1, lc, 'false')
-    _permute_assertion(False, "1", lc, 'false')
+    _permute_assertion(False, '1', lc, 'false')
     _permute_assertion(False, 0, lc, 'true')
-    _permute_assertion(False, "0", lc, 'true')
-    _permute_assertion(False, "10", lc, 'false')
-    _permute_assertion(False, "-1", lc, 'false')
+    _permute_assertion(False, '0', lc, 'true')
+    _permute_assertion(False, '10', lc, 'false')
+    _permute_assertion(False, '-1', lc, 'false')
 
     _permute_assertion('true', 1, lc, 'true')
-    _permute_assertion('true', "1", lc, 'true')
-    _permute_assertion('true', "0", lc, 'false')
-    _permute_assertion('true', "true", lc, 'true')
+    _permute_assertion('true', '1', lc, 'true')
+    _permute_assertion('true', '0', lc, 'false')
+    _permute_assertion('true', 'true', lc, 'true')
     _permute_assertion('false', 1, lc, 'false')
-    _permute_assertion('false', "1", lc, 'false')
-    _permute_assertion('false', "0", lc, 'true')
-    _permute_assertion('false', "false", lc, 'true')
-    _permute_assertion('true', "false", lc, 'false')
+    _permute_assertion('false', '1', lc, 'false')
+    _permute_assertion('false', '0', lc, 'true')
+    _permute_assertion('false', 'false', lc, 'true')
+    _permute_assertion('true', 'false', lc, 'false')
 
     # Numerics
     _permute_assertion(1, 1, lc, 'true')
@@ -95,15 +95,11 @@ def test_equals_substitution():
     _permute_assertion('-inf', '-inf', lc, 'true')
 
     # Strings
-    _permute_assertion('nan', 'nan', lc, 'true')
-    _permute_assertion('inf', 'inf', lc, 'true')
-    _permute_assertion('inf', 'nan', lc, 'false')
-
-    _permute_assertion("wow", "wow", lc, 'true')
-    _permute_assertion("wow", True, lc, 'false')
-    _permute_assertion("wow", 1, lc, 'false')
-    _permute_assertion("wow", 0, lc, 'false')
-    _permute_assertion("wow", 10, lc, 'false')
+    _permute_assertion('wow', 'wow', lc, 'true')
+    _permute_assertion('wow', True, lc, 'false')
+    _permute_assertion('wow', 1, lc, 'false')
+    _permute_assertion('wow', 0, lc, 'false')
+    _permute_assertion('wow', 10, lc, 'false')
 
     # Substitutions
     path = ['asd', 'bsd', 'cds']

--- a/launch/test/launch/substitutions/test_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_equals_substitution.py
@@ -23,18 +23,89 @@ import os
 
 
 def test_equals_substitution():
-    lc = LaunchContext()
-    assert EqualsSubstitution(None, None).perform(lc) == 'true'
-    assert EqualsSubstitution(None, "something").perform(lc) == 'false'
-    assert EqualsSubstitution(True, True).perform(lc) == 'true'
-    assert EqualsSubstitution(False, False).perform(lc) == 'true'
-    assert EqualsSubstitution(True, False).perform(lc) == 'false'
-    assert EqualsSubstitution(1, True).perform(lc) == 'true'
-    assert EqualsSubstitution(1, 1).perform(lc) == 'true'
-    assert EqualsSubstitution(1, 0).perform(lc) == 'false'
-    assert EqualsSubstitution(1, "1").perform(lc) == 'false'
-    assert EqualsSubstitution("1", "1").perform(lc) == 'true'
+    def _permute_assertion(left, right, context, output):
+        assert EqualsSubstitution(left, right).perform(context) == output
+        assert EqualsSubstitution(right, left).perform(context) == output
 
+    lc = LaunchContext()
+
+    # NoneType
+    _permute_assertion(None, None, lc, 'true')
+    _permute_assertion(None, "", lc, 'true')
+    _permute_assertion(None, "something", lc, 'false')
+
+    # Booleans
+    _permute_assertion(True, True, lc, 'true')
+    _permute_assertion(False, False, lc, 'true')
+    _permute_assertion(True, False, lc, 'false')
+
+    _permute_assertion(True, "true", lc, 'true')
+    _permute_assertion(True, "True", lc, 'true')
+    _permute_assertion(False, "false", lc, 'true')
+    _permute_assertion(False, "False", lc, 'true')
+    _permute_assertion(True, "False", lc, 'false')
+
+    _permute_assertion(True, 1, lc, 'true')
+    _permute_assertion(True, "1", lc, 'true')
+    _permute_assertion(True, 0, lc, 'false')
+    _permute_assertion(True, "0", lc, 'false')
+    _permute_assertion(True, "10", lc, 'false')
+    _permute_assertion(True, "-1", lc, 'false')
+
+    _permute_assertion(False, 1, lc, 'false')
+    _permute_assertion(False, "1", lc, 'false')
+    _permute_assertion(False, 0, lc, 'true')
+    _permute_assertion(False, "0", lc, 'true')
+    _permute_assertion(False, "10", lc, 'false')
+    _permute_assertion(False, "-1", lc, 'false')
+
+    _permute_assertion('true', 1, lc, 'true')
+    _permute_assertion('true', "1", lc, 'true')
+    _permute_assertion('true', "0", lc, 'false')
+    _permute_assertion('true', "true", lc, 'true')
+    _permute_assertion('false', 1, lc, 'false')
+    _permute_assertion('false', "1", lc, 'false')
+    _permute_assertion('false', "0", lc, 'true')
+    _permute_assertion('false', "false", lc, 'true')
+    _permute_assertion('true', "false", lc, 'false')
+
+    # Numerics
+    _permute_assertion(1, 1, lc, 'true')
+    _permute_assertion(1, 0, lc, 'false')
+    _permute_assertion(1, -1, lc, 'false')
+    _permute_assertion(10, 10, lc, 'true')
+    _permute_assertion(10, -10, lc, 'false')
+
+    _permute_assertion(10, 10.0, lc, 'true')
+    _permute_assertion(10, 10 + 1e-10, lc, 'true')
+    _permute_assertion(10, 10.1, lc, 'false')
+    _permute_assertion(10.0, -10.0, lc, 'false')
+
+    _permute_assertion(float('nan'), float('nan'), lc, 'false')
+    _permute_assertion(float('nan'), 'nan', lc, 'false')
+    _permute_assertion('nan', 'nan', lc, 'false')  # Special case
+
+    _permute_assertion(float('inf'), float('inf'), lc, 'true')
+    _permute_assertion(float('inf'), 'inf', lc, 'true')
+    _permute_assertion('inf', 'inf', lc, 'true')
+
+    _permute_assertion(float('inf'), float('-inf'), lc, 'false')
+    _permute_assertion(float('inf'), '-inf', lc, 'false')
+    _permute_assertion('inf', '-inf', lc, 'false')
+    _permute_assertion('-inf', '-inf', lc, 'true')
+
+    # Strings
+    _permute_assertion('nan', 'nan', lc, 'true')
+    _permute_assertion('inf', 'inf', lc, 'true')
+    _permute_assertion('inf', 'nan', lc, 'false')
+
+    _permute_assertion("wow", "wow", lc, 'true')
+    _permute_assertion("wow", True, lc, 'false')
+    _permute_assertion("wow", 1, lc, 'false')
+    _permute_assertion("wow", 0, lc, 'false')
+    _permute_assertion("wow", 10, lc, 'false')
+
+    # Substitutions
     path = ['asd', 'bsd', 'cds']
     sub = PathJoinSubstitution(path)
     assert EqualsSubstitution(sub, os.path.join(*path)).perform(lc) == 'true'

--- a/launch/test/launch/substitutions/test_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_equals_substitution.py
@@ -14,12 +14,12 @@
 
 """Tests for the EqualsSubstitution class."""
 
+import os
+
 from launch import LaunchContext
 
 from launch.substitutions import EqualsSubstitution
 from launch.substitutions import PathJoinSubstitution
-
-import os
 
 
 def test_equals_substitution():

--- a/launch/test/launch/substitutions/test_not_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_not_equals_substitution.py
@@ -14,12 +14,12 @@
 
 """Tests for the NotEqualsSubstitution class."""
 
+import os
+
 from launch import LaunchContext
 
 from launch.substitutions import NotEqualsSubstitution
 from launch.substitutions import PathJoinSubstitution
-
-import os
 
 
 def test_not_equals_substitution():
@@ -31,43 +31,43 @@ def test_not_equals_substitution():
 
     # NoneType
     _permute_assertion(None, None, lc, 'false')
-    _permute_assertion(None, "", lc, 'false')
-    _permute_assertion(None, "something", lc, 'true')
+    _permute_assertion(None, '', lc, 'false')
+    _permute_assertion(None, 'something', lc, 'true')
 
     # Booleans
     _permute_assertion(True, True, lc, 'false')
     _permute_assertion(False, False, lc, 'false')
     _permute_assertion(True, False, lc, 'true')
 
-    _permute_assertion(True, "true", lc, 'false')
-    _permute_assertion(True, "True", lc, 'false')
-    _permute_assertion(False, "false", lc, 'false')
-    _permute_assertion(False, "False", lc, 'false')
-    _permute_assertion(True, "False", lc, 'true')
+    _permute_assertion(True, 'true', lc, 'false')
+    _permute_assertion(True, 'True', lc, 'false')
+    _permute_assertion(False, 'false', lc, 'false')
+    _permute_assertion(False, 'False', lc, 'false')
+    _permute_assertion(True, 'False', lc, 'true')
 
     _permute_assertion(True, 1, lc, 'false')
-    _permute_assertion(True, "1", lc, 'false')
+    _permute_assertion(True, '1', lc, 'false')
     _permute_assertion(True, 0, lc, 'true')
-    _permute_assertion(True, "0", lc, 'true')
-    _permute_assertion(True, "10", lc, 'true')
-    _permute_assertion(True, "-1", lc, 'true')
+    _permute_assertion(True, '0', lc, 'true')
+    _permute_assertion(True, '10', lc, 'true')
+    _permute_assertion(True, '-1', lc, 'true')
 
     _permute_assertion(False, 1, lc, 'true')
-    _permute_assertion(False, "1", lc, 'true')
+    _permute_assertion(False, '1', lc, 'true')
     _permute_assertion(False, 0, lc, 'false')
-    _permute_assertion(False, "0", lc, 'false')
-    _permute_assertion(False, "10", lc, 'true')
-    _permute_assertion(False, "-1", lc, 'true')
+    _permute_assertion(False, '0', lc, 'false')
+    _permute_assertion(False, '10', lc, 'true')
+    _permute_assertion(False, '-1', lc, 'true')
 
     _permute_assertion('true', 1, lc, 'false')
-    _permute_assertion('true', "1", lc, 'false')
-    _permute_assertion('true', "0", lc, 'true')
-    _permute_assertion('true', "true", lc, 'false')
+    _permute_assertion('true', '1', lc, 'false')
+    _permute_assertion('true', '0', lc, 'true')
+    _permute_assertion('true', 'true', lc, 'false')
     _permute_assertion('false', 1, lc, 'true')
-    _permute_assertion('false', "1", lc, 'true')
-    _permute_assertion('false', "0", lc, 'false')
-    _permute_assertion('false', "false", lc, 'false')
-    _permute_assertion('true', "false", lc, 'true')
+    _permute_assertion('false', '1', lc, 'true')
+    _permute_assertion('false', '0', lc, 'false')
+    _permute_assertion('false', 'false', lc, 'false')
+    _permute_assertion('true', 'false', lc, 'true')
 
     # Numerics
     _permute_assertion(1, 1, lc, 'false')
@@ -95,11 +95,11 @@ def test_not_equals_substitution():
     _permute_assertion('-inf', '-inf', lc, 'false')
 
     # Strings
-    _permute_assertion("wow", "wow", lc, 'false')
-    _permute_assertion("wow", True, lc, 'true')
-    _permute_assertion("wow", 1, lc, 'true')
-    _permute_assertion("wow", 0, lc, 'true')
-    _permute_assertion("wow", 10, lc, 'true')
+    _permute_assertion('wow', 'wow', lc, 'false')
+    _permute_assertion('wow', True, lc, 'true')
+    _permute_assertion('wow', 1, lc, 'true')
+    _permute_assertion('wow', 0, lc, 'true')
+    _permute_assertion('wow', 10, lc, 'true')
 
     # Substitutions
     path = ['asd', 'bsd', 'cds']

--- a/launch/test/launch/substitutions/test_not_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_not_equals_substitution.py
@@ -22,7 +22,7 @@ from launch.substitutions import PathJoinSubstitution
 import os
 
 
-def test_equals_substitution():
+def test_not_equals_substitution():
     def _permute_assertion(left, right, context, output):
         assert NotEqualsSubstitution(left, right).perform(context) == output
         assert NotEqualsSubstitution(right, left).perform(context) == output
@@ -95,10 +95,6 @@ def test_equals_substitution():
     _permute_assertion('-inf', '-inf', lc, 'false')
 
     # Strings
-    _permute_assertion('nan', 'nan', lc, 'false')
-    _permute_assertion('inf', 'inf', lc, 'false')
-    _permute_assertion('inf', 'nan', lc, 'true')
-
     _permute_assertion("wow", "wow", lc, 'false')
     _permute_assertion("wow", True, lc, 'true')
     _permute_assertion("wow", 1, lc, 'true')
@@ -108,4 +104,4 @@ def test_equals_substitution():
     # Substitutions
     path = ['asd', 'bsd', 'cds']
     sub = PathJoinSubstitution(path)
-    assert NotEqualsSubstitution(sub, os.path.join(*path)).perform(lc) == 'true'
+    assert NotEqualsSubstitution(sub, os.path.join(*path)).perform(lc) == 'false'

--- a/launch/test/launch/substitutions/test_not_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_not_equals_substitution.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the NotEqualsSubstitution class."""
+
+from launch import LaunchContext
+
+from launch.substitutions import NotEqualsSubstitution
+from launch.substitutions import PathJoinSubstitution
+
+import os
+
+
+def test_equals_substitution():
+    lc = LaunchContext()
+    assert NotEqualsSubstitution(None, None).perform(lc) == 'false'
+    assert NotEqualsSubstitution(None, "something").perform(lc) == 'true'
+    assert NotEqualsSubstitution(True, True).perform(lc) == 'false'
+    assert NotEqualsSubstitution(False, False).perform(lc) == 'false'
+    assert NotEqualsSubstitution(True, False).perform(lc) == 'true'
+    assert NotEqualsSubstitution(1, True).perform(lc) == 'false'
+    assert NotEqualsSubstitution(1, 1).perform(lc) == 'false'
+    assert NotEqualsSubstitution(1, 0).perform(lc) == 'true'
+    assert NotEqualsSubstitution(1, "1").perform(lc) == 'true'
+    assert NotEqualsSubstitution("1", "1").perform(lc) == 'false'
+
+    path = ['asd', 'bsd', 'cds']
+    sub = PathJoinSubstitution(path)
+    assert NotEqualsSubstitution(sub, os.path.join(*path)).perform(lc) == 'false'


### PR DESCRIPTION
# Description
This PR implements new `Any` and `All` boolean substitutions. As well as new `Equals` and `NotEquals` substitutions.

The equality substitutions deprecate the `LaunchConfigurationEquals` and `LaunchConfigurationNotEquals` conditions, because they're more universal and can take in `LaunchConfiguration` substitutions.

It should be self-explanatory from the included tests (: