### PR TITLE
Enable document generation using rosdoc2 for ament_python pkgs

### DIFF
--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -55,7 +55,6 @@ release = '0.4.0'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',

--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -100,8 +100,9 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path .
-exclude_patterns: list[str] = []
+# This pattern also affects html_static_path and html_extra_path.
+#
+# exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -146,21 +146,21 @@ htmlhelp_basename = 'launchdoc'
 # -- Options for LaTeX output ------------------------------------------------
 
 # latex_elements: dict[str, str] = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
+#     # The paper size ('letterpaper' or 'a4paper').
 
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
+#     'papersize': 'letterpaper',
 
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
+#     # The font size ('10pt', '11pt' or '12pt').
 
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
+#     'pointsize': '10pt',
+
+#     # Additional stuff for the LaTeX preamble.
+
+#     'preamble': '',
+
+#     # Latex figure (float) alignment
+
+#     'figure_align': 'htbp',
 # }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -101,7 +101,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -144,7 +144,7 @@ htmlhelp_basename = 'launchdoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -28,6 +28,13 @@
 #
 import os
 import sys
+# The python interpreter that executes this conf.py file will not have this
+# package's modules in the system path which will lead to import failures when
+# running sphinx-autodoc. As a workaround, the sphinx_builder.py script in
+# rosdoc2 will copy this package's modules along with this conf.py into a folder
+# with the same name of this package within the docs_build directory.
+# Hence we add the parent folder to the system path so that the modules from
+# this package can be imported.
 sys.path.insert(0, os.path.abspath('..'))
 
 

--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -145,7 +145,7 @@ htmlhelp_basename = 'launchdoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements: dict[str, str] = {
+# latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
@@ -161,7 +161,7 @@ latex_elements: dict[str, str] = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
-}
+# }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,

--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -26,9 +26,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------
@@ -55,6 +55,7 @@ release = '0.4.0'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',

--- a/launch/doc/source/index.rst
+++ b/launch/doc/source/index.rst
@@ -11,7 +11,7 @@ Welcome to launch's documentation!
    :caption: Contents:
 
    architecture
-
+   modules
 
 
 Indices and tables

--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -162,7 +162,7 @@ class ExecuteLocal(Action):
             be overridden with the LaunchConfiguration called 'emulate_tty',
             the value of which is evaluated as true or false according to
             :py:func:`evaluate_condition_expression`.
-            Throws :py:exception:`InvalidConditionExpressionError` if the
+            Throws :py:exc:`InvalidConditionExpressionError` if the
             'emulate_tty' configuration does not represent a boolean.
         :param: output configuration for process output logging. Defaults to 'log'
             i.e. log both stdout and stderr to launch main log file and stderr to

--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -206,7 +206,7 @@ class ExecuteProcess(ExecuteLocal):
             be overridden with the LaunchConfiguration called 'emulate_tty',
             the value of which is evaluated as true or false according to
             :py:func:`evaluate_condition_expression`.
-            Throws :py:exception:`InvalidConditionExpressionError` if the
+            Throws :py:exc:`InvalidConditionExpressionError` if the
             'emulate_tty' configuration does not represent a boolean.
         :param: prefix a set of commands/arguments to precede the cmd, used for
             things like gdb/valgrind and defaults to the LaunchConfiguration

--- a/launch/launch/launch_description.py
+++ b/launch/launch/launch_description.py
@@ -81,7 +81,7 @@ class LaunchDescription(LaunchDescriptionEntity):
         """
         Return a list of :py:class:`launch.actions.DeclareLaunchArgument` actions.
 
-        See :py:method:`get_launch_arguments_with_include_launch_description_actions()`
+        See :py:meth:`get_launch_arguments_with_include_launch_description_actions()`
         for more details.
         """
         return [

--- a/launch/launch/launch_description_sources/any_launch_file_utilities.py
+++ b/launch/launch/launch_description_sources/any_launch_file_utilities.py
@@ -35,10 +35,10 @@ def get_launch_description_from_any_launch_file(
     """
     Load a given launch file (by path), and return the launch description from it.
 
-    :raise `InvalidLaunchFileError`: Failed to load launch file.
+    :raises `launch.invalid_launch_file_error.InvalidLaunchFileError`: Failed to load launch file.
         It's only showed with launch files without extension (or not recognized extensions).
-    :raise `SyntaxError`: Invalid file. The file may have a syntax error in it.
-    :raise `ValueError`: Invalid file. The file may not be a text file.
+    :raises `SyntaxError`: Invalid file. The file may have a syntax error in it.
+    :raises `ValueError`: Invalid file. The file may not be a text file.
     """
     loaders: List[Callable[[str], LaunchDescription]] =\
         [get_launch_description_from_frontend_launch_file]

--- a/launch/launch/substitutions/environment_variable.py
+++ b/launch/launch/substitutions/environment_variable.py
@@ -50,7 +50,7 @@ class EnvironmentVariable(Substitution):
         :param name: name of the environment variable.
         :param default_value: used when the environment variable doesn't exist.
             If `None`, the substitution is not optional.
-        :raise `SubstitutionFailure`:
+        :raises `launch.substitutions.substitution_failure.SubstitutionFailure`:
             If the environment variable doesn't exist and `default_value` is `None`.
         """
         super().__init__()

--- a/launch/launch/substitutions/this_launch_file_dir.py
+++ b/launch/launch/substitutions/this_launch_file_dir.py
@@ -50,7 +50,7 @@ class ThisLaunchFileDir(Substitution):
         If there is no current launch file, i.e. if run from a script, then an
         error is raised.
 
-        :raises: SubstitutionFailure if not in a launch file
+        :raises `launch.substitutions.substitution_failure.SubstitutionFailure`: if not in a launch file
         """
         if 'current_launch_file_directory' not in context.get_locals_as_dict():
             raise SubstitutionFailure(

--- a/launch/launch/substitutions/this_launch_file_dir.py
+++ b/launch/launch/substitutions/this_launch_file_dir.py
@@ -50,7 +50,8 @@ class ThisLaunchFileDir(Substitution):
         If there is no current launch file, i.e. if run from a script, then an
         error is raised.
 
-        :raises `launch.substitutions.substitution_failure.SubstitutionFailure`: if not in a launch file
+        :raises `launch.substitutions.substitution_failure.SubstitutionFailure`:
+            if not in a launch file
         """
         if 'current_launch_file_directory' not in context.get_locals_as_dict():
             raise SubstitutionFailure(

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -149,8 +149,8 @@ def extract_type(data_type: AllowedTypesType) -> Tuple[ScalarTypesType, bool]:
         `type_obj` is the object representing that type in Python. In the case of a list,
         it's the type of the items.
         e.g.:
-            `data_type = List[int]` -> `(int, True)`
-            `data_type = bool` -> `(bool, False)`
+        `data_type = List[int]` -> `(int, True)`
+        `data_type = bool` -> `(bool, False)`
     """
     is_list = False
     scalar_type: ScalarTypesType = cast(ScalarTypesType, data_type)
@@ -361,7 +361,7 @@ def is_substitution(x):
     This can be:
     - A :py:class:`launch.Substitution` instance.
     - A list of mixed `launch.Substitution` and `str` instances,
-        with at least one instance of the former.
+    with at least one instance of the former.
     """
     return (
         isinstance(x, Substitution) or
@@ -384,7 +384,7 @@ def normalize_typed_substitution(
     specific type.
 
     Example:
-    -------
+    --------
     ```python3
     class MyAction(Action):
         def __init__(self, my_int: Union[int, SomeSubstitutionsType]):

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -108,13 +108,13 @@ def is_typing_list(data_type: Any) -> bool:
     """
     Return `True` if data_type is `typing.List` or a subscription of it.
 
-    Examples
+    Examples:
     --------
-    ```python3
-    assert is_typing_list(typing.List)
-    assert is_typing_list(typing.List[int])
-    assert not is_typing_list(int)
-    ```
+    .. code-block:: python
+
+        assert is_typing_list(typing.List)
+        assert is_typing_list(typing.List[int])
+        assert not is_typing_list(int)
 
     """
     return data_type is List or (

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -384,7 +384,7 @@ def normalize_typed_substitution(
     specific type.
 
     Example:
-    --------
+    -------
     .. code-block:: python
 
         class MyAction(Action):

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -108,7 +108,7 @@ def is_typing_list(data_type: Any) -> bool:
     """
     Return `True` if data_type is `typing.List` or a subscription of it.
 
-    Examples:
+    Examples
     --------
     .. code-block:: python
 

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -384,17 +384,17 @@ def normalize_typed_substitution(
     specific type.
 
     Example:
-    --------
-    ```python3
-    class MyAction(Action):
-        def __init__(self, my_int: Union[int, SomeSubstitutionsType]):
-            self.__my_int_normalized = normalize_typed_substitution(some_int, int)
-            ...
 
-        def execute(self, context):
-            my_int = perform_typed_substitution(context, self.__my_int_normalized, int)
-            ...
-    ```
+    .. code-block:: python
+
+        class MyAction(Action):
+            def __init__(self, my_int: Union[int, SomeSubstitutionsType]):
+                self.__my_int_normalized = normalize_typed_substitution(some_int, int)
+                ...
+
+            def execute(self, context):
+                my_int = perform_typed_substitution(context, self.__my_int_normalized, int)
+                ...
 
     List of substitutions coerced a list to strings can be confused with a single substitution
     that is coerced to a list of strings.

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -384,7 +384,7 @@ def normalize_typed_substitution(
     specific type.
 
     Example:
-
+    --------
     .. code-block:: python
 
         class MyAction(Action):


### PR DESCRIPTION
Fix missing `exec_depends` in `package.xmls` and docstrings to generate documentation without most warnings using `autodoc`

>Note: One one warning is pending. Can be addressed in a future PR
```
ws_rosdoc2/docs_build/launch/launch/event_handlers/event_named.py:docstring of launch.event_handlers.event_named:1: WARNING: duplicate object description of launch.event_handlers.event_named, other instance in launch.event_handlers, use :noindex: for one of them
```