### PR TITLE
Add StringJoinSubstitution substituion

### DIFF
--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -34,6 +34,7 @@ from .local_substitution import LocalSubstitution
 from .not_equals_substitution import NotEqualsSubstitution
 from .path_join_substitution import PathJoinSubstitution
 from .python_expression import PythonExpression
+from .string_join_substitution import StringJoinSubstitution
 from .substitution_failure import SubstitutionFailure
 from .text_substitution import TextSubstitution
 from .this_launch_file import ThisLaunchFile
@@ -60,6 +61,7 @@ __all__ = [
     'OrSubstitution',
     'PathJoinSubstitution',
     'PythonExpression',
+    'StringJoinSubstitution',
     'SubstitutionFailure',
     'TextSubstitution',
     'ThisLaunchFile',

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -50,7 +50,7 @@ class StringJoinSubstitution(Substitution):
     def __init__(
         self,
         substitutions: Iterable[SomeSubstitutionsType],
-        delimiter: SomeSubstitutionsType = "",
+        delimiter: SomeSubstitutionsType = '',
     ) -> None:
         """
         Create a StringJoinSubstitution.

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -72,7 +72,7 @@ class StringJoinSubstitution(Substitution):
         return self.__substitutions
 
     @property
-    def delimiter(self) -> Text:
+    def delimiter(self) -> List[Substitution]:
         """Getter for delimiter."""
         return self.__delimiter
 

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -35,7 +35,7 @@ class StringJoinSubstitution(Substitution):
     .. code-block:: python
 
         StringJoinSubstitution(
-            ['https://', LaunchConfiguration('subdomain')], 'ros', 'org'],
+            [['https', '://'], LaunchConfiguration('subdomain')], 'ros', 'org'],
             delimiter='.'
         )
 

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -1,0 +1,94 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the StringJoinSubstitution substitution."""
+
+from typing import Iterable, List, Text
+
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+from ..utilities import perform_substitutions
+
+
+class StringJoinSubstitution(Substitution):
+    """
+    Substitution that joins strings and/or other substitutions.
+
+    This takes in a list of string components as substitutions.
+    The substitutions for each string component are performed and concatenated,
+    and then all string components are joined with a specified delimiter as seperation.
+
+    For example:
+
+    .. code-block:: python
+
+        StringJoinSubstitution(
+            ['https://', LaunchConfiguration('subdomain')], 'ros', 'org'],
+            delimiter='.'
+        )
+
+    If the ``subdomain`` launch configuration was set to ``docs``
+    and the ``delimiter`` to ``.``, this would result in a string equal to
+
+    .. code-block:: python
+
+        'https://docs.ros.org'
+    """
+
+    def __init__(
+        self, substitutions: Iterable[SomeSubstitutionsType], delimiter: str = ''
+    ) -> None:
+        """
+        Create a StringJointSubstitution.
+
+        :param substitutions: the list of string component substitutions to join
+        :param delimiter: the text inbetween two consecutive components (default no text)
+        """
+        from ..utilities import normalize_to_list_of_substitutions
+
+        self.__substitutions = [
+            normalize_to_list_of_substitutions(string_component_substitutions)
+            for string_component_substitutions in substitutions
+        ]
+        self.__delimiter = delimiter
+
+    @property
+    def substitutions(self) -> List[List[Substitution]]:
+        """Getter for substitutions."""
+        return self.__substitutions
+
+    @property
+    def delimiter(self) -> Text:
+        """Getter for delimiter."""
+        return self.__delimiter
+
+    def __repr__(self) -> Text:
+        """Return a description of this substitution as a string."""
+        string_components = [
+            ' + '.join([s.describe() for s in component_substitutions])
+            for component_substitutions in self.substitutions
+        ]
+        return (
+            f'StringJoinSubstitution(['
+            f'{", ".join(string_components)}], delimiter={self.delimiter})'
+        )
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution by retrieving the local variable."""
+        string_components = [
+            perform_substitutions(context, component_substitutions)
+            for component_substitutions in self.substitutions
+        ]
+        return self.delimiter.join(string_components)

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -48,10 +48,12 @@ class StringJoinSubstitution(Substitution):
     """
 
     def __init__(
-        self, substitutions: Iterable[SomeSubstitutionsType], delimiter: str = ''
+        self,
+        substitutions: Iterable[SomeSubstitutionsType],
+        delimiter: SomeSubstitutionsType = "",
     ) -> None:
         """
-        Create a StringJointSubstitution.
+        Create a StringJoinSubstitution.
 
         :param substitutions: the list of string component substitutions to join
         :param delimiter: the text inbetween two consecutive components (default no text)
@@ -62,7 +64,7 @@ class StringJoinSubstitution(Substitution):
             normalize_to_list_of_substitutions(string_component_substitutions)
             for string_component_substitutions in substitutions
         ]
-        self.__delimiter = delimiter
+        self.__delimiter = normalize_to_list_of_substitutions(delimiter)
 
     @property
     def substitutions(self) -> List[List[Substitution]]:
@@ -80,9 +82,10 @@ class StringJoinSubstitution(Substitution):
             ' + '.join([s.describe() for s in component_substitutions])
             for component_substitutions in self.substitutions
         ]
+        delimiter_component = ' + '.join([d.describe() for d in self.delimiter])
         return (
             f'StringJoinSubstitution(['
-            f'{", ".join(string_components)}], delimiter={self.delimiter})'
+            f'{", ".join(string_components)}], delimiter={delimiter_component})'
         )
 
     def perform(self, context: LaunchContext) -> Text:
@@ -91,4 +94,5 @@ class StringJoinSubstitution(Substitution):
             perform_substitutions(context, component_substitutions)
             for component_substitutions in self.substitutions
         ]
-        return self.delimiter.join(string_components)
+        delimiter_component = perform_substitutions(context, self.delimiter)
+        return delimiter_component.join(string_components)

--- a/launch/test/launch/substitutions/test_string_join_substitution.py
+++ b/launch/test/launch/substitutions/test_string_join_substitution.py
@@ -42,6 +42,7 @@ def test_string_join_with_delimiter():
     sub_with_sub = StringJoinSubstitution(strings, delimiter='.')
     assert sub_with_sub.perform(context) == 'abc.def.ghijkl.mno'
 
+
 def test_string_join_with_substitution_delimiter():
     context = LaunchContext()
 
@@ -66,5 +67,5 @@ def test_string_join_with_substitution_delimiter():
     assert sub.perform(context) == '(^_^)'.join(strings)
 
     strings = ['abc', ['def'], [TextSubstitution(text='ghi'), 'jkl'], TextSubstitution(text='mno')]
-    sub_with_sub = StringJoinSubstitution(strings, delimiter=['(^', TextSubstitution(text='_'), '^)'])
+    sub_with_sub = StringJoinSubstitution(strings, delimiter=[TextSubstitution(text='(^_'), '^)'])
     assert sub_with_sub.perform(context) == 'abc(^_^)def(^_^)ghijkl(^_^)mno'

--- a/launch/test/launch/substitutions/test_string_join_substitution.py
+++ b/launch/test/launch/substitutions/test_string_join_substitution.py
@@ -41,3 +41,30 @@ def test_string_join_with_delimiter():
     strings = ['abc', ['def'], [TextSubstitution(text='ghi'), 'jkl'], TextSubstitution(text='mno')]
     sub_with_sub = StringJoinSubstitution(strings, delimiter='.')
     assert sub_with_sub.perform(context) == 'abc.def.ghijkl.mno'
+
+def test_string_join_with_substitution_delimiter():
+    context = LaunchContext()
+
+    strings = ['abc', 'def', 'ghi']
+    sub = StringJoinSubstitution(strings, delimiter=['-', '.', '-'])
+    assert sub.perform(context) == '-.-'.join(strings)
+
+    strings = ['abc', ['def'], [TextSubstitution(text='ghi'), 'jkl'], TextSubstitution(text='mno')]
+    sub_with_sub = StringJoinSubstitution(strings, delimiter=['-', '.', '-'])
+    assert sub_with_sub.perform(context) == 'abc-.-def-.-ghijkl-.-mno'
+
+    strings = ['abc', 'def', 'ghi']
+    sub = StringJoinSubstitution(strings, delimiter=TextSubstitution(text='_'))
+    assert sub.perform(context) == '_'.join(strings)
+
+    strings = ['abc', ['def'], [TextSubstitution(text='ghi'), 'jkl'], TextSubstitution(text='mno')]
+    sub_with_sub = StringJoinSubstitution(strings, delimiter=TextSubstitution(text='_'))
+    assert sub_with_sub.perform(context) == 'abc_def_ghijkl_mno'
+
+    strings = ['abc', 'def', 'ghi']
+    sub = StringJoinSubstitution(strings, delimiter=['(^', TextSubstitution(text='_'), '^)'])
+    assert sub.perform(context) == '(^_^)'.join(strings)
+
+    strings = ['abc', ['def'], [TextSubstitution(text='ghi'), 'jkl'], TextSubstitution(text='mno')]
+    sub_with_sub = StringJoinSubstitution(strings, delimiter=['(^', TextSubstitution(text='_'), '^)'])
+    assert sub_with_sub.perform(context) == 'abc(^_^)def(^_^)ghijkl(^_^)mno'

--- a/launch/test/launch/substitutions/test_string_joint_substitution.py
+++ b/launch/test/launch/substitutions/test_string_joint_substitution.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/test/launch/substitutions/test_string_joint_substitution.py
+++ b/launch/test/launch/substitutions/test_string_joint_substitution.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the StringJoinSubstitution substitution class."""
+
+from launch import LaunchContext
+from launch.substitutions import StringJoinSubstitution
+from launch.substitutions import TextSubstitution
+
+
+def test_string_join():
+    context = LaunchContext()
+
+    strings = ['abc', 'def', 'ghi']
+    sub = StringJoinSubstitution(strings)
+    assert sub.perform(context) == ''.join(strings)
+
+    strings = ['abc', ['def'], [TextSubstitution(text='ghi'), 'jkl'], TextSubstitution(text='mno')]
+    sub_with_sub = StringJoinSubstitution(strings)
+    assert sub_with_sub.perform(context) == 'abcdefghijklmno'
+
+
+def test_string_join_with_delimiter():
+    context = LaunchContext()
+
+    strings = ['abc', 'def', 'ghi']
+    sub = StringJoinSubstitution(strings, delimiter='.')
+    assert sub.perform(context) == '.'.join(strings)
+
+    strings = ['abc', ['def'], [TextSubstitution(text='ghi'), 'jkl'], TextSubstitution(text='mno')]
+    sub_with_sub = StringJoinSubstitution(strings, delimiter='.')
+    assert sub_with_sub.perform(context) == 'abc.def.ghijkl.mno'


### PR DESCRIPTION
Add a substitution wrapper for python `str.join` method.
Supports concatenation of substitutions as implemented in ros2/launch#838

This PR would complement `PathJoinSubstitution` for general use cases like file names with separators (e.g. some.long.urdf.xacro), naming of entities (e.g. the_name_of_the_robot) or even namespaces (e.g. /env/group/robot/joint)

### Usecases
**Domains**
e.g. `https://docs.ros.org` with `subdomain` launch configuration equal to `docs`
```
StringJoinSubstitution(
    [
        ['https://', LaunchConfiguration('subdomain')],
        'ros',
        'org'
    ],
    delimiter='.'
)
```
**File names**
e.g. `robot.a.urdf.xacro` with `model` launch configuration equal to `a`
```
StringJoinSubstitution(
    [
        'robot'
        LaunchConfiguration('model'),
        'urdf',
        'xacro'
    ],
    delimiter='.'
)
```

