### PR TITLE
Fix #666 handle SIGTERM

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -185,15 +185,16 @@ class LaunchService:
 
             self.__this_task = this_task
             # Setup custom signal handlers for SIGINT & SIGTERM
-            signals_received: dict = {}
+            signals_received = set()
 
             def _on_signal(signum):
                 nonlocal signals_received
-                base_msg = 'caught ' + signal.Signals(signum).name
-                if signum not in signals_received or signals_received[signum] is not True:
-                    signals_received[signum] = True
+                signal_name = signal.Signals(signum).name
+                base_msg = 'caught ' + signal_name
+                if signal_name not in signals_received:
+                    signals_received.add(signal_name)
+                    due_to_sigint = True if signal_name == 'SIGINT' else False
                     self.__logger.warning(base_msg)
-                    due_to_sigint = True if signal.Signals(signum).name == 'SIGINT' else False
                     ret = self._shutdown(
                         reason=base_msg, due_to_sigint=due_to_sigint, force_sync=True
                     )

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -185,7 +185,7 @@ class LaunchService:
                 this_task = asyncio.Task.current_task(this_loop)
 
             self.__this_task = this_task
-            # Setup custom signal handlers for SIGINT, SIGTERM and maybe SIGQUIT.
+            # Setup custom signal handlers for SIGINT & SIGTERM
             sigint_received = False
 
             def _on_sigint(signum):
@@ -214,8 +214,6 @@ class LaunchService:
                 # Setup signal handlers
                 manager.handle(signal.SIGINT, _on_sigint)
                 manager.handle(signal.SIGTERM, _on_sigterm)
-                if platform.system() != 'Windows':
-                    manager.handle(signal.SIGQUIT, _on_sigterm)
                 # Yield asyncio loop and current task.
                 yield this_loop, this_task
         finally:

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -193,8 +193,9 @@ class LaunchService:
                 if signum not in signals_received or signals_received[signum] is not True:
                     signals_received[signum] = True
                     self.__logger.warning(base_msg)
+                    due_to_sigint = True if signal.Signals(signum).name == 'SIGINT' else False
                     ret = self._shutdown(
-                        reason=base_msg, due_to_sigint=True, force_sync=True
+                        reason=base_msg, due_to_sigint=due_to_sigint, force_sync=True
                     )
                     assert ret is None, ret
                 else:

--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -18,7 +18,6 @@ import asyncio
 import collections.abc
 import contextlib
 import logging
-import platform
 import signal
 import threading
 import traceback

--- a/launch/launch/utilities/signal_management.py
+++ b/launch/launch/utilities/signal_management.py
@@ -235,6 +235,7 @@ class AsyncSafeSignalManager:
         :return: previous handler if any, otherwise None
         """
         signum = signal.Signals(signum)
+        signal.signal(signum, signal.default_int_handler)
         if handler is not None:
             if not callable(handler):
                 raise ValueError('signal handler must be a callable')

--- a/launch/test/launch/utilities/test_signal_management.py
+++ b/launch/test/launch/utilities/test_signal_management.py
@@ -25,19 +25,19 @@ import osrf_pycommon.process_utils
 
 
 def cap_signals(*signals):
-    def _noop(*args):
-        pass
-
     def _decorator(func):
         @functools.wraps(func)
         def _wrapper(*args, **kwargs):
             handlers = {}
             try:
                 for s in signals:
-                    handlers[s] = signal.signal(s, _noop)
+                    handlers[s] = signal.signal(s, signal.default_int_handler)
                 return func(*args, **kwargs)
+            except KeyboardInterrupt:
+                pass
             finally:
-                assert all(signal.signal(s, h) is _noop for s, h in handlers.items())
+                assert all(signal.signal(s, h) is signal.default_int_handler
+                           for s, h in handlers.items())
         return _wrapper
 
     return _decorator


### PR DESCRIPTION
Fixes #666

### SIGTERM

Instead of installing signal handlers with the OS directly, ROS2 Launch uses Python's `signal.set_wakeup_fd` to queue and forward signals to handlers registered from the async event loop.

Although one of these handlers has been set for SIGTERM, it never gets called since when that signal gets delivered, the kernel terminates the process immediately. The process never changes the default disposition of that signal. Delivery of SIGINT however, doesn't cause the kernel to terminate the process, and instead that signal get dutifully forwarded to the appropriate handler. This is despite there being no difference in the ROS2 Launch code in setting them both up.

After running an strace on a one-line Python program and seeing that a handler was still automatically installed for SIGINT, I came across this ![StackOverflow post](https://stackoverflow.com/questions/40775054/capturing-sigint-using-keyboardinterrupt-exception-works-in-terminal-not-in-scr/40785230#40785230). Depending on whether a Python script is run in some combination of foreground process and in an interactive shell, a handler will be installed for SIGINT for use in the `KeyboardInterrupt` exception. It just so happens that it also gets forwarded by `signal.set_wakeup_fd`, and since the handler prevents the program from being automatically terminated, it can actually do so.

This is why the handler for SIGINT by chance works, but the one for SIGTERM does not.

The fix for this was to simply install the default interrupt signal handler on any signal the async event loop requested handled, so that they would no longer cause the program to terminate and instead be forwarded to `signal.set_wakeup_fd`.

### SIGQUIT

SIGQUIT signals are often generated by the user hitting 'CTRL+\' in an interactive shell. However, when the terminal driver receives those characters, it doesn't just send a SIGQUIT to the running process, but to the entire foreground process group.

By default, the ROS2 Client Libraries don't register a handler for SIGQUIT, as they do for SIGINT and SIGTERM, so the ROS2 node will be terminated immediately and its core dumpted on receipt. So there is little reason for ROS2 Launch to catch this signal or the purposes of forwarding it on to its children.

Also, not catching SIGQUIT means that if there is a problem with the Python signal handling, then the user still has available a shortcut on their keyboards to unilaterally kill the process.

The signal handler for SIGQUIT was removed.

### Future work

This Pull Request allows ROS2 Launch to handle SIGTERMs and initiate shutdown, but sends SIGINTs instead of SIGTERMs to the child processes. This will usually be fine since the ROS2 Client Libraries install handlers for both SIGINT and SIGTERM by default, and is no worse than the current situation, but it would be more flexible to allow users to send whatever signals they want to their nodes.

To do this would require removing the `due_to_sigint` and `send_sigint` arguments of many functions and replacing them with an argument passing the name of the signal to be forwarded. Care would need to be taken of other signals besides SIGINT such as SIGQUIT and SIGTSTP that also tend to get sent to the entire process group to avoid duplicates. Currently if the child node doesn't shutdown within 5 seconds an "escalated" SIGTERM is sent - but if SIGTERM was the initial signal then should it progress straight to SIGKILL? Or wait 10 seconds?

If others feel this is worth developing let me know and I'll work on another PR, but I feel this is in good shape now and will already be of benefit to others upstream.

@wjwwood - mentioned in the relevant ToDo for this feature