### PR TITLE
Drop unused data_files entry for example_processes

### DIFF
--- a/launch_pytest/setup.py
+++ b/launch_pytest/setup.py
@@ -13,7 +13,6 @@ setup(
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages', [f'resource/{package_name}']),
-        (f'lib/{package_name}', glob.glob('example_processes/**')),
         (f'share/{package_name}', ['package.xml']),
         (
             f'share/{package_name}/examples',


### PR DESCRIPTION
This appears to be left over from copying the setup.py from launch_testing when this package was originally created. The glob doesn't match anything so it's not an error, but it can sometimes result in installing an empty directory.