### PR TITLE
Expect deprecation warnings in tests

### DIFF
--- a/launch/test/launch/conditions/test_launch_configuration_equals.py
+++ b/launch/test/launch/conditions/test_launch_configuration_equals.py
@@ -17,6 +17,8 @@
 from launch.conditions import LaunchConfigurationEquals
 from launch.substitutions import TextSubstitution
 
+import pytest
+
 
 def test_launch_configuration_equals():
     """Test LaunchConfigurationEquals class."""
@@ -47,7 +49,8 @@ def test_launch_configuration_equals():
     ]
 
     for name, value, expected in test_cases:
-        assert LaunchConfigurationEquals(
-            name,
-            [TextSubstitution(text=value)] if value is not None else None
-        ).evaluate(lc) is expected
+        with pytest.warns(UserWarning):
+            assert LaunchConfigurationEquals(
+                name,
+                [TextSubstitution(text=value)] if value is not None else None
+            ).evaluate(lc) is expected

--- a/launch/test/launch/conditions/test_launch_configuration_not_equals.py
+++ b/launch/test/launch/conditions/test_launch_configuration_not_equals.py
@@ -17,6 +17,8 @@
 from launch.conditions import LaunchConfigurationNotEquals
 from launch.substitutions import TextSubstitution
 
+import pytest
+
 
 def test_launch_configuration_not_equals():
     """Test LaunchConfigurationNotEquals class."""
@@ -47,7 +49,8 @@ def test_launch_configuration_not_equals():
     ]
 
     for name, value, expected in test_cases:
-        assert LaunchConfigurationNotEquals(
-            name,
-            [TextSubstitution(text=value)] if value is not None else None
-        ).evaluate(lc) is expected
+        with pytest.warns(UserWarning):
+            assert LaunchConfigurationNotEquals(
+                name,
+                [TextSubstitution(text=value)] if value is not None else None
+            ).evaluate(lc) is expected


### PR DESCRIPTION
The LaunchConfigurationEquals and LaunchConfigurationNotEquals conditions were deprecated in https://github.com/ros2/launch/pull/649. This change captures the expected warnings in their unit tests.