### PR TITLE
launch_xml: fix xml syntax in README

### DIFF
--- a/launch_xml/README.md
+++ b/launch_xml/README.md
@@ -68,7 +68,7 @@ In this xml:
 <executable cmd="ls">
     <env name="a" value="100"/>
     <env name="b" value="stuff"/>
-</node>
+</executable>
 ```
 
 The `env` children could be accessed like:


### PR DESCRIPTION
I noticed some incorrect XML syntax in the `launch_xml` README, and this fixes it.