### PR TITLE
Allow providing launch args to include using let in frontends

### DIFF
--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -114,6 +114,12 @@ class IncludeLaunchDescription(Action):
                   value: '$(var arg1)'
                 - name: 'other_arg2'
                   value: 'value2'
+
+    .. note::
+
+        While frontends currently support both ``let`` and ``arg`` for launch arguments, they are
+        both converted into ``SetLaunchConfiguration`` actions (``let``). The same launch argument
+        should not be defined using both ``let`` and ``arg``.
     """
 
     def __init__(
@@ -141,12 +147,12 @@ class IncludeLaunchDescription(Action):
         file_path = parser.parse_substitution(entity.get_attr('file'))
         kwargs['launch_description_source'] = file_path
         args = []
-        args_let = entity.get_attr('let', data_type=List[Entity], optional=True)
-        if args_let is not None:
-            args.extend(args_let)
         args_arg = entity.get_attr('arg', data_type=List[Entity], optional=True)
         if args_arg is not None:
             args.extend(args_arg)
+        args_let = entity.get_attr('let', data_type=List[Entity], optional=True)
+        if args_let is not None:
+            args.extend(args_let)
         if args:
             kwargs['launch_arguments'] = [
                 (

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -68,6 +68,52 @@ class IncludeLaunchDescription(Action):
     Conditionally included launch arguments that do not have a default value
     will eventually raise an error if this best effort argument checking is
     unable to see an unsatisfied argument ahead of time.
+
+    For example, to include ``my_pkg``'s ``other_launch.py`` and set launch arguments for it:
+
+    .. code-block:: python
+
+        def generate_launch_description():
+            return ([
+                SetLaunchConfiguration('arg1', 'value1'),
+                IncludeLaunchDescription(
+                    AnyLaunchDescriptionSource([
+                        PathJoinSubstitution([
+                            FindPackageShare('my_pkg'),
+                            'launch',
+                            'other_launch.py',
+                        ]),
+                    ]),
+                    launch_arguments={
+                        'other_arg1': LaunchConfiguration('arg1'),
+                        'other_arg2': 'value2',
+                    }.items(),
+                ),
+            ])
+
+    .. code-block:: xml
+
+        <launch>
+            <let name="arg1" value="value1" />
+            <include file="$(find-pkg-share my_pkg)/launch/other_launch.py">
+                <let name="other_arg1" value="$(var arg1)" />
+                <let name="other_arg2" value="value2" />
+            </include>
+        </launch>
+
+    .. code-block:: yaml
+
+        launch:
+        - let:
+            name: 'arg1'
+            value: 'value1'
+        - include:
+            file: '$(find-pkg-share my_pkg)/launch/other_launch.py'
+            let:
+                - name: 'other_arg1'
+                  value: '$(var arg1)'
+                - name: 'other_arg2'
+                  value: 'value2'
     """
 
     def __init__(
@@ -94,8 +140,14 @@ class IncludeLaunchDescription(Action):
         _, kwargs = super().parse(entity, parser)
         file_path = parser.parse_substitution(entity.get_attr('file'))
         kwargs['launch_description_source'] = file_path
-        args = entity.get_attr('arg', data_type=List[Entity], optional=True)
-        if args is not None:
+        args = []
+        args_let = entity.get_attr('let', data_type=List[Entity], optional=True)
+        if args_let is not None:
+            args.extend(args_let)
+        args_arg = entity.get_attr('arg', data_type=List[Entity], optional=True)
+        if args_arg is not None:
+            args.extend(args_arg)
+        if args:
             kwargs['launch_arguments'] = [
                 (
                     parser.parse_substitution(e.get_attr('name')),

--- a/launch_xml/test/launch_xml/test_include.py
+++ b/launch_xml/test/launch_xml/test_include.py
@@ -34,6 +34,7 @@ def test_include():
             <let name="main_baz" value="BAZ" />
             <include file="{}">
                 <arg name="foo" value="FOO" />
+                <arg name="baz" value="overwritten" />
                 <let name="bar" value="BAR" />
                 <let name="baz" value="$(var main_baz)" />
             </include>

--- a/launch_yaml/test/launch_yaml/executable.yaml
+++ b/launch_yaml/test/launch_yaml/executable.yaml
@@ -1,0 +1,14 @@
+launch:
+- executable:
+    cmd: 'ls -l -a -s'
+    cwd: '/'
+    name: 'my_ls'
+    shell: true
+    output: 'log'
+    emulate_tty: true
+    sigkill_timeout: 4.0
+    sigterm_timeout: 7.0
+    launch-prefix: "$(env LAUNCH_PREFIX '')"
+    env:
+        - name: 'var'
+          value: '1'

--- a/launch_yaml/test/launch_yaml/test_include.py
+++ b/launch_yaml/test/launch_yaml/test_include.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,21 +26,27 @@ from parser_no_extensions import load_no_extensions
 
 
 def test_include():
-    """Parse include XML example."""
-    path = (Path(__file__).parent / 'executable.xml').as_posix()
-    xml_file = \
+    """Parse include YAML example."""
+    path = (Path(__file__).parent / 'executable.yaml').as_posix()
+    yaml_file = \
         """\
-        <launch>
-            <let name="main_baz" value="BAZ" />
-            <include file="{}">
-                <arg name="foo" value="FOO" />
-                <let name="bar" value="BAR" />
-                <let name="baz" value="$(var main_baz)" />
-            </include>
-        </launch>
+        launch:
+        - let:
+            name: 'main_baz'
+            value: 'BAZ'
+        - include:
+            file: '{}'
+            arg:
+                - name: 'foo'
+                  value: 'FOO'
+            let:
+                - name: 'bar'
+                  value: 'BAR'
+                - name: 'baz'
+                  value: '$(var main_baz)'
         """.format(path)  # noqa: E501
-    xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
     include = ld.entities[1]
     assert isinstance(include, IncludeLaunchDescription)

--- a/launch_yaml/test/launch_yaml/test_include.py
+++ b/launch_yaml/test/launch_yaml/test_include.py
@@ -39,6 +39,8 @@ def test_include():
             arg:
                 - name: 'foo'
                   value: 'FOO'
+                - name: 'baz'
+                  value: 'overwritten'
             let:
                 - name: 'bar'
                   value: 'BAR'


### PR DESCRIPTION
Resolves #720

Currently, `IncludeLaunchDescription` (`<include>`) expects launch arguments to be provided through `arg` in frontends, e.g.:

```xml
<launch>
  <let name="arg1" value="value1" />
  <include file="$(find-pkg-share my_pkg)/launch/other_launch.py">
    <arg name="other_arg1" value="$(var arg1)" />
    <arg name="other_arg2" value="value2" />
  </include>
</launch>
```

As mentioned in that issue, it is somewhat unexpected, since that syntax (`name` & `value`) corresponds to `let`; `arg` takes in `name` and `default_value`. As mentioned in https://github.com/ros2/launch/issues/720#issuecomment-2749093110, I believe this is simply because ROS 1's launch XML `<include>` used `<arg>`, and `<let>` didn't exist.

Change `IncludeLaunchDescription` to support both `arg` and `let` as child entities for frontends. Note that it is not expecting actual `arg`/`let` (`DeclareLaunchArgument`/`SetLaunchConfiguration`) actions: it simply expects a list of child entities named `arg` or `let` with attributes named `value` and `name`, whatever that means for the given frontend. The corresponding `SetLaunchConfiguration` actions are created from those later, when `IncludeLaunchDescription` executes.

I've also added some examples to the `IncludeLaunchDescription` docstring. After this PR, the ROS 2 docs should be updated, notably:

1. https://docs.ros.org/en/rolling/Tutorials/Intermediate/Launch/Using-Substitutions.html#parent-launch-file
2. https://docs.ros.org/en/rolling/How-To-Guides/Migrating-from-ROS1/Migrating-Launch-Files.html#include (this should mention that `<arg>` under `<include>` is now `<let>`)

We can consider eventually deprecating `arg` _under `include`_.