### PR TITLE
Pass modules to PythonExpression

### DIFF
--- a/launch/doc/source/architecture.rst
+++ b/launch/doc/source/architecture.rst
@@ -125,6 +125,7 @@ There are many possible variations of a substitution, but here are some of the c
 - :class:`launch.substitutions.PythonExpression`
 
   - This substitution will evaluate a python expression and get the result as a string.
+  - You may pass a list of Python modules to the constructor to allow the use of those modules in the evaluated expression.
 
 - :class:`launch.substitutions.LaunchConfiguration`
 

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -38,7 +38,7 @@ class PythonExpression(Substitution):
     """
 
     def __init__(self, expression: SomeSubstitutionsType,
-                 modules: SomeSubstitutionsType = ['math']) -> None:
+                 python_modules: SomeSubstitutionsType = ['math']) -> None:
         """Create a PythonExpression substitution."""
         super().__init__()
 
@@ -49,14 +49,14 @@ class PythonExpression(Substitution):
             'PythonExpression')
 
         ensure_argument_type(
-            modules,
+            python_modules,
             (str, Substitution, collections.abc.Iterable),
-            'modules',
+            'python_modules',
             'PythonExpression')
 
         from ..utilities import normalize_to_list_of_substitutions
         self.__expression = normalize_to_list_of_substitutions(expression)
-        self.__modules = normalize_to_list_of_substitutions(modules)
+        self.__python_modules = normalize_to_list_of_substitutions(python_modules)
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
@@ -68,11 +68,11 @@ class PythonExpression(Substitution):
         if len(data) == 2:
             # We get a text subsitution from XML,
             # whose contents are comma-separated module names
-            kwargs['modules'] = []
+            kwargs['python_modules'] = []
             # Check if we got empty list from XML
             if len(data[1]) > 0:
                 modules_str = data[1][0].perform(None)
-                kwargs['modules'] = modules_str.split(', ')
+                kwargs['python_modules'] = modules_str.split(', ')
         return cls, kwargs
 
     @property
@@ -81,20 +81,20 @@ class PythonExpression(Substitution):
         return self.__expression
 
     @property
-    def modules(self) -> List[Substitution]:
+    def python_modules(self) -> List[Substitution]:
         """Getter for expression."""
-        return self.__modules
+        return self.__python_modules
 
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
         return 'PythonExpr({}, [{}])'.format(
             ' + '.join([sub.describe() for sub in self.expression]),
-            ', '.join([sub.describe() for sub in self.modules]))
+            ', '.join([sub.describe() for sub in self.python_modules]))
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by evaluating the expression."""
         from ..utilities import perform_substitutions
-        module_names = [context.perform_substitution(sub) for sub in self.modules]
+        module_names = [context.perform_substitution(sub) for sub in self.python_modules]
         module_objects = [importlib.import_module(name) for name in module_names]
         locals = {}
         for module in module_objects:

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -37,7 +37,7 @@ class PythonExpression(Substitution):
     It also may contain math symbols and functions.
     """
 
-    def __init__(self, expression: SomeSubstitutionsType, locals: dict=math.__dict__) -> None:
+    def __init__(self, expression: SomeSubstitutionsType, locals: dict = math.__dict__) -> None:
         """Create a PythonExpression substitution."""
         super().__init__()
 

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -98,5 +98,11 @@ class PythonExpression(Substitution):
         module_objects = [importlib.import_module(name) for name in module_names]
         locals = {}
         for module in module_objects:
-            locals.update(vars(module))
+            # For backwards compatility, we allow math definitions to be implicitly
+            # referenced in expressions, without prepending the math module name
+            # TODO: This may be removed in a future release.
+            if module.__name__ == 'math':
+                locals.update(vars(module))
+
+            locals[module.__name__] = module
         return str(eval(perform_substitutions(context, self.expression), {}, locals))

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -96,13 +96,13 @@ class PythonExpression(Substitution):
         from ..utilities import perform_substitutions
         module_names = [context.perform_substitution(sub) for sub in self.python_modules]
         module_objects = [importlib.import_module(name) for name in module_names]
-        locals = {}
+        expression_locals = {}
         for module in module_objects:
             # For backwards compatility, we allow math definitions to be implicitly
             # referenced in expressions, without prepending the math module name
             # TODO: This may be removed in a future release.
             if module.__name__ == 'math':
-                locals.update(vars(module))
+                expression_locals.update(vars(module))
 
-            locals[module.__name__] = module
-        return str(eval(perform_substitutions(context, self.expression), {}, locals))
+            expression_locals[module.__name__] = module
+        return str(eval(perform_substitutions(context, self.expression), {}, expression_locals))

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -51,8 +51,10 @@ class PythonExpression(Substitution):
         self.__expression = normalize_to_list_of_substitutions(expression)
 
         self.__locals = {}
+        self.__modules = []
         for x in modules:
             self.__locals.update(vars(x))
+            self.__modules.append(x.__name__)
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
@@ -73,7 +75,13 @@ class PythonExpression(Substitution):
 
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
-        return 'PythonExpr({})'.format(' + '.join([sub.describe() for sub in self.expression]))
+        if self.__modules:
+            return 'PythonExpr({}, {})'.format(
+                ' + '.join([sub.describe() for sub in self.expression]),
+                self.__modules)
+        else:
+            return 'PythonExpr({})'.format(
+                ' + '.join([sub.describe() for sub in self.expression]))
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by evaluating the expression."""

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -37,7 +37,7 @@ class PythonExpression(Substitution):
     It also may contain math symbols and functions.
     """
 
-    def __init__(self, expression: SomeSubstitutionsType, locals: dict = math.__dict__) -> None:
+    def __init__(self, expression: SomeSubstitutionsType, modules: List[object] = [math]) -> None:
         """Create a PythonExpression substitution."""
         super().__init__()
 
@@ -50,7 +50,9 @@ class PythonExpression(Substitution):
         from ..utilities import normalize_to_list_of_substitutions
         self.__expression = normalize_to_list_of_substitutions(expression)
 
-        self.__locals = locals
+        self.__locals = {}
+        for x in modules:
+            self.__locals.update(vars(x))
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -15,7 +15,7 @@
 """Module for the PythonExpression substitution."""
 
 import collections.abc
-import math
+import importlib
 from typing import Iterable
 from typing import List
 from typing import Text
@@ -37,7 +37,8 @@ class PythonExpression(Substitution):
     It also may contain math symbols and functions.
     """
 
-    def __init__(self, expression: SomeSubstitutionsType, modules: List[object] = [math]) -> None:
+    def __init__(self, expression: SomeSubstitutionsType,
+                 modules: SomeSubstitutionsType = ['math']) -> None:
         """Create a PythonExpression substitution."""
         super().__init__()
 
@@ -47,21 +48,32 @@ class PythonExpression(Substitution):
             'expression',
             'PythonExpression')
 
+        ensure_argument_type(
+            modules,
+            (str, Substitution, collections.abc.Iterable),
+            'modules',
+            'PythonExpression')
+
         from ..utilities import normalize_to_list_of_substitutions
         self.__expression = normalize_to_list_of_substitutions(expression)
-
-        self.__locals = {}
-        self.__modules = []
-        for x in modules:
-            self.__locals.update(vars(x))
-            self.__modules.append(x.__name__)
+        self.__modules = normalize_to_list_of_substitutions(modules)
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
         """Parse `PythonExpression` substitution."""
-        if len(data) != 1:
-            raise TypeError('eval substitution expects 1 argument')
-        return cls, {'expression': data[0]}
+        if len(data) < 1 or len(data) > 2:
+            raise TypeError('eval substitution expects 1 or 2 arguments')
+        kwargs = {}
+        kwargs['expression'] = data[0]
+        if len(data) == 2:
+            # We get a text subsitution from XML,
+            # whose contents are comma-separated module names
+            kwargs['modules'] = []
+            # Check if we got empty list from XML
+            if len(data[1]) > 0:
+                modules_str = data[1][0].perform(None)
+                kwargs['modules'] = modules_str.split(', ')
+        return cls, kwargs
 
     @property
     def expression(self) -> List[Substitution]:
@@ -69,21 +81,22 @@ class PythonExpression(Substitution):
         return self.__expression
 
     @property
-    def locals(self) -> dict:
-        """Getter for locals."""
-        return self.__locals
+    def modules(self) -> List[Substitution]:
+        """Getter for expression."""
+        return self.__modules
 
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
-        if self.__modules:
-            return 'PythonExpr({}, {})'.format(
-                ' + '.join([sub.describe() for sub in self.expression]),
-                self.__modules)
-        else:
-            return 'PythonExpr({})'.format(
-                ' + '.join([sub.describe() for sub in self.expression]))
+        return 'PythonExpr({}, [{}])'.format(
+            ' + '.join([sub.describe() for sub in self.expression]),
+            ', '.join([sub.describe() for sub in self.modules]))
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by evaluating the expression."""
         from ..utilities import perform_substitutions
-        return str(eval(perform_substitutions(context, self.expression), {}, self.locals))
+        module_names = [context.perform_substitution(sub) for sub in self.modules]
+        module_objects = [importlib.import_module(name) for name in module_names]
+        locals = {}
+        for module in module_objects:
+            locals.update(vars(module))
+        return str(eval(perform_substitutions(context, self.expression), {}, locals))

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -37,7 +37,7 @@ class PythonExpression(Substitution):
     It also may contain math symbols and functions.
     """
 
-    def __init__(self, expression: SomeSubstitutionsType) -> None:
+    def __init__(self, expression: SomeSubstitutionsType, locals: dict=math.__dict__) -> None:
         """Create a PythonExpression substitution."""
         super().__init__()
 
@@ -49,6 +49,8 @@ class PythonExpression(Substitution):
 
         from ..utilities import normalize_to_list_of_substitutions
         self.__expression = normalize_to_list_of_substitutions(expression)
+
+        self.__locals = locals
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
@@ -62,6 +64,11 @@ class PythonExpression(Substitution):
         """Getter for expression."""
         return self.__expression
 
+    @property
+    def locals(self) -> dict:
+        """Getter for locals."""
+        return self.__locals
+
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
         return 'PythonExpr({})'.format(' + '.join([sub.describe() for sub in self.expression]))
@@ -69,4 +76,4 @@ class PythonExpression(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by evaluating the expression."""
         from ..utilities import perform_substitutions
-        return str(eval(perform_substitutions(context, self.expression), {}, math.__dict__))
+        return str(eval(perform_substitutions(context, self.expression), {}, self.locals))

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -72,7 +72,7 @@ class PythonExpression(Substitution):
             # Check if we got empty list from XML
             if len(data[1]) > 0:
                 modules_str = data[1][0].perform(None)
-                kwargs['python_modules'] = modules_str.split(', ')
+                kwargs['python_modules'] = [module.strip() for module in modules_str.split(',')]
         return cls, kwargs
 
     @property

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -259,6 +259,16 @@ def test_eval_subst_multiple_modules():
     assert expr.perform(LaunchContext())
 
 
+def test_eval_subst_multiple_modules_alt_syntax():
+    # Case where the module names are listed with irregular spacing
+    subst = parse_substitution(
+        r'$(eval "math.isfinite(sys.getrefcount(str(\'hello world!\')))" " math,sys ")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+    assert expr.perform(LaunchContext())
+
+
 def expand_cmd_subs(cmd_subs: List[SomeSubstitutionsType]):
     return [perform_substitutions_without_context(x) for x in cmd_subs]
 

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -206,11 +206,39 @@ def test_eval_subst():
 
 
 def test_eval_subst_of_math_expr():
+    # Math module is included by default
     subst = parse_substitution(r'$(eval "ceil(1.3)")')
     assert len(subst) == 1
     expr = subst[0]
     assert isinstance(expr, PythonExpression)
     assert '2' == expr.perform(LaunchContext())
+
+    # Do it again, with the math module explicitly given
+    subst = parse_substitution(r'$(eval "ceil(1.3)" "math")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+    assert '2' == expr.perform(LaunchContext())
+
+
+def test_eval_missing_module():
+    subst = parse_substitution(r'$(eval "ceil(1.3)" "")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+
+    # Should raise NameError since it does not have math module
+    with pytest.raises(NameError):
+        assert expr.perform(LaunchContext())
+
+
+def test_eval_subst_multiple_modules():
+    subst = parse_substitution(
+        r'$(eval "isfinite(getrefcount(str(\'hello world!\')))" "math, sys")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+    assert expr.perform(LaunchContext())
 
 
 def expand_cmd_subs(cmd_subs: List[SomeSubstitutionsType]):

--- a/launch/test/launch/frontend/test_substitutions.py
+++ b/launch/test/launch/frontend/test_substitutions.py
@@ -220,9 +220,27 @@ def test_eval_subst_of_math_expr():
     assert isinstance(expr, PythonExpression)
     assert '2' == expr.perform(LaunchContext())
 
+    # Do it again, with the math module explicitly given and referenced in the expression
+    subst = parse_substitution(r'$(eval "math.ceil(1.3)" "math")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+    assert '2' == expr.perform(LaunchContext())
+
 
 def test_eval_missing_module():
+    # Test with implicit math definition
     subst = parse_substitution(r'$(eval "ceil(1.3)" "")')
+    assert len(subst) == 1
+    expr = subst[0]
+    assert isinstance(expr, PythonExpression)
+
+    # Should raise NameError since it does not have math module
+    with pytest.raises(NameError):
+        assert expr.perform(LaunchContext())
+
+    # Test with explicit math definition
+    subst = parse_substitution(r'$(eval "math.ceil(1.3)" "")')
     assert len(subst) == 1
     expr = subst[0]
     assert isinstance(expr, PythonExpression)
@@ -234,7 +252,7 @@ def test_eval_missing_module():
 
 def test_eval_subst_multiple_modules():
     subst = parse_substitution(
-        r'$(eval "isfinite(getrefcount(str(\'hello world!\')))" "math, sys")')
+        r'$(eval "math.isfinite(sys.getrefcount(str(\'hello world!\')))" "math, sys")')
     assert len(subst) == 1
     expr = subst[0]
     assert isinstance(expr, PythonExpression)

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -19,7 +19,7 @@ import os
 from launch.substitutions import PathJoinSubstitution
 
 
-def test_this_launch_file_path():
+def test_path_join():
     path = ['asd', 'bsd', 'cds']
     sub = PathJoinSubstitution(path)
     assert sub.perform(None) == os.path.join(*path)

--- a/launch/test/launch/substitutions/test_python_expression.py
+++ b/launch/test/launch/substitutions/test_python_expression.py
@@ -24,7 +24,7 @@ from launch.substitutions import SubstitutionFailure
 def test_python_substitution_missing_module():
     """Check that evaluation fails if we do not pass a needed module (sys)."""
     lc = LaunchContext()
-    expr = 'getrefcount(str("hello world!"))'
+    expr = 'sys.getrefcount(str("hello world!"))'
 
     subst = PythonExpression([expr])
 
@@ -33,11 +33,25 @@ def test_python_substitution_missing_module():
         subst.perform(lc)
 
     # Test the describe() method
-    assert subst.describe() == "PythonExpr('getrefcount(str(\"hello world!\"))', ['math'])"
+    assert subst.describe() == "PythonExpr('sys.getrefcount(str(\"hello world!\"))', ['math'])"
 
 
 def test_python_substitution_no_module():
     """Check that PythonExpression has the math module by default."""
+    lc = LaunchContext()
+    expr = 'math.ceil(1.6)'
+
+    subst = PythonExpression([expr])
+    result = subst.perform(lc)
+
+    assert result == '2'
+
+    # Test the describe() method
+    assert subst.describe() == "PythonExpr('math.ceil(1.6)', ['math'])"
+
+
+def test_python_substitution_implicit_math():
+    """Check that PythonExpression will accept math definitions implicitly."""
     lc = LaunchContext()
     expr = 'ceil(1.6)'
 
@@ -53,7 +67,7 @@ def test_python_substitution_no_module():
 def test_python_substitution_empty_module_list():
     """Case where user provides empty module list."""
     lc = LaunchContext()
-    expr = 'ceil(1.6)'
+    expr = 'math.ceil(1.6)'
 
     subst = PythonExpression([expr], [])
 
@@ -62,13 +76,13 @@ def test_python_substitution_empty_module_list():
         subst.perform(lc)
 
     # Test the describe() method
-    assert subst.describe() == "PythonExpr('ceil(1.6)', [])"
+    assert subst.describe() == "PythonExpr('math.ceil(1.6)', [])"
 
 
 def test_python_substitution_one_module():
     """Evaluation while passing one module."""
     lc = LaunchContext()
-    expr = 'getrefcount(str("hello world!"))'
+    expr = 'sys.getrefcount(str("hello world!"))'
 
     subst = PythonExpression([expr], ['sys'])
     try:
@@ -80,13 +94,13 @@ def test_python_substitution_one_module():
     assert int(result) > 0
 
     # Test the describe() method
-    assert subst.describe() == "PythonExpr('getrefcount(str(\"hello world!\"))', ['sys'])"
+    assert subst.describe() == "PythonExpr('sys.getrefcount(str(\"hello world!\"))', ['sys'])"
 
 
 def test_python_substitution_two_modules():
     """Evaluation while passing two modules."""
     lc = LaunchContext()
-    expr = 'isfinite(getrefcount(str("hello world!")))'
+    expr = 'math.isfinite(sys.getrefcount(str("hello world!")))'
 
     subst = PythonExpression([expr], ['sys', 'math'])
     try:
@@ -99,4 +113,4 @@ def test_python_substitution_two_modules():
 
     # Test the describe() method
     assert subst.describe() ==\
-        "PythonExpr('isfinite(getrefcount(str(\"hello world!\")))', ['sys', 'math'])"
+        "PythonExpr('math.isfinite(sys.getrefcount(str(\"hello world!\")))', ['sys', 'math'])"

--- a/launch/test/launch/substitutions/test_python_expression.py
+++ b/launch/test/launch/substitutions/test_python_expression.py
@@ -14,9 +14,7 @@
 
 """Tests for the PythonExpression substitution class."""
 
-import math
 import pytest
-import sys
 
 from launch import LaunchContext
 from launch.substitutions import PythonExpression
@@ -64,7 +62,7 @@ def test_python_substitution_empty_module_list():
         subst.perform(lc)
 
     # Test the describe() method
-    assert subst.describe() == "PythonExpr('ceil(1.6)')"
+    assert subst.describe() == "PythonExpr('ceil(1.6)', [])"
 
 
 def test_python_substitution_one_module():
@@ -72,7 +70,7 @@ def test_python_substitution_one_module():
     lc = LaunchContext()
     expr = 'getrefcount(str("hello world!"))'
 
-    subst = PythonExpression([expr], [sys])
+    subst = PythonExpression([expr], ['sys'])
     try:
         result = subst.perform(lc)
     except SubstitutionFailure:
@@ -90,7 +88,7 @@ def test_python_substitution_two_modules():
     lc = LaunchContext()
     expr = 'isfinite(getrefcount(str("hello world!")))'
 
-    subst = PythonExpression([expr], [sys, math])
+    subst = PythonExpression([expr], ['sys', 'math'])
     try:
         result = subst.perform(lc)
     except SubstitutionFailure:

--- a/launch/test/launch/substitutions/test_python_expression.py
+++ b/launch/test/launch/substitutions/test_python_expression.py
@@ -14,11 +14,11 @@
 
 """Tests for the PythonExpression substitution class."""
 
-import pytest
-
 from launch import LaunchContext
 from launch.substitutions import PythonExpression
 from launch.substitutions import SubstitutionFailure
+
+import pytest
 
 
 def test_python_substitution_missing_module():
@@ -88,7 +88,7 @@ def test_python_substitution_one_module():
     try:
         result = subst.perform(lc)
     except SubstitutionFailure:
-        pytest.fail("Failed to evaluate PythonExpression containing sys module.")
+        pytest.fail('Failed to evaluate PythonExpression containing sys module.')
 
     # A refcount should be some positive number
     assert int(result) > 0
@@ -106,7 +106,7 @@ def test_python_substitution_two_modules():
     try:
         result = subst.perform(lc)
     except SubstitutionFailure:
-        pytest.fail("Failed to evaluate PythonExpression containing sys module.")
+        pytest.fail('Failed to evaluate PythonExpression containing sys module.')
 
     # The expression should evaluate to True - the refcount is finite
     assert result

--- a/launch/test/launch/substitutions/test_python_expression.py
+++ b/launch/test/launch/substitutions/test_python_expression.py
@@ -1,0 +1,65 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PythonExpression substitution class."""
+
+import math
+import pytest
+import sys
+
+from launch import LaunchContext
+from launch.substitutions import PythonExpression
+from launch.substitutions import SubstitutionFailure
+
+
+def test_python_substitution_fail():
+    """Check that evaluation fails if we do not pass a needed module (sys)."""
+    lc = LaunchContext()
+    expr = 'getrefcount(str("hello world!"))'
+
+    subst = PythonExpression([expr])
+
+    # Should raise a NameError since it doesn't see the sys module
+    with pytest.raises(NameError):
+        subst.perform(lc)
+
+
+def test_python_substitution_one_module():
+    """Evaluation while passing one module."""
+    lc = LaunchContext()
+    expr = 'getrefcount(str("hello world!"))'
+
+    subst = PythonExpression([expr], [sys])
+    try:
+        result = subst.perform(lc)
+    except SubstitutionFailure:
+        pytest.fail("Failed to evaluate PythonExpression containing sys module.")
+
+    # A refcount should be some positive number
+    assert int(result) > 0
+
+
+def test_python_substitution_two_modules():
+    """Evaluation while passing two modules."""
+    lc = LaunchContext()
+    expr = 'isfinite(getrefcount(str("hello world!")))'
+
+    subst = PythonExpression([expr], [math, sys])
+    try:
+        result = subst.perform(lc)
+    except SubstitutionFailure:
+        pytest.fail("Failed to evaluate PythonExpression containing sys module.")
+
+    # The expression should evaluate to True - the refcount is finite
+    assert result

--- a/launch/test/temporary_environment.py
+++ b/launch/test/temporary_environment.py
@@ -40,7 +40,6 @@ class TemporaryEnvironment:
 
 def sandbox_environment_variables(func):
     """Decorate a function to give it a temporary environment."""
-
     @functools.wraps(func)
     def wrapper_func(*args, **kwargs):
         with TemporaryEnvironment():


### PR DESCRIPTION
Added ability to pass Python modules to the PythonExpression substitution.
Allows eval of more expressions.

For example, my motivating use case was:
`robot_desc = PythonExpression(["process_file('", filepath, "').toprettyxml(indent='  ')"], xacro.__dict__)`