### PR TITLE
Allows substitutions with Python Standard Path Objects with `PathSubstitutions`

### DIFF
--- a/launch/launch/launch_description_sources/python_launch_description_source.py
+++ b/launch/launch/launch_description_sources/python_launch_description_source.py
@@ -14,6 +14,8 @@
 
 """Module for the PythonLaunchDescriptionSource class."""
 
+from typing import Text
+
 from .python_launch_file_utilities import get_launch_description_from_python_launch_file
 from ..launch_description_source import LaunchDescriptionSource
 from ..some_substitutions_type import SomeSubstitutionsType
@@ -46,6 +48,6 @@ class PythonLaunchDescriptionSource(LaunchDescriptionSource):
             'interpreted python launch file'
         )
 
-    def _get_launch_description(self, location):
+    def _get_launch_description(self, location: Text):
         """Get the LaunchDescription from location."""
         return get_launch_description_from_python_launch_file(location)

--- a/launch/launch/substitutions/path_substitution.py
+++ b/launch/launch/substitutions/path_substitution.py
@@ -1,0 +1,49 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the PathSubstitution substitution."""
+
+from pathlib import Path
+from typing import Text
+
+from ..launch_context import LaunchContext
+from ..substitution import Substitution
+
+
+class PathSubstitution(Substitution):
+    """Substitution that wraps a single string text."""
+
+    def __init__(self, *, path: Path) -> None:
+        """Create a PathSubstitution."""
+        super().__init__()
+
+        if not isinstance(path, Path):
+            raise TypeError(
+                "PathSubstitution expected Text object got '{}' instead.".format(type(path))
+            )
+
+        self.__text = path
+
+    @property
+    def path(self) -> Path:
+        """Getter for text."""
+        return self.__text
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return "'{}'".format(self.path)
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution by returning the string itself."""
+        return str(self.path)

--- a/launch/launch/utilities/class_tools_impl.py
+++ b/launch/launch/utilities/class_tools_impl.py
@@ -15,14 +15,20 @@
 """Module for the class tools utility functions."""
 
 import inspect
+from typing import Type, TYPE_CHECKING, TypeVar, Union
+
+T = TypeVar('T')
+
+if TYPE_CHECKING:
+    from typing import TypeGuard
 
 
-def isclassinstance(obj):
+def isclassinstance(obj: object) -> bool:
     """Return True if obj is an instance of a class."""
     return hasattr(obj, '__class__')
 
 
-def is_a(obj, entity_type):
+def is_a(obj: object, entity_type: Type[T]) -> 'TypeGuard[T]':
     """Return True if obj is an instance of the entity_type class."""
     if not isclassinstance(obj):
         raise RuntimeError("obj '{}' is not a class instance".format(obj))
@@ -31,11 +37,11 @@ def is_a(obj, entity_type):
     return isinstance(obj, entity_type)
 
 
-def is_a_subclass(obj, entity_type):
+def is_a_subclass(obj: Union[object, type], entity_type: Type[T]) -> 'TypeGuard[T]':
     """Return True if obj is an instance of the entity_type class or one of its subclass types."""
     if is_a(obj, entity_type):
         return True
-    try:
+    elif isinstance(obj, type):
         return issubclass(obj, entity_type)
-    except TypeError:
+    else:
         return False

--- a/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
+++ b/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
@@ -14,9 +14,10 @@
 
 """Module for the normalize_to_list_of_substitutions() utility function."""
 
-from typing import cast
+from pathlib import Path
 from typing import Iterable
 from typing import List
+from typing import Union
 
 from .class_tools_impl import is_a_subclass
 from ..some_substitutions_type import SomeSubstitutionsType
@@ -26,19 +27,26 @@ from ..substitution import Substitution
 def normalize_to_list_of_substitutions(subs: SomeSubstitutionsType) -> List[Substitution]:
     """Return a list of Substitutions given a variety of starting inputs."""
     # Avoid recursive import
-    from ..substitutions import TextSubstitution
+    from ..substitutions import TextSubstitution, PathSubstitution
 
-    def normalize(x):
+    def normalize(x: Union[str, Substitution, Path]) -> Substitution:
         if isinstance(x, Substitution):
             return x
         if isinstance(x, str):
             return TextSubstitution(text=x)
+        if isinstance(x, Path):
+            return PathSubstitution(path=x)
         raise TypeError(
             "Failed to normalize given item of type '{}', when only "
             "'str' or 'launch.Substitution' were expected.".format(type(x)))
 
     if isinstance(subs, str):
         return [TextSubstitution(text=subs)]
-    if is_a_subclass(subs, Substitution):
-        return [cast(Substitution, subs)]
-    return [normalize(y) for y in cast(Iterable, subs)]
+    elif isinstance(subs, Path):
+        return [PathSubstitution(path=subs)]
+    elif is_a_subclass(subs, Substitution):
+        return [subs]
+    elif isinstance(subs, Iterable):
+        return [normalize(y) for y in subs]
+
+    raise TypeError(f'{subs} is not a valid SomeSubstitutionsType.')

--- a/launch/test/launch/substitutions/test_path_join_substitution copy.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution copy.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for SomeSubstitutionsType type."""
+"""Tests for the PathJoinSubstitution substitution class."""
 
-import collections.abc
-from pathlib import Path
-from typing import Iterable
-from typing import Text
-from typing import Union
+import os
 
-from .substitution import Substitution
+from launch.substitutions import PathJoinSubstitution
 
-SomeSubstitutionsType = Union[
-    Text,
-    Substitution,
-    Iterable[Union[Text, Substitution]],
-    Path
-]
 
-SomeSubstitutionsType_types_tuple = (
-    str,
-    Substitution,
-    collections.abc.Iterable,
-)
+def test_path_join():
+    path = ['asd', 'bsd', 'cds']
+    sub = PathJoinSubstitution(path)
+    assert sub.perform(None) == os.path.join(*path)

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the PathJoinSubstitution substitution class."""
+"""Tests for the PathSubstitution substitution class."""
 
 import os
+from pathlib import Path
 
-from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import PathSubstitution
 
 
 def test_path_join():
-    path = ['asd', 'bsd', 'cds']
-    sub = PathJoinSubstitution(path)
-    assert sub.perform(None) == os.path.join(*path)
+    path = Path('asd') / 'bsd' / 'cds'
+    sub = PathSubstitution(path)
+    assert sub.perform(None) == os.path.join('asd', 'bsd', 'cds')


### PR DESCRIPTION
Creates `PathSubstitutions` and update some types. For more information on Path check out the documentation [here](https://docs.python.org/3/library/pathlib.html)