### PR TITLE
Stop loading extensions during launch_{xml,yaml} tests.

### DIFF
--- a/launch_xml/test/launch_xml/parser_no_extensions.py
+++ b/launch_xml/test/launch_xml/parser_no_extensions.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TextIO
+from typing import Tuple
+from typing import Union
+
+from launch.frontend import Parser
+from launch.frontend.entity import Entity
+from launch.utilities.typing_file_path import FilePath
+
+
+def load_no_extensions(file: Union[FilePath, TextIO]) -> Tuple[Entity, 'Parser']:
+    entity, parser = Parser.load(file)
+    # By default, the parser returned from Parser.load() will attempt to load in all extensions.
+    # However, those extensions tend to have other dependencies that *this* package doesn't
+    # have (like rclpy).  Thus, attempting to load those in can fail.  Here we explicitly disable
+    # the loading of extra extensions to avoid this problem.
+    parser.__class__.extensions_loaded = True
+    return entity, parser

--- a/launch_xml/test/launch_xml/test_append_env.py
+++ b/launch_xml/test/launch_xml/test_append_env.py
@@ -19,7 +19,8 @@ import os
 import textwrap
 
 from launch.actions import AppendEnvironmentVariable
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_append_env():
@@ -35,7 +36,7 @@ def test_append_env():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     assert len(ld.entities) == 6
     assert isinstance(ld.entities[0], AppendEnvironmentVariable)

--- a/launch_xml/test/launch_xml/test_arg.py
+++ b/launch_xml/test/launch_xml/test_arg.py
@@ -17,7 +17,7 @@
 import io
 import textwrap
 
-from launch.frontend import Parser
+from parser_no_extensions import load_no_extensions
 
 import pytest
 
@@ -30,7 +30,7 @@ def test_arg():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     arg = ld.entities[0]
     assert 'my_arg' == arg.name
@@ -49,7 +49,7 @@ def test_arg_with_choices():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     arg = ld.entities[0]
     assert 'my_arg' == arg.name
@@ -66,7 +66,7 @@ def test_arg_wrong_attribute():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     with pytest.raises(ValueError) as excinfo:
         parser.parse_description(root_entity)
     assert '`arg`' in str(excinfo.value)
@@ -83,7 +83,7 @@ def test_arg_with_subtag():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     with pytest.raises(ValueError) as excinfo:
         parser.parse_description(root_entity)
     assert '`arg`' in str(excinfo.value)

--- a/launch_xml/test/launch_xml/test_boolean_substitution.py
+++ b/launch_xml/test/launch_xml/test_boolean_substitution.py
@@ -16,8 +16,9 @@ import io
 import textwrap
 
 from launch import LaunchService
-from launch.frontend import Parser
 from launch.utilities import perform_substitutions
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_boolean_substitution_xml():
@@ -47,7 +48,7 @@ def test_boolean_substitution_xml():
 
 
 def check_boolean_substitution(file):
-    root_entity, parser = Parser.load(file)
+    root_entity, parser = load_no_extensions(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
     ls.include_launch_description(ld)

--- a/launch_xml/test/launch_xml/test_deprecated_launch_file.py
+++ b/launch_xml/test/launch_xml/test_deprecated_launch_file.py
@@ -18,7 +18,8 @@ import io
 import textwrap
 
 from launch import LaunchDescription
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_deprecated_launch_file():
@@ -27,7 +28,7 @@ def test_deprecated_launch_file():
         <launch deprecated="MY_DEPRECATED_MESSAGE"/>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     assert isinstance(ld, LaunchDescription)
     assert 'MY_DEPRECATED_MESSAGE' == ld.deprecated_reason

--- a/launch_xml/test/launch_xml/test_executable.py
+++ b/launch_xml/test/launch_xml/test_executable.py
@@ -20,7 +20,8 @@ import textwrap
 
 from launch import LaunchService
 from launch.actions import Shutdown
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 import pytest
 
@@ -28,7 +29,7 @@ import pytest
 def test_executable():
     """Parse node xml example."""
     xml_file = str(Path(__file__).parent / 'executable.xml')
-    root_entity, parser = Parser.load(xml_file)
+    root_entity, parser = load_no_extensions(xml_file)
     ld = parser.parse_description(root_entity)
     executable = ld.entities[0]
     cmd = [i[0].perform(None) for i in executable.cmd]
@@ -61,7 +62,7 @@ def test_executable_wrong_subtag():
         </launch>
         """  # noqa, line too long
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     with pytest.raises(ValueError) as excinfo:
         parser.parse_description(root_entity)
     assert '`executable`' in str(excinfo.value)
@@ -76,7 +77,7 @@ def test_executable_on_exit():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     executable = ld.entities[0]
     sub_entities = executable.get_sub_entities()

--- a/launch_xml/test/launch_xml/test_group.py
+++ b/launch_xml/test/launch_xml/test_group.py
@@ -25,8 +25,9 @@ from launch.actions import PushLaunchConfigurations
 from launch.actions import ResetEnvironment
 from launch.actions import ResetLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
-from launch.frontend import Parser
 from launch.launch_context import LaunchContext
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_group():
@@ -44,7 +45,7 @@ def test_group():
         </launch>
         """  # noqa: E501
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
 
     assert isinstance(ld.entities[0], SetLaunchConfiguration)

--- a/launch_xml/test/launch_xml/test_include.py
+++ b/launch_xml/test/launch_xml/test_include.py
@@ -20,8 +20,9 @@ import textwrap
 
 from launch import LaunchService
 from launch.actions import IncludeLaunchDescription
-from launch.frontend import Parser
 from launch.launch_description_sources import AnyLaunchDescriptionSource
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_include():
@@ -35,7 +36,7 @@ def test_include():
         </launch>
         """.format(path)  # noqa: E501
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     include = ld.entities[0]
     assert isinstance(include, IncludeLaunchDescription)

--- a/launch_xml/test/launch_xml/test_let_var.py
+++ b/launch_xml/test/launch_xml/test_let_var.py
@@ -18,7 +18,8 @@ import io
 import textwrap
 
 from launch import LaunchContext
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_let_var():
@@ -31,7 +32,7 @@ def test_let_var():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     context = LaunchContext()
     assert len(ld.entities) == 2

--- a/launch_xml/test/launch_xml/test_list.py
+++ b/launch_xml/test/launch_xml/test_list.py
@@ -18,7 +18,7 @@ import io
 import textwrap
 from typing import List
 
-from launch.frontend import Parser
+from parser_no_extensions import load_no_extensions
 
 
 def test_list():
@@ -32,7 +32,7 @@ def test_list():
         </root>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     tags = root_entity.children
     assert tags[0].get_attr('attr', data_type=List[str]) == ['1', '2', '3']
     assert tags[0].get_attr('attr', data_type=List[int]) == [1, 2, 3]

--- a/launch_xml/test/launch_xml/test_log.py
+++ b/launch_xml/test/launch_xml/test_log.py
@@ -19,8 +19,9 @@ import textwrap
 
 from launch import LaunchContext
 from launch.actions import LogInfo
-from launch.frontend import Parser
 from launch.utilities import perform_substitutions
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_log():
@@ -32,7 +33,7 @@ def test_log():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     launch_description = parser.parse_description(root_entity)
     log_info = launch_description.entities[0]
     assert isinstance(log_info, LogInfo)

--- a/launch_xml/test/launch_xml/test_reset.py
+++ b/launch_xml/test/launch_xml/test_reset.py
@@ -18,8 +18,9 @@ import io
 import textwrap
 
 from launch.actions import ResetLaunchConfigurations, SetLaunchConfiguration
-from launch.frontend import Parser
 from launch.launch_context import LaunchContext
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_reset():
@@ -35,7 +36,7 @@ def test_reset():
         </launch>
         """  # noqa: E501
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
 
     assert isinstance(ld.entities[0], SetLaunchConfiguration)

--- a/launch_xml/test/launch_xml/test_set_env.py
+++ b/launch_xml/test/launch_xml/test_set_env.py
@@ -18,7 +18,8 @@ import io
 import textwrap
 
 from launch.actions import SetEnvironmentVariable
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_set_env():
@@ -29,7 +30,7 @@ def test_set_env():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     assert len(ld.entities) == 1
     set_env = ld.entities[0]

--- a/launch_xml/test/launch_xml/test_timer.py
+++ b/launch_xml/test/launch_xml/test_timer.py
@@ -19,8 +19,9 @@ import math
 import textwrap
 
 from launch.actions import TimerAction
-from launch.frontend import Parser
 from launch.substitutions import LaunchConfiguration
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_timer():
@@ -33,7 +34,7 @@ def test_timer():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     timer = ld.entities[0]
     assert isinstance(timer, TimerAction)
@@ -52,7 +53,7 @@ def test_timer_period_is_substitution():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     timer = ld.entities[0]
     assert isinstance(timer, TimerAction)

--- a/launch_xml/test/launch_xml/test_unset_env.py
+++ b/launch_xml/test/launch_xml/test_unset_env.py
@@ -18,7 +18,8 @@ import io
 import textwrap
 
 from launch.actions import UnsetEnvironmentVariable
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_unset_env():
@@ -29,7 +30,7 @@ def test_unset_env():
         </launch>
         """
     xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
     ld = parser.parse_description(root_entity)
     assert len(ld.entities) == 1
     unset_env = ld.entities[0]

--- a/launch_yaml/test/launch_yaml/parser_no_extensions.py
+++ b/launch_yaml/test/launch_yaml/parser_no_extensions.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TextIO
+from typing import Tuple
+from typing import Union
+
+from launch.frontend import Parser
+from launch.frontend.entity import Entity
+from launch.utilities.typing_file_path import FilePath
+
+
+def load_no_extensions(file: Union[FilePath, TextIO]) -> Tuple[Entity, 'Parser']:
+    entity, parser = Parser.load(file)
+    # By default, the parser returned from Parser.load() will attempt to load in all extensions.
+    # However, those extensions tend to have other dependencies that *this* package doesn't
+    # have (like rclpy).  Thus, attempting to load those in can fail.  Here we explicitly disable
+    # the loading of extra extensions to avoid this problem.
+    parser.__class__.extensions_loaded = True
+    return entity, parser

--- a/launch_yaml/test/launch_yaml/test_append_env.py
+++ b/launch_yaml/test/launch_yaml/test_append_env.py
@@ -19,7 +19,8 @@ import os
 import textwrap
 
 from launch.actions import AppendEnvironmentVariable
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_append_env():
@@ -51,7 +52,7 @@ def test_append_env():
                 separator: "|"
         """
     yaml_file = textwrap.dedent(yaml_file)
-    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
     assert len(ld.entities) == 6
     assert isinstance(ld.entities[0], AppendEnvironmentVariable)

--- a/launch_yaml/test/launch_yaml/test_boolean_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_boolean_substitution.py
@@ -16,8 +16,9 @@ import io
 import textwrap
 
 from launch import LaunchService
-from launch.frontend import Parser
 from launch.utilities import perform_substitutions
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_boolean_substitution_yaml():
@@ -46,7 +47,7 @@ def test_boolean_substitution_yaml():
 
 
 def check_boolean_substitution(file):
-    root_entity, parser = Parser.load(file)
+    root_entity, parser = load_no_extensions(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
     ls.include_launch_description(ld)

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -19,7 +19,8 @@ import textwrap
 
 from launch import LaunchService
 from launch.actions import Shutdown
-from launch.frontend import Parser
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_executable():
@@ -42,7 +43,7 @@ def test_executable():
                         value: '1'
         """
     yaml_file = textwrap.dedent(yaml_file)
-    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
     executable = ld.entities[0]
     cmd = [i[0].perform(None) for i in executable.cmd]
@@ -73,7 +74,7 @@ def test_executable_on_exit():
                 on_exit: shutdown
         """
     yaml_file = textwrap.dedent(yaml_file)
-    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
     executable = ld.entities[0]
     sub_entities = executable.get_sub_entities()

--- a/launch_yaml/test/launch_yaml/test_group.py
+++ b/launch_yaml/test/launch_yaml/test_group.py
@@ -25,8 +25,9 @@ from launch.actions import PushLaunchConfigurations
 from launch.actions import ResetEnvironment
 from launch.actions import ResetLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
-from launch.frontend import Parser
 from launch.launch_context import LaunchContext
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_group():
@@ -56,7 +57,7 @@ def test_group():
                         value: 'asd'
         """  # noqa: E501
     yaml_file = textwrap.dedent(yaml_file)
-    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
 
     assert isinstance(ld.entities[0], SetLaunchConfiguration)

--- a/launch_yaml/test/launch_yaml/test_log.py
+++ b/launch_yaml/test/launch_yaml/test_log.py
@@ -19,8 +19,9 @@ import textwrap
 
 from launch import LaunchContext
 from launch.actions import LogInfo
-from launch.frontend import Parser
 from launch.utilities import perform_substitutions
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_log():
@@ -32,7 +33,7 @@ def test_log():
                 message: Hello world!
         """
     yaml_file = textwrap.dedent(yaml_file)
-    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     launch_description = parser.parse_description(root_entity)
     log_info = launch_description.entities[0]
     assert isinstance(log_info, LogInfo)

--- a/launch_yaml/test/launch_yaml/test_reset.py
+++ b/launch_yaml/test/launch_yaml/test_reset.py
@@ -18,8 +18,9 @@ import io
 import textwrap
 
 from launch.actions import ResetLaunchConfigurations, SetLaunchConfiguration
-from launch.frontend import Parser
 from launch.launch_context import LaunchContext
+
+from parser_no_extensions import load_no_extensions
 
 
 def test_reset():
@@ -39,11 +40,8 @@ def test_reset():
                     -   name: 'baz'
                         value: 'BAZ'
         """  # noqa: E501
-    print('Load YAML')
     yaml_file = textwrap.dedent(yaml_file)
-    print('Load Parser')
-    root_entity, parser = Parser.load(io.StringIO(yaml_file))
-    print('Parse Description')
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
 
     assert isinstance(ld.entities[0], SetLaunchConfiguration)


### PR DESCRIPTION
The reason for this requires some explanation.  In current Windows builds, a "soft" error is generated every time these tests are run.  That error suggests that launch_xml or launch_yaml failed to load in the launch_ros component. But launch_xml and launch_yaml are in a repository that launch_ros depends on; how are they trying to load in launch_ros?

The answer has to do with the extension mechanism.  Because launch has the ability to load in extensions, it will attempt to do so anytime the Parser class is initialized.  One of the available extensions is the launch_ros parser, so it will attempt to load that.  And on Windows, that will fail to find rclpy.  This makes some sense; launch_xml doesn't depend on rclpy, so it doesn't necessarily have the paths setup properly to find it.  However, I don't understand why this only fails on Windows and not Linux.

Regardless, the solution presented here disables the loading of extensions in both launch_xml and launch_yaml.  This should ensure that it only loads in the things from this repository, avoiding the problem completely.