### PR TITLE
[Draft] Added syslog handler for launch log

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -110,6 +110,7 @@ class LaunchConfig:
         self._log_dir = None
         self.file_handlers = {}
         self.screen_handler = None
+        self.syslog_handler = None
         self.screen_formatter = None
         self.file_formatter = None
         self._log_handler_factory = None
@@ -250,6 +251,17 @@ class LaunchConfig:
             self.screen_handler.setFormatter(self.screen_formatter)
         return self.screen_handler
 
+    def get_syslog_handler(self):
+        """
+        Get the one and only syslog handler
+        """
+        if self.syslog_handler is None:
+            self.syslog_handler = logging.handlers.SysLogHandler(address='/dev/log', facility='local1')
+
+            if self.file_formatter:
+                self.syslog_handler.setFormatter(self.file_formatter)
+        return self.syslog_handler
+
     def set_log_format(self, log_format, *, log_style=None):
         """
         Set up launch log file format.
@@ -275,6 +287,8 @@ class LaunchConfig:
             )
             for handler in self.file_handlers.values():
                 handler.setFormatter(self.file_formatter)
+            if self.syslog_handler:
+                self.syslog_handler.setFormatter(self.file_formatter)
         else:
             self.file_formatter = None
 
@@ -328,6 +342,10 @@ def get_logger(name=None) -> logging.Logger:
     launch_log_file_handler = launch_config.get_log_file_handler()
     if launch_log_file_handler not in logger.handlers:
         logger.addHandler(launch_log_file_handler)
+    syslog_handler = launch_config.get_syslog_handler()
+    if syslog_handler not in logger.handlers:
+        logger.addHandler(syslog_handler)
+
     return logger
 
 


### PR DESCRIPTION
This PR adds initial support for writing to the syslog. 
It goes hand in hand with: https://github.com/ros2/rcl_logging/pull/105
In combination it allows to write the whole log a ros2 application creates to the syslog. Both PRs use 'local1' as facility which allows to redirect the whole log into a seperate log file or even a remote logging server without the need for additional configuration inside the ros2 logging system. (Everything can be configured in rsyslog.conf)

And also answers my question from #736 

## Why do we need it

In enterprise environments it can be desirable to store the whole application log on a remote logging server. Utilizing rsyslog for providing this functionality is an easy and established way.

Just grabbing `/rosout` won't suffice as we cannot grab all parts of the log. 

## What is missing so far:

1. Allow configuring the SysLogHandler (address, facility)
2. Allow to disable/enable the SysLogHandler
3. Implement custom formatter / do not reuse the file_formatter

## How to test it:

I redirected the 'local1' facility to `/var/log/local1.log`. This allows testing without spamming into your normal syslog.

```
sudo touch /var/log/local1.log
sudo chown syslog /var/log/local1.log
```

Edit ` /etc/rsyslog.d/50-default.conf`
And add the line:

```
local1.*                        -/var/log/local1.log
```
Restart rsyslog

```
sudo systemctl restart rsyslog.service 
```

Afterwards you should see the most basic output written into the file. 
Eg:

```
Oct 11 08:33:01 my_pc 1697005981.4697814 [INFO] [launch]: All log files can be found below /home/my_user/.ros/log/2023-10-11-08-33-01-469156-my_pc-2027270

```

## Some additional notes

The current implementation grabs on purpose only the parts of the log which can't be grabbed via rcl_logging  (https://github.com/ros2/rcl_logging/pull/105). Otherwise some log messages would occur twice in the syslog. 
