### PR TITLE
Add AndCondition, OrCondition to conditions

### DIFF
--- a/launch/launch/conditions/__init__.py
+++ b/launch/launch/conditions/__init__.py
@@ -14,18 +14,22 @@
 
 """conditions Module."""
 
+from .and_condition import AndCondition
 from .evaluate_condition_expression_impl import evaluate_condition_expression
 from .if_condition import IfCondition
 from .invalid_condition_expression_error import InvalidConditionExpressionError
 from .launch_configuration_equals import LaunchConfigurationEquals
 from .launch_configuration_not_equals import LaunchConfigurationNotEquals
+from .or_condition import OrCondition
 from .unless_condition import UnlessCondition
 
 __all__ = [
+    'AndCondition',
     'evaluate_condition_expression',
     'IfCondition',
     'InvalidConditionExpressionError',
     'LaunchConfigurationEquals',
     'LaunchConfigurationNotEquals',
+    'OrCondition',
     'UnlessCondition',
 ]

--- a/launch/launch/conditions/and_condition.py
+++ b/launch/launch/conditions/and_condition.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Module for AndCondition class."""
+
+from typing import List, Text, Union
+
+from .evaluate_condition_expression_impl import evaluate_condition_expression
+from ..condition import Condition
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..utilities import normalize_to_list_of_substitutions
+
+
+class AndCondition(Condition):
+    """
+    Encapsulates an and condition to be evaluated when launching.
+
+    This condition takes a list or tuple of string expressions that are lexically evaluated as
+    booleans, but the expressions may consist of launch.Substitution or launch.Condition instances.
+
+    This condition will raise a TypeError if a list or tuple is not provided.
+    """
+
+    def __init__(
+        self,
+        predicate_expressions: List[Union[SomeSubstitutionsType, Condition]]
+    ) -> None:
+        if isinstance(predicate_expressions, str) or len(predicate_expressions) == 1:
+            raise TypeError(
+                'Only given a single expression. Two or more expressions are expected.'
+            )
+        self.__conditions = []
+        to_be_normalized = []
+        # Separate Conditions to be evaluated on their own
+        for pe in predicate_expressions:
+            if isinstance(pe, Condition):
+                self.__conditions.append(pe)
+            else:
+                to_be_normalized.append(pe)
+        self.__substitutions = [
+            normalize_to_list_of_substitutions(condition) for condition in to_be_normalized
+        ]
+        super().__init__(predicate=self._predicate_func)
+
+    def _predicate_func(self, context: LaunchContext) -> bool:
+        return all(
+            [evaluate_condition_expression(context, sub) for sub in self.__substitutions]
+        ) and all([condition.evaluate(context) for condition in self.__conditions])
+
+    def describe(self) -> Text:
+        return self.__repr__()

--- a/launch/launch/conditions/or_condition.py
+++ b/launch/launch/conditions/or_condition.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Module for OrCondition class."""
+
+from typing import List, Text, Union
+
+from .evaluate_condition_expression_impl import evaluate_condition_expression
+from ..condition import Condition
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..utilities import normalize_to_list_of_substitutions
+
+
+class OrCondition(Condition):
+    """
+    Encapsulates an or condition to be evaluated when launching.
+
+    This condition takes a list or tuple of string expressions that are lexically evaluated as
+    booleans, but the expressions may consist of launch.Substitution instances.
+
+    This condition will raise a TypeError if a list or tuple is not provided.
+    """
+
+    def __init__(
+        self,
+        predicate_expressions: List[Union[SomeSubstitutionsType, Condition]]
+    ) -> None:
+        if isinstance(predicate_expressions, str) or len(predicate_expressions) == 1:
+            raise TypeError(
+                'Only given a single expression. Two or more expressions are expected.'
+            )
+        self.__conditions = []
+        to_be_normalized = []
+        # Separate Conditions to be evaluated on their own
+        for pe in predicate_expressions:
+            if isinstance(pe, Condition):
+                self.__conditions.append(pe)
+            else:
+                to_be_normalized.append(pe)
+        self.__substitutions = [
+            normalize_to_list_of_substitutions(condition) for condition in to_be_normalized
+        ]
+        super().__init__(predicate=self._predicate_func)
+
+    def _predicate_func(self, context: LaunchContext) -> bool:
+        return any(
+            [evaluate_condition_expression(context, sub) for sub in self.__substitutions]
+        ) or any([condition.evaluate(context) for condition in self.__conditions])
+
+    def describe(self) -> Text:
+        return self.__repr__()

--- a/launch/test/launch/conditions/test_and_condition.py
+++ b/launch/test/launch/conditions/test_and_condition.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# POSSIBILITY OF SUCH DAMAGE.
+
+from launch.conditions import AndCondition
+from launch.conditions import IfCondition
+
+import pytest
+
+
+def test_and_condition():
+    """Test AndCondition class."""
+    class MockLaunchContext:
+
+        def perform_substitution(self, substitution):
+            return substitution.perform(self)
+
+    lc = MockLaunchContext()
+    test_cases = [
+        (['true', 'True', 'TRUE', '1'], True),
+        (('true', 'True', 'TRUE', '1'), True),
+        (['true', 'false'], False),
+        (['false', 'false'], False),
+        (['true', IfCondition('true')], True),
+        (['true', IfCondition('false')], False),
+    ]
+
+    for conditions, expected in test_cases:
+        assert AndCondition(conditions).evaluate(lc) is expected
+
+    with pytest.raises(TypeError):
+        AndCondition('true').evaluate(lc)
+
+    with pytest.raises(TypeError):
+        AndCondition(['true']).evaluate(lc)

--- a/launch/test/launch/conditions/test_or_condition.py
+++ b/launch/test/launch/conditions/test_or_condition.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# POSSIBILITY OF SUCH DAMAGE.
+
+from launch.conditions import OrCondition
+from launch.conditions import IfCondition
+
+import pytest
+
+
+def test_or_condition():
+    """Test OrCondition class."""
+    class MockLaunchContext:
+
+        def perform_substitution(self, substitution):
+            return substitution.perform(self)
+
+    lc = MockLaunchContext()
+    test_cases = [
+        (['true', 'True', 'TRUE', '1'], True),
+        (('true', 'True', 'TRUE', '1'), True),
+        (['false', 'False', 'FALSE', '0'], False),
+        (['true', 'false'], True),
+        (['true', IfCondition('false')], True),
+        (['false', IfCondition('false')], False),
+    ]
+
+    for conditions, expected in test_cases:
+        assert OrCondition(conditions).evaluate(lc) is expected
+
+    with pytest.raises(TypeError):
+        OrCondition('true').evaluate(lc)
+
+    with pytest.raises(TypeError):
+        OrCondition(['true']).evaluate(lc)


### PR DESCRIPTION
This pull request adds `AndCondition` and `OrCondition` to the conditions module. These classes can be used to evaluate a list or tuple of strings or `Conditions`. Implementing this change would tidy up somewhat messy conditional statements like

```python
condition=(IfCondition(condition1) and IfCondition(condition2))
```

simplifying them to something like

```python
condition=AndCondition([condition1, condition2])
```

This change addresses the third "combine multiple conditions" option in #105.