### PR TITLE
Expose sigterm_timeout and sigkill_timeout to xml frontend

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -224,12 +224,12 @@ class ExecuteLocal(Action):
 
     @property
     def sigkill_timeout(self):
-        """Getter for sigkill timeout"""
+        """Getter for sigkill timeout."""
         return self.__sigkill_timeout
 
     @property
     def sigterm_timeout(self):
-        """Getter for sigterm timeout"""
+        """Getter for sigterm timeout."""
         return self.__sigterm_timeout
 
     @property

--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -223,6 +223,16 @@ class ExecuteLocal(Action):
         return self.__shell
 
     @property
+    def sigkill_timeout(self):
+        """Getter for sigkill timeout"""
+        return self.__sigkill_timeout
+
+    @property
+    def sigterm_timeout(self):
+        """Getter for sigterm timeout"""
+        return self.__sigterm_timeout
+
+    @property
     def output(self):
         """Getter for output."""
         return self.__output

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -352,6 +352,26 @@ class ExecuteProcess(ExecuteLocal):
                     )
                 kwargs['respawn_delay'] = respawn_delay
 
+        if 'sigkill_timeout' not in ignore:
+            sigkill_timeout = entity.get_attr('sigkill_timeout', data_type=float, optional=True)
+            if sigkill_timeout is not None:
+                if sigkill_timeout < 0.0:
+                    raise ValueError(
+                        'Attribute sigkill_timeout of Entity node expected to be '
+                        'a non-negative value but got `{}`'.format(sigkill_timeout)
+                    )
+                kwargs['sigkill_timeout'] = sigkill_timeout
+
+        if 'sigterm_timeout' not in ignore:
+            sigterm_timeout = entity.get_attr('sigterm_timeout', data_type=float, optional=True)
+            if sigterm_timeout is not None:
+                if sigterm_timeout < 0.0:
+                    raise ValueError(
+                        'Attribute sigterm_timeout of Entity node expected to be '
+                        'a non-negative value but got `{}`'.format(sigterm_timeout)
+                    )
+                kwargs['sigterm_timeout'] = sigterm_timeout
+
         if 'shell' not in ignore:
             shell = entity.get_attr('shell', data_type=bool, optional=True)
             if shell is not None:

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -360,7 +360,7 @@ class ExecuteProcess(ExecuteLocal):
                         'Attribute sigkill_timeout of Entity node expected to be '
                         'a non-negative value but got `{}`'.format(sigkill_timeout)
                     )
-                kwargs['sigkill_timeout'] = parser.parse_substitution(str(sigkill_timeout))
+                kwargs['sigkill_timeout'] = str(sigkill_timeout)
 
         if 'sigterm_timeout' not in ignore:
             sigterm_timeout = entity.get_attr('sigterm_timeout', data_type=float, optional=True)
@@ -370,7 +370,7 @@ class ExecuteProcess(ExecuteLocal):
                         'Attribute sigterm_timeout of Entity node expected to be '
                         'a non-negative value but got `{}`'.format(sigterm_timeout)
                     )
-                kwargs['sigterm_timeout'] = parser.parse_substitution(str(sigterm_timeout))
+                kwargs['sigterm_timeout'] = str(sigterm_timeout)
 
         if 'shell' not in ignore:
             shell = entity.get_attr('shell', data_type=bool, optional=True)

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -360,7 +360,7 @@ class ExecuteProcess(ExecuteLocal):
                         'Attribute sigkill_timeout of Entity node expected to be '
                         'a non-negative value but got `{}`'.format(sigkill_timeout)
                     )
-                kwargs['sigkill_timeout'] = sigkill_timeout
+                kwargs['sigkill_timeout'] = parser.parse_substitution(str(sigkill_timeout))
 
         if 'sigterm_timeout' not in ignore:
             sigterm_timeout = entity.get_attr('sigterm_timeout', data_type=float, optional=True)
@@ -370,7 +370,7 @@ class ExecuteProcess(ExecuteLocal):
                         'Attribute sigterm_timeout of Entity node expected to be '
                         'a non-negative value but got `{}`'.format(sigterm_timeout)
                     )
-                kwargs['sigterm_timeout'] = sigterm_timeout
+                kwargs['sigterm_timeout'] = parser.parse_substitution(str(sigterm_timeout))
 
         if 'shell' not in ignore:
             shell = entity.get_attr('shell', data_type=bool, optional=True)

--- a/launch_xml/test/launch_xml/executable.xml
+++ b/launch_xml/test/launch_xml/executable.xml
@@ -1,5 +1,5 @@
 <launch>
-    <executable cmd="ls -l -a -s" cwd="/" name="my_ls" shell="true" output="log" launch-prefix="$(env LAUNCH_PREFIX '')">
+    <executable cmd="ls -l -a -s" cwd="/" name="my_ls" shell="true" output="log" sigkill_timeout="4.0" sigterm_timeout="7.0" launch-prefix="$(env LAUNCH_PREFIX '')">
         <env name="var" value="1"/>
     </executable>
 </launch>

--- a/launch_xml/test/launch_xml/test_executable.py
+++ b/launch_xml/test/launch_xml/test_executable.py
@@ -36,6 +36,8 @@ def test_executable():
     assert executable.name[0].perform(None) == 'my_ls'
     assert executable.shell is True
     assert executable.output[0].perform(None) == 'log'
+    assert executable.sigkill_timeout[0].perform(None) == '4.0'
+    assert executable.sigterm_timeout[0].perform(None) == '7.0'
     key, value = executable.additional_env[0]
     key = key[0].perform(None)
     value = value[0].perform(None)

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -32,6 +32,8 @@ def test_executable():
                 name: my_ls
                 shell: true
                 output: log
+                sigkill_timeout: 4.0
+                sigterm_timeout: 7.0
                 'launch-prefix': $(env LAUNCH_PREFIX '')
                 env:
                     -   name: var
@@ -48,6 +50,8 @@ def test_executable():
     assert(executable.name[0].perform(None) == 'my_ls')
     assert(executable.shell is True)
     assert(executable.output[0].perform(None) == 'log')
+    assert(executable.sigkill_timeout[0].perform(None) == '4.0')
+    assert(executable.sigterm_timeout[0].perform(None) == '7.0')
     key, value = executable.additional_env[0]
     key = key[0].perform(None)
     value = value[0].perform(None)


### PR DESCRIPTION
This PR exposes ``sigkill_timeout`` and ``sigterm_timeout`` arguments to xml frontends. Added a simple test for parsing using xml.

Signed-off-by: Aditya <aditya050995@gmail.com>