### PR TITLE
Don't write Python bytecode when invoking launch tests

### DIFF
--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -133,6 +133,7 @@ function(add_launch_test filename)
     COMMAND ${cmd}
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/launch_test/${_launch_test_TARGET}.txt"
     RESULT_FILE "${_launch_test_RESULT_FILE}"
+    ENV PYTHONDONTWRITEBYTECODE=1
     TIMEOUT "${_launch_test_TIMEOUT}"
     ${_launch_test_UNPARSED_ARGUMENTS}
   )


### PR DESCRIPTION
This should prevent pytest invocations via `add_launch_test` from writing `__pycache__` directories into the package sources.

See also: colcon/colcon-core#611, ament/ament_cmake#533

https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE