### PR TITLE
Add maximum times for a process to respawn

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -618,10 +618,10 @@ class ExecuteLocal(Action):
                 and not self.__shutdown_future.done()\
                 and self.__respawn and abs(self.__respawn_max_retries) > 0:
             # if self.__respawn_max_retries == None, we respawn the process infinite times
-            # by using abs(self.__respawn_max_retries) we can track the 
+            # by using abs(self.__respawn_max_retries) we can track the
             # total amount of respawns using negative values.
             # discount 1 to self.__respawn_max_retries
-            self.__respawn_max_retries -= 1 
+            self.__respawn_max_retries -= 1
             if self.__respawn_delay is not None and self.__respawn_delay > 0.0:
                 # wait for a timeout(`self.__respawn_delay`) to respawn the process
                 # and handle shutdown event with future(`self.__shutdown_future`)

--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -217,9 +217,11 @@ class ExecuteLocal(Action):
                 self.__respawn_max_retries = respawn_max_retries
             else:
                 self.__logger = launch.logging.get_logger(
-                                self.__process_description.final_name)
-                self.__logger.warning("respawn_max_retries should be a positive integer.\
-                    Setting respawn_max_retries to infinite as default")
+                                    self.__process_description.final_name)
+                self.__logger.warning(
+                    "respawn_max_retries should be a positive integer.\
+                    Setting respawn_max_retries to infinite as default."
+                    )
                 self.__respawn_max_retries = -1
 
         self.__process_event_args = None  # type: Optional[Dict[Text, Any]]

--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -183,7 +183,8 @@ class ExecuteLocal(Action):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Either a boolean or a Substitution to be resolved at runtime. Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
-        :param: respawn_max_retries number of times to respawn the process. Defaults to infinite times.
+        :param: respawn_max_retries number of times to respawn the process.
+            Defaults to infinite times.
         """
         super().__init__(**kwargs)
         self.__process_description = process_description

--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -98,7 +98,7 @@ class ExecuteLocal(Action):
         ]] = None,
         respawn: Union[bool, SomeSubstitutionsType] = False,
         respawn_delay: Optional[float] = None,
-        respawn_max_retries: Optional[int] = None,
+        respawn_max_retries: int = -1,
         **kwargs
     ) -> None:
         """
@@ -183,8 +183,8 @@ class ExecuteLocal(Action):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Either a boolean or a Substitution to be resolved at runtime. Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
-        :param: respawn_max_retries number of times to respawn the process.
-            Defaults to infinite times.
+        :param: respawn_max_retries number of times to respawn the process. A negative value
+            will respawn an infinite number of times (this is the default behavior).
         """
         super().__init__(**kwargs)
         self.__process_description = process_description
@@ -210,20 +210,8 @@ class ExecuteLocal(Action):
         self.__respawn = normalize_typed_substitution(respawn, bool)
         self.__respawn_delay = respawn_delay
 
-        if not respawn_max_retries:
-            # a negative value for self.__respawn_max_retries means infinite respawns
-            self.__respawn_max_retries = -1
-        else:
-            if respawn_max_retries >= 0:
-                self.__respawn_max_retries = respawn_max_retries
-            else:
-                self.__logger = launch.logging.get_logger(
-                                    self.__process_description.final_name)
-                self.__logger.warning(
-                    "respawn_max_retries should be a positive integer.\
-                    Setting respawn_max_retries to infinite as default."
-                    )
-                self.__respawn_max_retries = -1
+        self.__respawn_max_retries = respawn_max_retries
+        self.__respawn_retries = 0
 
         self.__process_event_args = None  # type: Optional[Dict[Text, Any]]
         self._subprocess_protocol = None  # type: Optional[Any]
@@ -616,12 +604,11 @@ class ExecuteLocal(Action):
         if not context.is_shutdown\
                 and self.__shutdown_future is not None\
                 and not self.__shutdown_future.done()\
-                and self.__respawn and abs(self.__respawn_max_retries) > 0:
-            # if self.__respawn_max_retries == None, we respawn the process infinite times
-            # by using abs(self.__respawn_max_retries) we can track the
-            # total amount of respawns using negative values.
-            # discount 1 to self.__respawn_max_retries
-            self.__respawn_max_retries -= 1
+                and self.__respawn and \
+                (self.__respawn_max_retries < 0 or
+                 self.__respawn_retries < self.__respawn_max_retries):
+            # Increase the respawn_retries counter
+            self.__respawn_retries += 1
             if self.__respawn_delay is not None and self.__respawn_delay > 0.0:
                 # wait for a timeout(`self.__respawn_delay`) to respawn the process
                 # and handle shutdown event with future(`self.__shutdown_future`)

--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -183,8 +183,8 @@ class ExecuteLocal(Action):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Either a boolean or a Substitution to be resolved at runtime. Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
-        :param: respawn_max_retries number of times to respawn the process. A negative value
-            will respawn an infinite number of times (this is the default behavior).
+        :param: respawn_max_retries number of times to respawn the process if respawn is 'True'.
+                A negative value will respawn an infinite number of times (default behavior).
         """
         super().__init__(**kwargs)
         self.__process_description = process_description

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -232,6 +232,7 @@ class ExecuteProcess(ExecuteLocal):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
+        :param: respawn_amount number of times to respawn the process. Defaults to infinite times.
         """
         executable = Executable(cmd=cmd, prefix=prefix, name=name, cwd=cwd, env=env,
                                 additional_env=additional_env)

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -232,8 +232,8 @@ class ExecuteProcess(ExecuteLocal):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
-        :param: respawn_max_retries number of times to respawn the process. A negative value
-            will respawn an infinite number of times (this is the default behavior).
+        :param: respawn_max_retries number of times to respawn the process if respawn is 'True'.
+                A negative value will respawn an infinite number of times (default behavior).
         """
         executable = Executable(cmd=cmd, prefix=prefix, name=name, cwd=cwd, env=env,
                                 additional_env=additional_env)

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -232,7 +232,8 @@ class ExecuteProcess(ExecuteLocal):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
-        :param: respawn_max_retries number of times to respawn the process. Defaults to infinite times.
+        :param: respawn_max_retries number of times to respawn the process.
+            Defaults to infinite times.
         """
         executable = Executable(cmd=cmd, prefix=prefix, name=name, cwd=cwd, env=env,
                                 additional_env=additional_env)

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -232,8 +232,8 @@ class ExecuteProcess(ExecuteLocal):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
-        :param: respawn_max_retries number of times to respawn the process.
-            Defaults to infinite times.
+        :param: respawn_max_retries number of times to respawn the process. A negative value
+            will respawn an infinite number of times (this is the default behavior).
         """
         executable = Executable(cmd=cmd, prefix=prefix, name=name, cwd=cwd, env=env,
                                 additional_env=additional_env)

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -232,7 +232,7 @@ class ExecuteProcess(ExecuteLocal):
         :param: respawn if 'True', relaunch the process that abnormally died.
             Defaults to 'False'.
         :param: respawn_delay a delay time to relaunch the died process if respawn is 'True'.
-        :param: respawn_amount number of times to respawn the process. Defaults to infinite times.
+        :param: respawn_max_retries number of times to respawn the process. Defaults to infinite times.
         """
         executable = Executable(cmd=cmd, prefix=prefix, name=name, cwd=cwd, env=env,
                                 additional_env=additional_env)

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -346,6 +346,12 @@ class ExecuteProcess(ExecuteLocal):
             if respawn is not None:
                 kwargs['respawn'] = parser.parse_substitution(respawn)
 
+        if 'respawn_max_retries' not in ignore:
+            respawn_max_retries = entity.get_attr('respawn_max_retries', data_type=int,
+                                                  optional=True)
+            if respawn_max_retries is not None:
+                kwargs['respawn_max_retries'] = respawn_max_retries
+
         if 'respawn_delay' not in ignore:
             respawn_delay = entity.get_attr('respawn_delay', data_type=float, optional=True)
             if respawn_delay is not None:

--- a/launch/test/launch/test_execute_local.py
+++ b/launch/test/launch/test_execute_local.py
@@ -129,7 +129,7 @@ def test_execute_process_with_respawn():
 def test_execute_process_with_respawn_max_retries():
     """Test launching a process with respawn_max_retries attribute."""
     def on_exit_callback(event, context):
-        on_exit_callback.called_count += 1        
+        on_exit_callback.called_count += 1
         if on_exit_callback.called_count == expected_called_count:
             timer = TimerAction(
                 period=2.,   # wait to verify if the process continues to respawn itself
@@ -138,7 +138,6 @@ def test_execute_process_with_respawn_max_retries():
                 ]
             )
             timer.execute(context)
-            
     on_exit_callback.called_count = 0
 
     respawn_max_retries = 2   # we want the process to respawn this amount of times

--- a/launch/test/launch/test_execute_local.py
+++ b/launch/test/launch/test_execute_local.py
@@ -127,14 +127,23 @@ def test_execute_process_with_respawn():
 
 
 def test_execute_process_with_respawn_max_retries():
-    """Test launching a process with respaw_max_retries attribute."""
+    """Test launching a process with respawn_max_retries attribute."""
     def on_exit_callback(event, context):
-        on_exit_callback.called_count = on_exit_callback.called_count + 1
+        on_exit_callback.called_count += 1        
+        if on_exit_callback.called_count == expected_called_count:
+            timer = TimerAction(
+                period=2.,   # wait to verify if the process continues to respawn itself
+                actions=[
+                    Shutdown(reason='Timer expired')
+                ]
+            )
+            timer.execute(context)
+            
     on_exit_callback.called_count = 0
 
     respawn_max_retries = 2   # we want the process to respawn this amount of times
-    shutdown_time = 10.0   # leave enough time to actually test the respawn_max_retries
     expected_called_count = 3   # normal exit + respawn_max_retries exits
+    shutdown_time = 10.0   # security timer to kill the process
 
     def generate_launch_description():
         return LaunchDescription([

--- a/launch/test/launch/test_execute_local.py
+++ b/launch/test/launch/test_execute_local.py
@@ -132,7 +132,7 @@ def test_execute_process_with_respawn_max_retries():
         on_exit_callback.called_count = on_exit_callback.called_count + 1
     on_exit_callback.called_count = 0
 
-    respawn_max_retries = 2 # we want the process to respawn this amount of times
+    respawn_max_retries = 2   # we want the process to respawn this amount of times
     shutdown_time = 10.0   # leave enough time to actually test the respawn_max_retries
     expected_called_count = 3   # normal exit + respawn_max_retries exits
 

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -225,7 +225,7 @@ def test_execute_process_with_respawn_max_retries():
         on_exit_callback.called_count = on_exit_callback.called_count + 1
     on_exit_callback.called_count = 0
 
-    respawn_max_retries = 2 # we want the process to respawn this amount of times
+    respawn_max_retries = 2   # we want the process to respawn this amount of times
     shutdown_time = 10.0   # leave enough time to actually test the respawn_max_retries
     expected_called_count = 3   # normal exit + respawn_max_retries exits
 

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -220,14 +220,22 @@ def test_execute_process_with_respawn_substitution():
 
 
 def test_execute_process_with_respawn_max_retries():
-    """Test launching a process with respaw_max_retries attribute."""
+    """Test launching a process with respawn_max_retries attribute."""
     def on_exit_callback(event, context):
-        on_exit_callback.called_count = on_exit_callback.called_count + 1
+        on_exit_callback.called_count += 1        
+        if on_exit_callback.called_count == expected_called_count:
+            timer = TimerAction(
+                period=2.,   # wait to verify if the process continues to respawn itself
+                actions=[
+                    Shutdown(reason='Timer expired')
+                ]
+            )
+            timer.execute(context)            
     on_exit_callback.called_count = 0
 
     respawn_max_retries = 2   # we want the process to respawn this amount of times
-    shutdown_time = 10.0   # leave enough time to actually test the respawn_max_retries
     expected_called_count = 3   # normal exit + respawn_max_retries exits
+    shutdown_time = 10.0   # security timer to kill the process
 
     def generate_launch_description():
         return LaunchDescription([

--- a/launch/test/launch/test_execute_process.py
+++ b/launch/test/launch/test_execute_process.py
@@ -222,7 +222,7 @@ def test_execute_process_with_respawn_substitution():
 def test_execute_process_with_respawn_max_retries():
     """Test launching a process with respawn_max_retries attribute."""
     def on_exit_callback(event, context):
-        on_exit_callback.called_count += 1        
+        on_exit_callback.called_count += 1
         if on_exit_callback.called_count == expected_called_count:
             timer = TimerAction(
                 period=2.,   # wait to verify if the process continues to respawn itself
@@ -230,7 +230,7 @@ def test_execute_process_with_respawn_max_retries():
                     Shutdown(reason='Timer expired')
                 ]
             )
-            timer.execute(context)            
+            timer.execute(context)
     on_exit_callback.called_count = 0
 
     respawn_max_retries = 2   # we want the process to respawn this amount of times


### PR DESCRIPTION
Hi, on this PR I'm adding the following feature:

- Ability to set a maximum number of times for a process to respawn. `respawn_max_retries`

**Why?**
Sometimes I want a process (a Node) to respawn a few times in case there were any trouble within the system. But if the Node keeps failing over and over again then I want it to stop spawning or it would overflow my logs. To accomplish that I added an optional parameter to set up the max number of retries. By default, i.e. without setting this parameter, the behavior remains the same as it was, infinite retries.

**What changed?**
Added the parameter `respawn_max_retries` to both `ExecuteProcess` and `ExecuteLocal`.
Type: `int` [OPTIONAL]. Default = None, which ends up on infinite respawns.

**How I tested**

I modified the `talker_listener.launch.py` [launch file](https://github.com/ros2/demos/blob/rolling/demo_nodes_cpp/launch/topics/talker_listener.launch.py) inside `demo_nodes_cpp/launch/topics` folder with the following:
```
def generate_launch_description():
    return LaunchDescription([
        launch_ros.actions.Node(
            package='demo_nodes_cpp', executable='talker', output='screen'),
        launch_ros.actions.Node(
            package='demo_nodes_cpp', executable='listener', output='screen', respawn=True, respawn_max_retries=1),
    ])
```

1. Run `ros2 launch demo_nodes_cpp talker_listener.launch.py`
Two process spawned, `talker` and `listener` (to verify `ps -a`).

2. Now I killed the listener with `kill -SEGV $(pidof listener)`
On the publisher/listener terminal you should see the listener process died.

3. Verify that the listener process is respawned. Note that I settled `respawn_max_retries`=1.
4. Kill the process again  `kill -SEGV $(pidof listener)`
Now since the process was already respawned 1 time, it won't respawn anymore.


EDIT:
To run the tests added you can 
`colcon test --packages-select launch --return-code-on-test-failure --event-handlers=console_direct+`
Or if you just want to run the tests I added, called `test_execute_process_with_respawn_max_retries` you can run
`colcon test --packages-select launch --return-code-on-test-failure --event-handlers=console_direct+ --pytest-args -k max_retries` and this would inly run the functions I've created.

Signed-off-by: Santiago Aupi
