### PR TITLE
add LaunchLogDir substitution, replacing log_dir frontend only substitution

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -24,14 +24,9 @@ import os
 import socket
 import sys
 
-from typing import Iterable
 from typing import List
 
 from . import handlers
-
-from ..frontend import expose_substitution
-from ..some_substitutions_type import SomeSubstitutionsType
-from ..substitutions import TextSubstitution
 
 __all__ = [
     'get_logger',
@@ -303,13 +298,6 @@ def get_logger(name=None):
     if launch_log_file_handler not in logger.handlers:
         logger.addHandler(launch_log_file_handler)
     return logger
-
-
-@expose_substitution('log_dir')
-def _log_dir(data: Iterable[SomeSubstitutionsType]):
-    if len(data) > 0:
-        raise ValueError('log_dir substitution does not expect any arguments')
-    return TextSubstitution, {'text': launch_config.log_dir}
 
 
 def _normalize_output_configuration(config):

--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -22,6 +22,7 @@ from .command import Command
 from .environment_variable import EnvironmentVariable
 from .find_executable import FindExecutable
 from .launch_configuration import LaunchConfiguration
+from .launch_log_dir import LaunchLogDir
 from .local_substitution import LocalSubstitution
 from .path_join_substitution import PathJoinSubstitution
 from .python_expression import PythonExpression
@@ -37,6 +38,7 @@ __all__ = [
     'EnvironmentVariable',
     'FindExecutable',
     'LaunchConfiguration',
+    'LaunchLogDir',
     'LocalSubstitution',
     'NotSubstitution',
     'OrSubstitution',

--- a/launch/launch/substitutions/launch_log_dir.py
+++ b/launch/launch/substitutions/launch_log_dir.py
@@ -45,7 +45,5 @@ class LaunchLogDir(Substitution):
         return 'LaunchLogDir()'
 
     def perform(self, context: LaunchContext) -> Text:
-        """
-        Perform the substitution by returning the path to the current launch log directory.
-        """
+        """Perform the substitution by returning the path to the current launch log directory."""
         return launch_logging_config.log_dir()

--- a/launch/launch/substitutions/launch_log_dir.py
+++ b/launch/launch/substitutions/launch_log_dir.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,47 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for the ThisLaunchFileDir substitution."""
+"""Module for the LaunchLogDir substitution."""
 
 from typing import Iterable
 from typing import Text
 
-from .substitution_failure import SubstitutionFailure
 from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
+from ..logging import launch_config as launch_logging_config
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 
 
-@expose_substitution('dirname')
-class ThisLaunchFileDir(Substitution):
-    """Substitution that returns the absolute path to the current launch file."""
+@expose_substitution('launch_log_dir')
+@expose_substitution('log_dir')
+class LaunchLogDir(Substitution):
+    """Substitution that returns the absolute path to the current launch log directory."""
 
     def __init__(self) -> None:
-        """Create a ThisLaunchFileDir substitution."""
+        """Create a LaunchLogDir substitution."""
         super().__init__()
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
-        """Parse `ThisLaunchFileDir` substitution."""
+        """Parse `LaunchLogDir` substitution."""
         if len(data) != 0:
-            raise TypeError("dirname substitution doesn't expect arguments")
+            raise TypeError("launch_log_dir/log_dir substitution doesn't expect arguments")
         return cls, {}
 
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
-        return 'ThisLaunchFileDir()'
+        return 'LaunchLogDir()'
 
     def perform(self, context: LaunchContext) -> Text:
         """
-        Perform the substitution by returning the path to the current launch file.
-
-        If there is no current launch file, i.e. if run from a script, then an
-        error is raised.
-
-        :raises: SubstitutionFailure if not in a launch file
+        Perform the substitution by returning the path to the current launch log directory.
         """
-        if 'current_launch_file_directory' not in context.get_locals_as_dict():
-            raise SubstitutionFailure(
-                'ThisLaunchFileDir used outside of a launch file (in a script)')
-        return context.locals.current_launch_file_directory
+        return launch_logging_config.log_dir()

--- a/launch/launch/substitutions/launch_log_dir.py
+++ b/launch/launch/substitutions/launch_log_dir.py
@@ -46,4 +46,4 @@ class LaunchLogDir(Substitution):
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by returning the path to the current launch log directory."""
-        return launch_logging_config.log_dir()
+        return launch_logging_config.log_dir

--- a/launch/launch/substitutions/this_launch_file.py
+++ b/launch/launch/substitutions/this_launch_file.py
@@ -34,7 +34,7 @@ class ThisLaunchFile(Substitution):
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
-        """Parse `EnviromentVariable` substitution."""
+        """Parse `ThisLaunchFile` substitution."""
         if len(data) != 0:
             raise TypeError("filename substitution doesn't expect arguments")
         return cls, {}

--- a/launch/test/launch/actions/test_push_and_pop_environment.py
+++ b/launch/test/launch/actions/test_push_and_pop_environment.py
@@ -18,13 +18,17 @@ from launch import LaunchContext
 from launch.actions import PopEnvironment
 from launch.actions import PushEnvironment
 
+from temporary_environment import sandbox_environment_variables
 
+
+@sandbox_environment_variables
 def test_push_and_pop_environment_constructors():
     """Test the constructors for PopEnvironment and PushEnvironment classes."""
     PopEnvironment()
     PushEnvironment()
 
 
+@sandbox_environment_variables
 def test_push_and_pop_environment_execute():
     """Test the execute() of the PopEnvironment and PushEnvironment classes."""
     context = LaunchContext()

--- a/launch/test/launch/substitutions/test_launch_log_dir.py
+++ b/launch/test/launch/substitutions/test_launch_log_dir.py
@@ -25,7 +25,7 @@ import pytest
 
 def test_launch_log_dir():
     """Test the constructors for LaunchLogDir class."""
-    ThisLaunchFile()
+    LaunchLogDir()
 
 
 def test_launch_log_dir_methods():
@@ -36,7 +36,7 @@ def test_launch_log_dir_methods():
     assert lld.perform(lc)
 
 
-def test_launch_log_dir_frontend():
+def test_launch_log_dir_frontend(log_dir):
     """Test launch_log_dir/log_dir frontend substitutions."""
     launch.logging.reset()
     launch.logging.launch_config.log_dir = log_dir

--- a/launch/test/launch/substitutions/test_launch_log_dir.py
+++ b/launch/test/launch/substitutions/test_launch_log_dir.py
@@ -16,17 +16,7 @@
 
 from launch import LaunchContext
 from launch.frontend.parse_substitution import parse_substitution
-import launch.logging
 from launch.substitutions import LaunchLogDir
-from launch.substitutions import TextSubstitution
-
-import pytest
-
-
-@pytest.fixture
-def log_dir(tmpdir_factory):
-    """Test fixture that generates a temporary directory for log files."""
-    return str(tmpdir_factory.mktemp('logs'))
 
 
 def test_launch_log_dir():
@@ -42,17 +32,10 @@ def test_launch_log_dir_methods():
     assert lld.perform(lc)
 
 
-def test_launch_log_dir_frontend(log_dir):
+def test_launch_log_dir_frontend():
     """Test launch_log_dir/log_dir frontend substitutions."""
-    launch.logging.reset()
-    launch.logging.launch_config.log_dir = log_dir
-
     for sub in ('launch_log_dir', 'log_dir'):
         subst = parse_substitution(f'$({sub})')
         assert len(subst) == 1
         result = subst[0]
-        assert isinstance(result, TextSubstitution)
-        assert result.text == log_dir
-
-        with pytest.raises(TypeError):
-            parse_substitution(f'$({sub} some_args)')
+        assert isinstance(result, LaunchLogDir)

--- a/launch/test/launch/substitutions/test_launch_log_dir.py
+++ b/launch/test/launch/substitutions/test_launch_log_dir.py
@@ -23,6 +23,12 @@ from launch.substitutions import TextSubstitution
 import pytest
 
 
+@pytest.fixture
+def log_dir(tmpdir_factory):
+    """Test fixture that generates a temporary directory for log files."""
+    return str(tmpdir_factory.mktemp('logs'))
+
+
 def test_launch_log_dir():
     """Test the constructors for LaunchLogDir class."""
     LaunchLogDir()

--- a/launch/test/launch/substitutions/test_launch_log_dir.py
+++ b/launch/test/launch/substitutions/test_launch_log_dir.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the LaunchLogDir substitution class."""
+
+from launch import LaunchContext
+from launch.frontend.parse_substitution import parse_substitution
+import launch.logging
+from launch.substitutions import LaunchLogDir
+from launch.substitutions import TextSubstitution
+
+import pytest
+
+
+def test_launch_log_dir():
+    """Test the constructors for LaunchLogDir class."""
+    ThisLaunchFile()
+
+
+def test_launch_log_dir_methods():
+    """Test the methods of the LaunchLogDir class."""
+    lld = LaunchLogDir()
+
+    lc = LaunchContext()
+    assert lld.perform(lc)
+
+
+def test_launch_log_dir_frontend():
+    """Test launch_log_dir/log_dir frontend substitutions."""
+    launch.logging.reset()
+    launch.logging.launch_config.log_dir = log_dir
+
+    for sub in ('launch_log_dir', 'log_dir'):
+        subst = parse_substitution(f'$({sub})')
+        assert len(subst) == 1
+        result = subst[0]
+        assert isinstance(result, TextSubstitution)
+        assert result.text == log_dir
+
+        with pytest.raises(TypeError):
+            parse_substitution(f'$({sub} some_args)')

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -20,9 +20,7 @@ import pathlib
 import re
 from unittest import mock
 
-from launch.frontend.parse_substitution import parse_substitution
 import launch.logging
-from launch.substitutions import TextSubstitution
 
 import pytest
 
@@ -323,15 +321,3 @@ def test_get_logging_directory():
 
     os.environ.pop('ROS_HOME', None)
     launch.logging.launch_config.reset()
-
-
-def test_get_log_dir_frontend(log_dir):
-    """Test log_dir frontend substitution."""
-    launch.logging.reset()
-    launch.logging.launch_config.log_dir = log_dir
-
-    subst = parse_substitution('$(log_dir)')
-    assert len(subst) == 1
-    result = subst[0]
-    assert isinstance(result, TextSubstitution)
-    assert result.text == log_dir

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -25,12 +25,6 @@ import launch.logging
 import pytest
 
 
-@pytest.fixture
-def log_dir(tmpdir_factory):
-    """Test fixture that generates a temporary directory for log files."""
-    return str(tmpdir_factory.mktemp('logs'))
-
-
 def test_bad_logging_launch_config():
     """Tests that setup throws at bad configuration."""
     launch.logging.reset()

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -25,6 +25,12 @@ import launch.logging
 import pytest
 
 
+@pytest.fixture
+def log_dir(tmpdir_factory):
+    """Test fixture that generates a temporary directory for log files."""
+    return str(tmpdir_factory.mktemp('logs'))
+
+
 def test_bad_logging_launch_config():
     """Tests that setup throws at bad configuration."""
     launch.logging.reset()


### PR DESCRIPTION
This is needed in support of a new `launch_ros` action that lets you have all the node log files collect inside the launch log directory.

This changes some of the stuff done in https://github.com/ros2/launch/pull/490.

Connected to:

- https://github.com/ros2/launch_ros/pull/325