### PR TITLE
Fix the restoring of os.environ to maintain type.

### DIFF
--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -169,10 +169,27 @@ class LaunchContext:
     def _pop_environment(self):
         if not self.__environment_stack:
             raise RuntimeError('environment stack unexpectedly empty')
-        os.environ = self.__environment_stack.pop()
+
+        # Note that we cannot just assign os.environ to the copy of the
+        # environment that we saved during _push_environment() above.
+        # That's because os.environ.copy() returns a dict, while os.environ
+        # is a os._Environ object.  They act the same in many, but not all
+        # circumstances.  Instead, when we go to pop the environment, we
+        # clear out the current environment and push the values from the
+        # copy one-by-one into os.environ.
+
+        old_env = self.__environment_stack.pop()
+        os.environ.clear()
+        for k, v in old_env.items():
+            os.environ[k] = v
 
     def _reset_environment(self):
-        os.environ = self.__environment_reset.copy()
+        # See the comment in _pop_environment for why we do this dance.
+
+        old_env = self.__environment_reset.copy()
+        os.environ.clear()
+        for k, v in old_env.items():
+            os.environ[k] = v
 
     def _push_launch_configurations(self):
         self.__launch_configurations_stack.append(self.__launch_configurations.copy())

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -180,15 +180,12 @@ class LaunchContext:
 
         old_env = self.__environment_stack.pop()
         os.environ.clear()
-        for k, v in old_env.items():
-            os.environ[k] = v
+        os.environ.update(old_env)
 
     def _reset_environment(self):
         # See the comment in _pop_environment for why we do this dance.
-
         os.environ.clear()
-        for k, v in self.__environment_reset.items():
-            os.environ[k] = v
+        os.environ.update(self.__environment_reset)
 
     def _push_launch_configurations(self):
         self.__launch_configurations_stack.append(self.__launch_configurations.copy())

--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -186,9 +186,8 @@ class LaunchContext:
     def _reset_environment(self):
         # See the comment in _pop_environment for why we do this dance.
 
-        old_env = self.__environment_reset.copy()
         os.environ.clear()
-        for k, v in old_env.items():
+        for k, v in self.__environment_reset.items():
             os.environ[k] = v
 
     def _push_launch_configurations(self):

--- a/launch/test/launch/actions/test_push_and_pop_environment.py
+++ b/launch/test/launch/actions/test_push_and_pop_environment.py
@@ -14,6 +14,8 @@
 
 """Tests for the PopEnvironment and PushEnvironment action classes."""
 
+import os
+
 from launch import LaunchContext
 from launch.actions import PopEnvironment
 from launch.actions import PushEnvironment
@@ -31,6 +33,8 @@ def test_push_and_pop_environment_constructors():
 @sandbox_environment_variables
 def test_push_and_pop_environment_execute():
     """Test the execute() of the PopEnvironment and PushEnvironment classes."""
+    assert(type(os.environ) == os._Environ)
+
     context = LaunchContext()
 
     # does not change empty state
@@ -83,3 +87,6 @@ def test_push_and_pop_environment_execute():
     assert len(context.environment) == 1
     assert 'foo' in context.environment
     assert context.environment['foo'] == 'FOO'
+
+    # Pushing and popping the environment should not change the type of os.environ
+    assert(type(os.environ) == os._Environ)


### PR DESCRIPTION
During the LaunchContext constructor or _push_environment(), we take a copy of the environment via os.environ.copy().  That function returns a dict, but it turns out that os.environ itself is an os._Environ object, not a dict.  Thus, when restoring the environment in either _pop_environment() or _reset_environment(), we cannot just set os.environ to that value.  Instead, we clear out the environment and then set the key/value pairs one-by-one into the environment.  That maintains os.environ as a os._Environ object while also performing the desired pop or reset of the environment variables.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>