### PR TITLE
Add in a timeout for launch pytests.

### DIFF
--- a/launch/pytest.ini
+++ b/launch/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 junit_family=xunit2
 addopts = --doctest-modules
+timeout=900
+timeout_method=thread


### PR DESCRIPTION
We recently had a PR where the tests for launch hung, and this hung the CI job forever.  Avoid this by adding in a 900 second timeout for the launch tests.  Given that our current launch tests take ~200 seconds on our slowest platform, this should be plenty of overhead to ensure we have no "flakes".