### PR TITLE
Add exception type to error output

### DIFF
--- a/launch/launch/invalid_launch_file_error.py
+++ b/launch/launch/invalid_launch_file_error.py
@@ -32,7 +32,7 @@ class InvalidLaunchFileError(Exception):
             ).format('multiple exceptions' if len(self._likely_errors) > 1 else 'exception',
                      self._extension)
             for error in self._likely_errors:
-                self._error_message += '\n - {}'.format(error)
+                self._error_message += '\n - {}: {}'.format(type(error).__name__, error)
 
             self.__cause__ = self._likely_errors[0]
 

--- a/launch/test/launch/test_invalid_launch_file_error.py
+++ b/launch/test/launch/test_invalid_launch_file_error.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/test/launch/test_invalid_launch_file_error.py
+++ b/launch/test/launch/test_invalid_launch_file_error.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch.invalid_launch_file_error import InvalidLaunchFileError
+
+
+def test_invalid_launch_file_error():
+    try:
+        exception = KeyError('Test')
+        raise InvalidLaunchFileError(extension='.py', likely_errors=[exception])
+    except InvalidLaunchFileError as ex:
+        assert 'KeyError' in ex.__str__()
+
+
+def test_invalid_launch_file_errors():
+    try:
+        exceptions = [ValueError('Test1'), AttributeError('Test2'), BufferError('Test3')]
+        raise InvalidLaunchFileError(extension='.py', likely_errors=exceptions)
+    except InvalidLaunchFileError as ex:
+        assert 'ValueError' in ex.__str__()
+        assert 'AttributeError' in ex.__str__()
+        assert 'BufferError' in ex.__str__()


### PR DESCRIPTION
Knowing the type of exception that occurred provides more context and makes launch exceptions easier to track down.