### PR TITLE
Humble backport of #665: Allow ReadyToTest() usage in event handler

### DIFF
--- a/launch/launch/event_handlers/on_action_event_base.py
+++ b/launch/launch/event_handlers/on_action_event_base.py
@@ -19,6 +19,7 @@ from typing import Callable
 from typing import List  # noqa
 from typing import Optional
 from typing import Text
+from typing import Tuple
 from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
@@ -109,6 +110,13 @@ class OnActionEventBase(BaseEventHandler):
         if self.__actions_on_event:
             return self.__actions_on_event
         return self.__on_event(event, context)
+
+    def describe(self) -> Tuple[Text, List[SomeActionsType]]:
+        """Return a description tuple."""
+        text, actions = super().describe()
+        if self.__actions_on_event:
+            actions.extend(self.__actions_on_event)
+        return (text, actions)
 
     @property
     def handler_description(self) -> Text:

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import sys
 import unittest
 
 import launch
@@ -80,6 +81,25 @@ class TestNewStyleTestDescriptions(unittest.TestCase):
         def generate_test_description():
             return launch.LaunchDescription([
                 ReadyToTest()
+            ])
+
+        runs = make_test_run_for_dut(generate_test_description)
+        dut = LaunchTestRunner(
+            runs
+        )
+
+        dut.validate()  # Make sure this passes initial validation (probably redundant with above)
+        runs[0].normalized_test_description(ready_fn=lambda: None)
+
+    def test_event_triggered_launch_description(self):
+
+        def generate_test_description():
+            dummy = launch.actions.ExecuteProcess(cmd=[sys.executable, '-c', ''], output='screen')
+            return launch.LaunchDescription([
+                dummy,
+                launch.actions.RegisterEventHandler(
+                    launch.event_handlers.OnProcessExit(target_action=dummy, on_exit=ReadyToTest())
+                ),
             ])
 
         runs = make_test_run_for_dut(generate_test_description)


### PR DESCRIPTION
See https://github.com/ros2/launch/pull/665