### PR TITLE
fix(launch_pytest): prevent re-wrapping test funtions on re-run

### DIFF
--- a/launch_pytest/launch_pytest/plugin.py
+++ b/launch_pytest/launch_pytest/plugin.py
@@ -316,7 +316,12 @@ def pytest_pyfunc_call(pyfuncitem):
         yield
         return
 
-    func = pyfuncitem.obj
+    # Store the original unwrapped function to avoid re-wrapping on reruns.
+    # This prevents issues with pytest plugins like pytest-flaky or pytest-rerunfailures,
+    # which reuse the same pyfuncitem across multiple test runs.
+    func = getattr(pyfuncitem, "_launch_pytest_original_obj", pyfuncitem.obj)
+    pyfuncitem._launch_pytest_original_obj = func
+    
     if has_shutdown_kwarg(pyfuncitem) and need_shutdown_test_item(func):
         error_msg = (
             'generator or async generator based launch test items cannot be marked with'

--- a/launch_pytest/launch_pytest/plugin.py
+++ b/launch_pytest/launch_pytest/plugin.py
@@ -319,9 +319,9 @@ def pytest_pyfunc_call(pyfuncitem):
     # Store the original unwrapped function to avoid re-wrapping on reruns.
     # This prevents issues with pytest plugins like pytest-flaky or pytest-rerunfailures,
     # which reuse the same pyfuncitem across multiple test runs.
-    func = getattr(pyfuncitem, "_launch_pytest_original_obj", pyfuncitem.obj)
+    func = getattr(pyfuncitem, '_launch_pytest_original_obj', pyfuncitem.obj)
     pyfuncitem._launch_pytest_original_obj = func
-    
+
     if has_shutdown_kwarg(pyfuncitem) and need_shutdown_test_item(func):
         error_msg = (
             'generator or async generator based launch test items cannot be marked with'


### PR DESCRIPTION
Colcon provides a flag [--retest-until-pass](https://github.com/colcon/colcon-core/blob/f1d3055b2c39abb7b6e272c1cafbaf95780fd9a7/colcon_core/task/python/test/pytest.py#L132) which uses [pytest-rerunfailures](https://pypi.org/project/pytest-rerunfailures/) to re-run tests.

Each time the test is run, `launch_pytest` wraps the `pyfuncitem.obj` (the user's test function) and assigns it back to `pyfuncitem.obj`. This means after each test run, the wrapped function is re-wrapped. 

_This change stores a reference to the initial unwrapped function so the we don't wrap an already wrapped function._

Currently, wrapping an already wrapped function leads the [executor](https://github.com/Greenroom-Robotics/launch/blob/82f25edd0e2004aa6e5cbf2867e614766a658788/launch_pytest/launch_pytest/plugin.py#L400) to launch using the `event_loop` from the previous attempt leading to a `RuntimeError: Event loop is closed` error.

Closes https://github.com/ros2/launch/issues/853
