### PR TITLE
Expose StringJoinSubstitution to frontend

### DIFF
--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -59,7 +59,7 @@ class StringJoinSubstitution(Substitution):
                     name: url
                     value: "$(string-join . https://$(var subdomain) ros org)"
 
-    If the ``subdomain`` launch configuration was set to ``docs`` and the ``delimiter`` to ``.``, 
+    If the ``subdomain`` launch configuration was set to ``docs`` and the ``delimiter`` to ``.``,
     then any of the above launch descriptions would result in a string equal to
 
     .. code-block:: python

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -16,6 +16,8 @@
 
 from typing import Iterable, List, Sequence, Text
 
+from launch.utilities.normalize_to_list_of_substitutions_impl import normalize_to_list_of_substitutions
+
 from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
@@ -83,11 +85,14 @@ class StringJoinSubstitution(Substitution):
         """Parse `StringJoinSubstitution` substitution."""
         if len(data) < 2:
             raise TypeError(
-                'string-join substitution expects at least 2 arguments (delimiter at first position)'
+                'string-join substitution expects at least 2 arguments'
             )
         kwargs = {}
         kwargs['delimiter'] = data[0]
-        kwargs['substitutions'] = data[1:]
+        kwargs['substitutions'] = [
+            normalize_to_list_of_substitutions(string_component_substitutions)
+            for string_component_substitutions in data[1:]
+        ]
         return cls, kwargs
 
     def __repr__(self) -> Text:

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -16,8 +16,6 @@
 
 from typing import Iterable, List, Sequence, Text
 
-from launch.utilities.normalize_to_list_of_substitutions_impl import normalize_to_list_of_substitutions
-
 from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
@@ -89,10 +87,7 @@ class StringJoinSubstitution(Substitution):
             )
         kwargs = {}
         kwargs['delimiter'] = data[0]
-        kwargs['substitutions'] = [
-            normalize_to_list_of_substitutions(string_component_substitutions)
-            for string_component_substitutions in data[1:]
-        ]
+        kwargs['substitutions'] = iter(data[1:])
         return cls, kwargs
 
     def __repr__(self) -> Text:

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -36,13 +36,31 @@ class StringJoinSubstitution(Substitution):
 
     .. code-block:: python
 
-        StringJoinSubstitution(
-            [['https', '://'], LaunchConfiguration('subdomain')], 'ros', 'org'],
+        subdomain = LaunchConfiguration(variable_name='subdomain', default='docs')
+        url = StringJoinSubstitution(
+            [['https', '://'], subdomain], 'ros', 'org'],
             delimiter='.'
         )
 
-    If the ``subdomain`` launch configuration was set to ``docs``
-    and the ``delimiter`` to ``.``, this would result in a string equal to
+    .. code-block:: xml
+
+        <launch>
+            <arg name="subdomain" default="docs"/>
+            <let name="url" value="$(string-join . https://$(var subdomain) ros org)"/>
+        </launch>
+
+    .. code-block:: yaml
+
+            launch:
+                - arg:
+                    name: subdomain
+                    default: "docs"
+                - let:
+                    name: url
+                    value: "$(string-join . https://$(var subdomain) ros org)"
+
+    If the ``subdomain`` launch configuration was set to ``docs`` and the ``delimiter`` to ``.``, 
+    then any of the above launch descriptions would result in a string equal to
 
     .. code-block:: python
 

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -14,7 +14,7 @@
 
 """Module for the StringJoinSubstitution substitution."""
 
-from typing import Dict, Iterable, List, Sequence, Text
+from typing import Any, Dict, Iterable, List, Sequence, Text, Tuple, Type
 
 from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
@@ -97,17 +97,16 @@ class StringJoinSubstitution(Substitution):
         return self.__delimiter
 
     @classmethod
-    def parse(cls, data: Sequence[SomeSubstitutionsType]):
+    def parse(
+        cls, data: Sequence[SomeSubstitutionsType]
+    ) -> Tuple[Type['StringJoinSubstitution'], Dict[str, Any]]:
         """Parse `StringJoinSubstitution` substitution."""
         if len(data) < 2:
             raise TypeError(
                 'string-join substitution expects at least 2 arguments: '
                 '1 delimiter + at least 1 component'
             )
-        kwargs: Dict[str, SomeSubstitutionsType | Iterable[SomeSubstitutionsType]] = {}
-        kwargs['delimiter'] = data[0]
-        kwargs['substitutions'] = data[1:]
-        return cls, kwargs
+        return cls, {'delimiter': data[0], 'substitutions': data[1:]}
 
     def __repr__(self) -> Text:
         """Return a description of this substitution as a string."""

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -14,14 +14,16 @@
 
 """Module for the StringJoinSubstitution substitution."""
 
-from typing import Iterable, List, Text
+from typing import Iterable, List, Sequence, Text
 
+from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
 from ..utilities import perform_substitutions
 
 
+@expose_substitution('string-join')
 class StringJoinSubstitution(Substitution):
     """
     Substitution that joins strings and/or other substitutions.
@@ -75,6 +77,18 @@ class StringJoinSubstitution(Substitution):
     def delimiter(self) -> List[Substitution]:
         """Getter for delimiter."""
         return self.__delimiter
+
+    @classmethod
+    def parse(cls, data: Sequence[SomeSubstitutionsType]):
+        """Parse `StringJoinSubstitution` substitution."""
+        if len(data) < 2:
+            raise TypeError(
+                'string-join substitution expects at least 2 arguments (delimiter at first position)'
+            )
+        kwargs = {}
+        kwargs['delimiter'] = data[0]
+        kwargs['substitutions'] = data[1:]
+        return cls, kwargs
 
     def __repr__(self) -> Text:
         """Return a description of this substitution as a string."""

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -38,7 +38,7 @@ class StringJoinSubstitution(Substitution):
 
         subdomain = LaunchConfiguration(variable_name='subdomain', default='docs')
         url = StringJoinSubstitution(
-            [['https', '://'], subdomain], 'ros', 'org'],
+            [['https', '://', subdomain], 'ros', 'org'],
             delimiter='.'
         )
 

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -14,7 +14,7 @@
 
 """Module for the StringJoinSubstitution substitution."""
 
-from typing import Iterable, List, Sequence, Text
+from typing import Dict, Iterable, List, Sequence, Text
 
 from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
@@ -86,9 +86,9 @@ class StringJoinSubstitution(Substitution):
                 'string-join substitution expects at least 2 arguments: '
                 '1 delimiter + at least 1 component'
             )
-        kwargs = {}
+        kwargs: Dict[str, SomeSubstitutionsType | Iterable[SomeSubstitutionsType]] = {}
         kwargs['delimiter'] = data[0]
-        kwargs['substitutions'] = iter(data[1:])
+        kwargs['substitutions'] = data[1:]
         return cls, kwargs
 
     def __repr__(self) -> Text:

--- a/launch/launch/substitutions/string_join_substitution.py
+++ b/launch/launch/substitutions/string_join_substitution.py
@@ -83,7 +83,8 @@ class StringJoinSubstitution(Substitution):
         """Parse `StringJoinSubstitution` substitution."""
         if len(data) < 2:
             raise TypeError(
-                'string-join substitution expects at least 2 arguments'
+                'string-join substitution expects at least 2 arguments: '
+                '1 delimiter + at least 1 component'
             )
         kwargs = {}
         kwargs['delimiter'] = data[0]

--- a/launch_xml/test/launch_xml/test_string_join_substitution.py
+++ b/launch_xml/test/launch_xml/test_string_join_substitution.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test parsing a StringJoinSubstitution in XML launch file."""
+
+import io
+import textwrap
+
+from launch.actions import DeclareLaunchArgument, SetLaunchConfiguration
+from launch.frontend import Parser
+from launch.launch_context import LaunchContext
+from launch.substitutions import StringJoinSubstitution
+
+
+def test_nested():
+    xml_file = textwrap.dedent(
+        """
+        <launch>
+            <arg name="subdomain" default="wiki"/>
+            <let name="url" value="$(string-join . https://$(var subdomain) ros org)"/>
+        </launch>
+        """
+    )
+    root_entity, parser = Parser.load(io.StringIO(xml_file))
+    ld = parser.parse_description(root_entity)
+
+    assert len(ld.entities) == 2
+    assert isinstance(ld.describe_sub_entities()[0], DeclareLaunchArgument)
+    assert isinstance(ld.describe_sub_entities()[1], SetLaunchConfiguration)
+
+    lc = LaunchContext()
+    ld.entities[0].visit(lc)
+
+    let = ld.describe_sub_entities()[1]
+    assert isinstance(let.value[0], StringJoinSubstitution)
+    assert let.value[0].perform(lc) == 'https://wiki.ros.org'
+
+
+def test_delimiter():
+    yaml_file = textwrap.dedent(
+        """
+        <launch>
+            <arg name="delimiter" default="^_^"/>
+            <let name="text" value="$(string-join '($(var delimiter))' a b c)"/>
+        </launch>
+        """
+    )
+    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    ld = parser.parse_description(root_entity)
+
+    assert len(ld.entities) == 2
+    assert isinstance(ld.entities[0], DeclareLaunchArgument)
+    assert isinstance(ld.entities[1], SetLaunchConfiguration)
+
+    lc = LaunchContext()
+    ld.entities[0].visit(lc)
+
+    let = ld.describe_sub_entities()[1]
+    assert isinstance(let.value[0], StringJoinSubstitution)
+    assert let.value[0].perform(lc) == 'a(^_^)b(^_^)c'

--- a/launch_xml/test/launch_xml/test_string_join_substitution.py
+++ b/launch_xml/test/launch_xml/test_string_join_substitution.py
@@ -66,6 +66,6 @@ def test_delimiter():
     lc = LaunchContext()
     ld.entities[0].visit(lc)
 
-    let = ld.describe_sub_entities()[1]
+    let = ld.entities[1]
     assert isinstance(let.value[0], StringJoinSubstitution)
     assert let.value[0].perform(lc) == 'a(^_^)b(^_^)c'

--- a/launch_xml/test/launch_xml/test_string_join_substitution.py
+++ b/launch_xml/test/launch_xml/test_string_join_substitution.py
@@ -36,8 +36,8 @@ def test_nested():
     ld = parser.parse_description(root_entity)
 
     assert len(ld.entities) == 2
-    assert isinstance(ld.describe_sub_entities()[0], DeclareLaunchArgument)
-    assert isinstance(ld.describe_sub_entities()[1], SetLaunchConfiguration)
+    assert isinstance(ld.entities[0], DeclareLaunchArgument)
+    assert isinstance(ld.entities[1], SetLaunchConfiguration)
 
     lc = LaunchContext()
     ld.entities[0].visit(lc)

--- a/launch_xml/test/launch_xml/test_string_join_substitution.py
+++ b/launch_xml/test/launch_xml/test_string_join_substitution.py
@@ -42,7 +42,7 @@ def test_nested():
     lc = LaunchContext()
     ld.entities[0].visit(lc)
 
-    let = ld.describe_sub_entities()[1]
+    let = ld.entities[1]
     assert isinstance(let.value[0], StringJoinSubstitution)
     assert let.value[0].perform(lc) == 'https://wiki.ros.org'
 

--- a/launch_yaml/test/launch_yaml/test_string_join_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_string_join_substitution.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test parsing a StringJoinSubstitution in yaml launch file."""
+
+import io
+import textwrap
+
+from launch.actions import DeclareLaunchArgument, SetLaunchConfiguration
+from launch.frontend import Parser
+from launch.launch_context import LaunchContext
+from launch.substitutions import StringJoinSubstitution
+
+
+def test_nested():
+    yaml_file = textwrap.dedent(
+        """
+        launch:
+            - arg:
+                name: subdomain
+                default: "wiki"
+            - let:
+                name: url
+                value: "$(string-join . https://$(var subdomain) ros org)"
+        """
+    )
+    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    ld = parser.parse_description(root_entity)
+
+    assert len(ld.entities) == 2
+    assert isinstance(ld.describe_sub_entities()[0], DeclareLaunchArgument)
+    assert isinstance(ld.describe_sub_entities()[1], SetLaunchConfiguration)
+
+    lc = LaunchContext()
+    ld.entities[0].visit(lc)
+
+    let = ld.describe_sub_entities()[1]
+    assert isinstance(let.value[0], StringJoinSubstitution)
+    assert let.value[0].perform(lc) == 'https://wiki.ros.org'
+
+
+def test_delimiter():
+    yaml_file = textwrap.dedent(
+        """
+        launch:
+            - arg:
+                name: delimiter
+                default: "^_^"
+            - let:
+                name: text
+                value: "$(string-join '($(var delimiter))' a b c)"
+        """
+    )
+    root_entity, parser = Parser.load(io.StringIO(yaml_file))
+    ld = parser.parse_description(root_entity)
+
+    assert len(ld.entities) == 2
+    assert isinstance(ld.entities[0], DeclareLaunchArgument)
+    assert isinstance(ld.entities[1], SetLaunchConfiguration)
+
+    lc = LaunchContext()
+    ld.entities[0].visit(lc)
+
+    let = ld.describe_sub_entities()[1]
+    assert isinstance(let.value[0], StringJoinSubstitution)
+    assert let.value[0].perform(lc) == 'a(^_^)b(^_^)c'

--- a/launch_yaml/test/launch_yaml/test_string_join_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_string_join_substitution.py
@@ -45,7 +45,7 @@ def test_nested():
     lc = LaunchContext()
     ld.entities[0].visit(lc)
 
-    let = ld.describe_sub_entities()[1]
+    let = ld.entities[1]
     assert isinstance(let.value[0], StringJoinSubstitution)
     assert let.value[0].perform(lc) == 'https://wiki.ros.org'
 

--- a/launch_yaml/test/launch_yaml/test_string_join_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_string_join_substitution.py
@@ -72,6 +72,6 @@ def test_delimiter():
     lc = LaunchContext()
     ld.entities[0].visit(lc)
 
-    let = ld.describe_sub_entities()[1]
+    let = ld.entities[1]
     assert isinstance(let.value[0], StringJoinSubstitution)
     assert let.value[0].perform(lc) == 'a(^_^)b(^_^)c'

--- a/launch_yaml/test/launch_yaml/test_string_join_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_string_join_substitution.py
@@ -39,8 +39,8 @@ def test_nested():
     ld = parser.parse_description(root_entity)
 
     assert len(ld.entities) == 2
-    assert isinstance(ld.describe_sub_entities()[0], DeclareLaunchArgument)
-    assert isinstance(ld.describe_sub_entities()[1], SetLaunchConfiguration)
+    assert isinstance(ld.entities[0], DeclareLaunchArgument)
+    assert isinstance(ld.entities[1], SetLaunchConfiguration)
 
     lc = LaunchContext()
     ld.entities[0].visit(lc)


### PR DESCRIPTION
This PR exposes StringJoinSubstitution from #843 to the frontend, as suggested by @christophebedard in #843.

# Usage 
(i.e. with `delimiter=.` and `string components=[https://$(var subdomain), ros, org]`):
```
%YAML 1.2
---
launch:
  - arg:
      name: subdomain
      default: 'wiki'
  - log:
      message: "$(string-join . https://$(var subdomain) ros org)"
```
results in terminal output
```
[INFO] [launch.user]: https://wiki.ros.org
```