### PR TITLE
Stop using python_cmake_module.

### DIFF
--- a/launch_testing_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ament_cmake/CMakeLists.txt
@@ -24,10 +24,6 @@ if(BUILD_TESTING)
       message(FATAL_ERROR "launch_testing package not found")
   endif()
 
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-
   # Test argument passing.  This test won't pass unless you give it an argument
   add_launch_test(
     "${LAUNCH_TESTING_INSTALL_PREFIX}/share/launch_testing/examples/args_launch_test.py"

--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -60,12 +60,7 @@ macro(parse_launch_test_arguments namespace filename)
   endif()
 
   if(NOT ${namespace}_PYTHON_EXECUTABLE)
-    set(${namespace}_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-    if(WIN32)
-      if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(${namespace}_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-      endif()
-    endif()
+    set(${namespace}_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
   endif()
 
   set(${namespace}_FILE_NAME NOTFOUND)

--- a/launch_testing_ament_cmake/launch_testing_ament_cmake-extras.cmake
+++ b/launch_testing_ament_cmake/launch_testing_ament_cmake-extras.cmake
@@ -13,8 +13,5 @@
 # limitations under the License.
 
 find_package(ament_cmake_test REQUIRED)
-# Provides PYTHON_EXECUTABLE_DEBUG
-find_package(python_cmake_module REQUIRED)
-find_package(PythonExtra REQUIRED)
 
 include("${launch_testing_ament_cmake_DIR}/add_launch_test.cmake")

--- a/launch_testing_ament_cmake/package.xml
+++ b/launch_testing_ament_cmake/package.xml
@@ -21,12 +21,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
-  <buildtool_export_depend>python_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>launch_testing</buildtool_export_depend>
 
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>launch_testing</test_depend>
-  <test_depend>python_cmake_module</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
We really don't need it anymore, and can just use the builtin find_package(Python3).

This must be merged before https://github.com/ros2/ros2/pull/1524 ; see that pull request for more information about this change.