### PR TITLE
[rosdoc2] Fix document generation on buildfarm

### DIFF
--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -35,7 +35,7 @@ import sys
 # with the same name of this package within the docs_build directory.
 # Hence we add the parent folder to the system path so that the modules from
 # this package can be imported.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------

--- a/launch/package.xml
+++ b/launch/package.xml
@@ -17,9 +17,14 @@
 
   <depend>osrf_pycommon</depend>
 
+  <!-- The rosdep key for python3 lark module is python3-lark-parser.
+  rosdoc2 will mock "lark-parser" however the module is imported as "lark".
+  Hence, to mock the import of the lark module, we add this doc depend. -->
+  <doc_depend>lark</doc_depend>
+
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
-  <exec_depend>python3-lark</exec_depend>
+  <exec_depend>python3-lark-parser</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/launch/package.xml
+++ b/launch/package.xml
@@ -19,7 +19,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
-  <exec_depend>python3-lark-parser</exec_depend>
+  <exec_depend>python3-lark</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Doc job on buildfarm is failing for `launch` with the error below
```
21:11:15     import logging
21:11:15   File "/tmp/ws/docs_build/launch/launch/logging/__init__.py", line 21, in <module>
21:11:15     import logging.handlers
21:11:15   File "/tmp/ws/docs_build/launch/launch/logging/handlers.py", line 79, in <module>
21:11:15     sys.modules[__name__] = _module_wrapper(sys.modules[__name__])
21:11:15   File "/tmp/ws/docs_build/launch/launch/logging/handlers.py", line 61, in __init__
21:11:15     for module in (logging, logging.handlers):
21:11:15 AttributeError: partially initialized module 'logging' has no attribute 'handlers' (most likely due to a circular import)
```

This reason and fix for this is described here https://github.com/ros-infrastructure/rosdoc2/pull/52

This PR updates the path added to sys.path within conf.py. With the PR above, the entire module folder will be copied over to the same location as this conf.py file within `docs_build/`. Hence, we need to append the current working dir to the `sys.path` such that the modules can be imported correctly.

In addition to this, added `lark` as a `<doc_depend>` to explicitly mock `lark` imports since rosdoc2 will mock `lark-parser` given that the rosdep key is `python3-lark-parser`. 