### PR TITLE
Cleanup the launch dependencies.

### DIFF
--- a/launch/package.xml
+++ b/launch/package.xml
@@ -15,14 +15,13 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
   <author email="william@osrfoundation.org">William Woodall</author>
 
-  <depend>osrf_pycommon</depend>
-
   <!-- The rosdep key for python3 lark module is python3-lark-parser.
   rosdoc2 will mock "lark-parser" however the module is imported as "lark".
   Hence, to mock the import of the lark module, we add this doc depend. -->
   <doc_depend>lark</doc_depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>osrf_pycommon</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-lark-parser</exec_depend>
   <exec_depend>python3-yaml</exec_depend>

--- a/launch_pytest/package.xml
+++ b/launch_pytest/package.xml
@@ -25,7 +25,6 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
-  <test_depend>launch</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/launch_testing/package.xml
+++ b/launch_testing/package.xml
@@ -30,7 +30,6 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
-  <test_depend>launch</test_depend>
 
   <group_depend>launch_frontend_packages</group_depend>
 

--- a/launch_xml/package.xml
+++ b/launch_xml/package.xml
@@ -15,7 +15,7 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
   <author email="william@osrfoundation.org">William Woodall</author>
 
-  <depend>launch</depend>
+  <exec_depend>launch</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/launch_yaml/package.xml
+++ b/launch_yaml/package.xml
@@ -15,7 +15,7 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
   <author email="william@osrfoundation.org">William Woodall</author>
 
-  <depend>launch</depend>
+  <exec_depend>launch</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
Make two changes here:

1.  Any dependency that is already listed as an exec_depend or a depend does not also need to be marked as a test_depend.
2.  ament_python packages should always use exec_depend, as there are no build-time dependencies.