### PR TITLE
Ignore ModuleNotFoundError in entry point discovery

### DIFF
--- a/launch_testing/launch_testing/pytest/hooks.py
+++ b/launch_testing/launch_testing/pytest/hooks.py
@@ -180,7 +180,7 @@ def find_launch_test_entrypoint(path):
             # Assume we got legacy path in earlier versions of pytest
             module = path.pyimport()
         return getattr(module, 'generate_test_description', None)
-    except SyntaxError:
+    except (ModuleNotFoundError, SyntaxError):
         return None
 
 


### PR DESCRIPTION
This prevents pytest (or colcon test) from failing if a module imports a missing dependency.
