### PR TITLE
add symlink to latest log directory

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -85,7 +85,8 @@ def _renew_latest_log_dir(*, log_dir):
     """
     Renew the symbolic link to the latest logging directory.
 
-    :param log_dir: the current logging directory 
+    :param log_dir: the current logging directory
+    :return True if the link was successfully created/updated, False otherwise
     """
     base_dir = os.path.dirname(log_dir)
     latest_dir = os.path.join(base_dir, 'latest')

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -81,6 +81,23 @@ def _make_unique_log_dir(*, base_path):
             return log_dir
 
 
+def _renew_latest_log_dir(*, log_dir):
+    """
+    Renew the symbolic link to the latest logging directory.
+
+    :param log_dir: the current logging directory 
+    """
+    base_dir = os.path.dirname(log_dir)
+    latest_dir = os.path.join(base_dir, 'latest')
+
+    if os.path.lexists(latest_dir):
+        if not os.path.islink(latest_dir):
+            return False
+        os.unlink(latest_dir)
+    os.symlink(log_dir, latest_dir, target_is_directory=True)
+    return True
+
+
 class LaunchConfig:
     """Launch Logging Configuration class."""
 
@@ -118,6 +135,18 @@ class LaunchConfig:
             self._log_dir = _make_unique_log_dir(
                 base_path=_get_logging_directory()
             )
+            try:
+                success = _renew_latest_log_dir(log_dir=self._log_dir)
+                if not success:
+                    import warnings
+                    warnings.warn(
+                        "Cannot create a symlink to latest log directory")
+
+            except OSError as e:
+                import warnings
+                warnings.warn(
+                    ("Cannot create a symlink to latest log directory: {}\n")
+                    .format(e))
 
         return self._log_dir
 

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -258,7 +258,13 @@ def fake_make_unique_log_dir(*, base_path):
     return base_path
 
 
+def fake_renew_latest_log_dir(*, log_dir):
+    # Passthrough; do not create the symlink
+    return True
+
+
 @mock.patch('launch.logging._make_unique_log_dir', mock.MagicMock(wraps=fake_make_unique_log_dir))
+@mock.patch("launch.logging._renew_latest_log_dir", mock.MagicMock(wraps=fake_renew_latest_log_dir))
 def test_get_logging_directory():
     launch.logging.launch_config.reset()
     os.environ.pop('ROS_LOG_DIR', None)

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -264,7 +264,10 @@ def fake_renew_latest_log_dir(*, log_dir):
 
 
 @mock.patch('launch.logging._make_unique_log_dir', mock.MagicMock(wraps=fake_make_unique_log_dir))
-@mock.patch("launch.logging._renew_latest_log_dir", mock.MagicMock(wraps=fake_renew_latest_log_dir))
+@mock.patch(
+    'launch.logging._renew_latest_log_dir',
+    mock.MagicMock(wraps=fake_renew_latest_log_dir)
+)
 def test_get_logging_directory():
     launch.logging.launch_config.reset()
     os.environ.pop('ROS_LOG_DIR', None)


### PR DESCRIPTION
Add a symbolic link (`latest`) to the last logging  directory.

I found it useful to have a direct link to the last directory. Right now I'm creating it manually in my main launch file but I think it could be done in this project directly.

If this doesn't fit this project feel free to close

Signed-off-by: Tonywelte <tony.welte@gmail.com>