### PR TITLE
[Humble] Let XML executables/nodes be "required" (like in ROS 1) (#751)

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -23,7 +23,7 @@ from typing import Optional
 from typing import Text
 
 from .execute_local import ExecuteLocal
-
+from .shutdown_action import Shutdown
 from ..descriptions import Executable
 from ..frontend import Entity
 from ..frontend import expose_action
@@ -330,6 +330,16 @@ class ExecuteProcess(ExecuteLocal):
             name = entity.get_attr('name', optional=True)
             if name is not None:
                 kwargs['name'] = parser.parse_substitution(name)
+
+        if 'on_exit' not in ignore:
+            on_exit = entity.get_attr('on_exit', optional=True)
+            if on_exit is not None:
+                if on_exit == 'shutdown':
+                    kwargs['on_exit'] = [Shutdown()]
+                else:
+                    raise ValueError(
+                        'Attribute on_exit of Entity node expected to be shutdown but got `{}`'
+                        'Other on_exit actions not yet supported'.format(on_exit))
 
         if 'prefix' not in ignore:
             prefix = entity.get_attr('launch-prefix', optional=True)

--- a/launch_xml/test/launch_xml/test_executable.py
+++ b/launch_xml/test/launch_xml/test_executable.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import textwrap
 
 from launch import LaunchService
+from launch.actions import Shutdown
 from launch.frontend import Parser
 
 import pytest
@@ -62,6 +63,22 @@ def test_executable_wrong_subtag():
         parser.parse_description(root_entity)
     assert '`executable`' in str(excinfo.value)
     assert 'whats_this' in str(excinfo.value)
+
+
+def test_executable_on_exit():
+    xml_file = \
+        """\
+        <launch>
+            <executable cmd="ls" on_exit="shutdown"/>
+        </launch>
+        """
+    xml_file = textwrap.dedent(xml_file)
+    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    ld = parser.parse_description(root_entity)
+    executable = ld.entities[0]
+    sub_entities = executable.get_sub_entities()
+    assert len(sub_entities) == 1
+    assert isinstance(sub_entities[0], Shutdown)
 
 
 if __name__ == '__main__':

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -18,6 +18,7 @@ import io
 import textwrap
 
 from launch import LaunchService
+from launch.actions import Shutdown
 from launch.frontend import Parser
 
 
@@ -56,6 +57,23 @@ def test_executable():
     ls = LaunchService()
     ls.include_launch_description(ld)
     assert(0 == ls.run())
+
+
+def test_executable_on_exit():
+    yaml_file = \
+        """\
+        launch:
+        -   executable:
+                cmd: ls
+                on_exit: shutdown
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    ld = parser.parse_description(root_entity)
+    executable = ld.entities[0]
+    sub_entities = executable.get_sub_entities()
+    assert len(sub_entities) == 1
+    assert isinstance(sub_entities[0], Shutdown)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cherry pick of the commit discussed here: https://github.com/ros2/launch/pull/179

Supports "on_exit" for XML launch files in ROS 2 humble. 
I tested it locally and it works as expected: 
- Launch file with 2 nodes (both on_exit=shutdown)
- When I kill one node, the process exits with Exit Code = 0.


* Let XML nodes be "required"

Essentially on_exit="shutdown" is equivalent to ROS 1 required="true".

This feature is implemented using the python launchfile on_exit mechanism.

Right now "shutdown" is the only action accepted by on_exit, but theoretically more "on_exit" actions could be added later.

Example:
<executable cmd="ls" on_exit="shutdown"/>

* Added tests for yaml