### PR TITLE
Fix `ExecuteLocal` output flushing

### DIFF
--- a/launch/launch/actions/execute_local.py
+++ b/launch/launch/actions/execute_local.py
@@ -345,7 +345,7 @@ class ExecuteLocal(Action):
         if buffer.closed:
             # buffer was probably closed by __flush_buffers on shutdown.  Output without
             # buffering.
-            buffer.info(
+            logger.info(
                 self.__output_format.format(line=to_write, this=self)
             )
         else:


### PR DESCRIPTION
Closes https://github.com/ros2/launch/issues/859. Partially backports https://github.com/ros2/launch/pull/679.