### PR TITLE
Fix a warning in modern unittest.

### DIFF
--- a/launch_testing/launch_testing/markers.py
+++ b/launch_testing/launch_testing/markers.py
@@ -49,7 +49,11 @@ def retry_on_failure(*, times, delay=None):
                         assert self._outcome.success
                     return ret
                 except AssertionError:
-                    self._outcome.errors.clear()
+                    if hasattr(self._outcome, 'errors'):
+                        self._outcome.errors.clear()
+                    else:
+                        if self._outcome.result is not None:
+                            self._outcome.result.errors.clear()
                     self._outcome.success = True
                     n -= 1
                 if delay is not None:


### PR DESCRIPTION
Newer versions of unittest no longer store an errors list; instead, they store a result, which then stores an error list.  Update the code here to be able to deal with either version.