### PR TITLE
Avoid too many characters cached in buffer

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -375,14 +375,14 @@ class ExecuteLocal(Action):
             buffer.write(to_write)
             buffer.seek(0)
             last_line = None
+            MAX_CHARACTER_KEPT_BEFORE_LOG = 4096
             for line in buffer:
-                if line.endswith(os.linesep):
+                if line.endswith('\n') or len(line) >= MAX_CHARACTER_KEPT_BEFORE_LOG:
                     logger.info(
-                        self.__output_format.format(line=line[:-len(os.linesep)], this=self)
+                        self.__output_format.format(line=line.rstrip(os.linesep), this=self)
                     )
                 else:
                     last_line = line
-                    break
             buffer.seek(0)
             buffer.truncate(0)
             if last_line is not None:


### PR DESCRIPTION
# Issue Description

Recently, I've encountered an issue that the launch test (added with `add_ros_test` with a launch.py file) hangs indefinitely.
After investigation, I found that it was stuck at the `getvalue` call of a `StringIO` buffer:
https://github.com/ros2/launch/blob/f3e9cfebcfa75c82299bb31674355a29454489fa/launch/launch/actions/execute_local.py#L391-L396

The root cause is that the `__on_process_output` method stores output in the buffer but does not process it, resulting in a huge buffer to be `getvalue` on (and thus hangs):
https://github.com/ros2/launch/blob/f3e9cfebcfa75c82299bb31674355a29454489fa/launch/launch/actions/execute_local.py#L378-L385

This happens because one of my noisy program prints to stdout without a line separator, causing the buffer to accumulate.

# Proposed Improvement
This PR addresses the issue by ensuring the buffer does not store too many characters, which I think it is always not wrong.

# Other Changes
1.  I also change the `os.linesep` to `\n` since from the [doc of StringIO](https://docs.python.org/3.10/library/io.html#io.StringIO), the `StringIO` by default uses `\n` as newline. Otherwise, writing lines with EOL='\n' in Windows will stop line from being processed. 
2. Remove the `break` in the else clause; this is unnecessary, it will be the last line in the buffer if it does not end with the line separator.