### PR TITLE
Some small cleanups to launch

### DIFF
--- a/launch/launch/launch_context.py
+++ b/launch/launch/launch_context.py
@@ -52,24 +52,24 @@ class LaunchContext:
         self.__argv = argv if argv is not None else []
         self.__noninteractive = noninteractive
 
-        self._event_queue = asyncio.Queue()  # type: asyncio.Queue
-        self._event_handlers = collections.deque()  # type: collections.deque
-        self._completion_futures = []  # type: List[asyncio.Future]
+        self._event_queue: asyncio.Queue = asyncio.Queue()
+        self._event_handlers: collections.deque = collections.deque()
+        self._completion_futures: List[asyncio.Future] = []
 
-        self.__globals = {}  # type: Dict[Text, Any]
-        self.__locals_stack = []  # type: List[Dict[Text, Any]]
-        self.__locals = {}  # type: Dict[Text, Any]
-        self.__combined_locals_cache = None  # type: Optional[Dict[Text, Any]]
+        self.__globals: Dict[Text, Any] = {}
+        self.__locals_stack: List[Dict[Text, Any]] = []
+        self.__locals: Dict[Text, Any] = {}
+        self.__combined_locals_cache: Optional[Dict[Text, Any]] = None
 
-        self.__launch_configurations_stack = []  # type: List[Dict[Text, Text]]
-        self.__launch_configurations = {}  # type: Dict[Text, Text]
+        self.__launch_configurations_stack: List[Dict[Text, Text]] = []
+        self.__launch_configurations: Dict[Text, Text] = {}
 
-        self.__environment_stack = []  # type: List[Mapping[Text, Text]]
+        self.__environment_stack: List[Mapping[Text, Text]] = []
         # We will reset to this copy when "reset_environment" is called
-        self.__environment_reset = os.environ.copy()  # type: Mapping[Text, Text]
+        self.__environment_reset: Mapping[Text, Text] = os.environ.copy()
 
         self.__is_shutdown = False
-        self.__asyncio_loop = None  # type: Optional[asyncio.AbstractEventLoop]
+        self.__asyncio_loop: Optional[asyncio.AbstractEventLoop] = None
 
         self.__logger = launch.logging.get_logger(__name__)
 

--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -511,7 +511,7 @@ def get_output_loggers(process_name, output_config):
 
 # Mypy does not support dynamic base classes, so workaround by typing the base
 # class as Any
-_Base = logging.getLoggerClass()  # type: Any
+_Base: Any = logging.getLoggerClass()
 
 
 # Track all loggers to support module resets

--- a/launch_pytest/launch_pytest/plugin.py
+++ b/launch_pytest/launch_pytest/plugin.py
@@ -213,7 +213,7 @@ def from_parent(cls, *args, **kwargs):
 # Part of this function was adapted from
 # https://github.com/pytest-dev/pytest-asyncio/blob/f21e0da345f877755b89ff87b6dcea70815b4497/pytest_asyncio/plugin.py#L37-L50.
 # See their license https://github.com/pytest-dev/pytest-asyncio/blob/master/LICENSE.
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_pycollect_makeitem(collector, name, obj):
     """Collect coroutine based launch tests."""
     if collector.funcnamefilter(name) and is_valid_test_item(obj):
@@ -275,7 +275,7 @@ def is_same_launch_test_fixture(left_item, right_item):
     return get_fixture_params(left_item) == get_fixture_params(right_item)
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(session, config, items):
     """Move shutdown tests after normal tests."""
     def enumerate_reversed(sequence):


### PR DESCRIPTION
1.  Cleanup some type annotations.  In particular, use the inline style of type annotations, rather than the comments, as this is what we do everywhere else.  It will also make newer versions of mypy happier.
2.  Change the pytest markers tryfirst/trylast to using hookimpl, since the former are deprecated and throw warnings on newer versions of pytest.