### PR TITLE
Add special cases to coerce "1" and "0" to bool when using bool coercion only

### DIFF
--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -275,7 +275,12 @@ def coerce_to_type(
             else:
                 raise
 
-    if type_obj is not bool:
+    if type_obj is bool:  # For bool coercion, allow '1' and '0' to be truthy and falsy
+        if value == '1':
+            value = 'true'
+        elif value == '0':
+            value = 'false'
+    else:
         raise ValueError(
             'data_type is invalid. Expected one of: '
             'int, float, str, bool, List[int], List[float], List[str], List[bool]'

--- a/launch/test/launch/substitutions/test_boolean_substitution.py
+++ b/launch/test/launch/substitutions/test_boolean_substitution.py
@@ -28,6 +28,8 @@ def test_not_substitution():
     lc = LaunchContext()
     assert NotSubstitution('true').perform(lc) == 'false'
     assert NotSubstitution('false').perform(lc) == 'true'
+    assert NotSubstitution('1').perform(lc) == 'false'
+    assert NotSubstitution('0').perform(lc) == 'true'
     with pytest.raises(SubstitutionFailure):
         NotSubstitution('not-condition-expression').perform(lc)
 
@@ -38,6 +40,22 @@ def test_and_substitution():
     assert AndSubstitution('true', 'false').perform(lc) == 'false'
     assert AndSubstitution('false', 'true').perform(lc) == 'false'
     assert AndSubstitution('false', 'false').perform(lc) == 'false'
+
+    assert AndSubstitution('true', '1').perform(lc) == 'true'
+    assert AndSubstitution('true', '0').perform(lc) == 'false'
+    assert AndSubstitution('false', '1').perform(lc) == 'false'
+    assert AndSubstitution('false', '0').perform(lc) == 'false'
+
+    assert AndSubstitution('1', 'true').perform(lc) == 'true'
+    assert AndSubstitution('1', 'false').perform(lc) == 'false'
+    assert AndSubstitution('0', 'true').perform(lc) == 'false'
+    assert AndSubstitution('0', 'false').perform(lc) == 'false'
+
+    assert AndSubstitution('1', '1').perform(lc) == 'true'
+    assert AndSubstitution('1', '0').perform(lc) == 'false'
+    assert AndSubstitution('0', '1').perform(lc) == 'false'
+    assert AndSubstitution('0', '0').perform(lc) == 'false'
+
     with pytest.raises(SubstitutionFailure):
         AndSubstitution('not-condition-expression', 'true').perform(lc)
     with pytest.raises(SubstitutionFailure):
@@ -50,6 +68,22 @@ def test_or_substitution():
     assert OrSubstitution('true', 'false').perform(lc) == 'true'
     assert OrSubstitution('false', 'true').perform(lc) == 'true'
     assert OrSubstitution('false', 'false').perform(lc) == 'false'
+
+    assert OrSubstitution('true', '1').perform(lc) == 'true'
+    assert OrSubstitution('true', '0').perform(lc) == 'true'
+    assert OrSubstitution('false', '1').perform(lc) == 'true'
+    assert OrSubstitution('false', '0').perform(lc) == 'false'
+
+    assert OrSubstitution('1', 'true').perform(lc) == 'true'
+    assert OrSubstitution('1', 'false').perform(lc) == 'true'
+    assert OrSubstitution('0', 'true').perform(lc) == 'true'
+    assert OrSubstitution('0', 'false').perform(lc) == 'false'
+
+    assert OrSubstitution('1', '1').perform(lc) == 'true'
+    assert OrSubstitution('1', '0').perform(lc) == 'true'
+    assert OrSubstitution('0', '1').perform(lc) == 'true'
+    assert OrSubstitution('0', '0').perform(lc) == 'false'
+
     with pytest.raises(SubstitutionFailure):
         OrSubstitution('not-condition-expression', 'true').perform(lc)
     with pytest.raises(SubstitutionFailure):

--- a/launch/test/launch/utilities/test_type_utils.py
+++ b/launch/test/launch/utilities/test_type_utils.py
@@ -234,6 +234,8 @@ def test_coercions_given_specific_type(coerce_to_type_impl):
     assert coerce_to_type_impl('on', data_type=bool) is True
     assert coerce_to_type_impl('off', data_type=bool) is False
     assert coerce_to_type_impl('True', data_type=bool) is True
+    assert coerce_to_type_impl('1', data_type=bool) is True
+    assert coerce_to_type_impl('0', data_type=bool) is False
 
     assert coerce_to_type_impl('[.2, .1, .1]', data_type=List[float]) == [.2, .1, .1]
     assert coerce_to_type_impl('[asd, bsd, csd]', data_type=List[str]) == ['asd', 'bsd', 'csd']

--- a/launch/test/launch/utilities/test_type_utils.py
+++ b/launch/test/launch/utilities/test_type_utils.py
@@ -286,10 +286,6 @@ def test_coercion_raises_value_error(coerce_to_type_impl):
     with pytest.raises(ValueError):
         coerce_to_type_impl('Bsd', data_type=bool)
 
-    # '1' and '0' are special cases for bool coercion
-    # with pytest.raises(ValueError):
-    #     coerce_to_type_impl('1', data_type=bool)
-
     with pytest.raises(ValueError):
         coerce_to_type_impl('', data_type=List[float])
     with pytest.raises(ValueError):

--- a/launch/test/launch/utilities/test_type_utils.py
+++ b/launch/test/launch/utilities/test_type_utils.py
@@ -283,8 +283,10 @@ def test_coercion_raises_value_error(coerce_to_type_impl):
         coerce_to_type_impl('', data_type=bool)
     with pytest.raises(ValueError):
         coerce_to_type_impl('Bsd', data_type=bool)
-    with pytest.raises(ValueError):
-        coerce_to_type_impl('1', data_type=bool)
+
+    # '1' and '0' are special cases for bool coercion
+    # with pytest.raises(ValueError):
+    #     coerce_to_type_impl('1', data_type=bool)
 
     with pytest.raises(ValueError):
         coerce_to_type_impl('', data_type=List[float])


### PR DESCRIPTION
# Description
Exactly as the title says.

Given that "1" and "0" are valid true and false expressions according [to the conditions](https://github.com/ros2/launch/blob/76ade26d3f7bcb6a5a1b72a512a8c098e6d53f04/launch/launch/conditions/evaluate_condition_expression_impl.py#L25-L26), I think it makes sense to allow coercion of the "1" and "0" strings to `True` and `False`.

This ONLY affects coercion when `bool` is explicitly passed to it. It's as small a change as possible.

This supports the work in https://github.com/ros2/launch/pull/649 and will be used to support the boolean substitution implementations.

# Tests
Special note: This means that [one test for the type coercion](https://github.com/ros2/launch/pull/651/files#diff-56f27934664cd12e7a3b96577955eb19f008622849f77cfd2d7c8a15cc756859L286) will no longer apply.

Beyond that, relevant tests have been implemented.
- https://github.com/ros2/launch/pull/651/files#diff-f1043644a82be146c361f43bb127588df2726dacda3264794c19441bc428fbec
- https://github.com/ros2/launch/pull/651/files#diff-56f27934664cd12e7a3b96577955eb19f008622849f77cfd2d7c8a15cc756859