### PR TITLE
Scope launch file dir/path locals to included launch file

### DIFF
--- a/launch/test/launch/actions/launch/included/launch_file_dir.launch.py
+++ b/launch/test/launch/actions/launch/included/launch_file_dir.launch.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchContext
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import SetEnvironmentVariable
+from launch.substitutions import ThisLaunchFile
+from launch.substitutions import ThisLaunchFileDir
+
+
+def set_local(context: LaunchContext) -> None:
+    context.extend_locals({'included_local': 'context_local_value'})
+
+
+def generate_launch_description():
+    """Fixture for tests."""
+    return LaunchDescription([
+        SetEnvironmentVariable('Included_ThisLaunchFile', ThisLaunchFile()),
+        OpaqueFunction(function=set_local),
+        SetEnvironmentVariable('Included_ThisLaunchFileDir', ThisLaunchFileDir()),
+    ])

--- a/launch/test/launch/actions/launch/parent_launch_file_dir.launch.py
+++ b/launch/test/launch/actions/launch/parent_launch_file_dir.launch.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.actions import SetEnvironmentVariable
+from launch.substitutions import ThisLaunchFile
+from launch.substitutions import ThisLaunchFileDir
+
+
+def generate_launch_description():
+    """Fixture for tests."""
+    return LaunchDescription([
+        SetEnvironmentVariable('Before_ThisLaunchFile', ThisLaunchFile()),
+        SetEnvironmentVariable('Before_ThisLaunchFileDir', ThisLaunchFileDir()),
+        IncludeLaunchDescription(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                'included',
+                'launch_file_dir.launch.py',
+            ),
+        ),
+        SetEnvironmentVariable('After_ThisLaunchFile', ThisLaunchFile()),
+        SetEnvironmentVariable('After_ThisLaunchFileDir', ThisLaunchFileDir()),
+    ])

--- a/launch/test/launch/actions/test_include_launch_description.py
+++ b/launch/test/launch/actions/test_include_launch_description.py
@@ -51,7 +51,7 @@ def test_include_launch_description_methods():
     assert isinstance(action.describe_sub_entities(), list)
     assert isinstance(action.describe_conditional_sub_entities(), list)
     # Result should only contain the launch description as there are no launch arguments.
-    assert action.visit(LaunchContext()) == [ld]
+    assert action.visit(LaunchContext())[0] == ld
     assert action.get_asyncio_future() is None
     assert len(action.launch_arguments) == 0
 
@@ -61,7 +61,7 @@ def test_include_launch_description_methods():
     assert isinstance(action2.describe_sub_entities(), list)
     assert isinstance(action2.describe_conditional_sub_entities(), list)
     # Result should only contain the launch description as there are no launch arguments.
-    assert action2.visit(LaunchContext()) == [ld2]
+    assert action2.visit(LaunchContext())[0] == ld2
     assert action2.get_asyncio_future() is None
     assert len(action2.launch_arguments) == 0
 
@@ -75,7 +75,7 @@ def test_include_launch_description_launch_file_location():
     assert isinstance(action.describe_conditional_sub_entities(), list)
     lc1 = LaunchContext()
     # Result should only contain the launch description as there are no launch arguments.
-    assert action.visit(lc1) == [ld]
+    assert action.visit(lc1)[0] == ld
     assert lc1.locals.current_launch_file_directory == '<script>'
     assert action.get_asyncio_future() is None
 
@@ -87,7 +87,7 @@ def test_include_launch_description_launch_file_location():
     assert isinstance(action2.describe_conditional_sub_entities(), list)
     lc2 = LaunchContext()
     # Result should only contain the launch description as there are no launch arguments.
-    assert action2.visit(lc2) == [ld2]
+    assert action2.visit(lc2)[0] == ld2
     assert lc2.locals.current_launch_file_directory == str(this_file.parent)
     assert action2.get_asyncio_future() is None
 
@@ -150,7 +150,7 @@ def test_include_launch_description_launch_arguments():
     assert len(action1.launch_arguments) == 1
     lc1 = LaunchContext()
     result1 = action1.visit(lc1)
-    assert len(result1) == 2
+    assert len(result1) == 3
     assert isinstance(result1[0], SetLaunchConfiguration)
     assert perform_substitutions(lc1, result1[0].name) == 'foo'
     assert perform_substitutions(lc1, result1[0].value) == 'FOO'
@@ -276,8 +276,9 @@ def test_include_python():
         assert 'IncludeLaunchDescription' in action.describe()
         assert isinstance(action.describe_sub_entities(), list)
         assert isinstance(action.describe_conditional_sub_entities(), list)
-        # Result should only contain a single launch description as there are no launch arguments.
-        assert len(action.visit(LaunchContext())) == 1
+        # Result should only contain a single launch description (+ internal action) as there are
+        # no launch arguments.
+        assert len(action.visit(LaunchContext())) == 2
         assert action.get_asyncio_future() is None
         assert len(action.launch_arguments) == 0
 

--- a/launch/test/launch/actions/test_include_launch_description.py
+++ b/launch/test/launch/actions/test_include_launch_description.py
@@ -14,6 +14,7 @@
 
 """Tests for the IncludeLaunchDescription action class."""
 
+import os
 from pathlib import Path
 
 from launch import LaunchContext
@@ -22,9 +23,13 @@ from launch import LaunchDescriptionSource
 from launch import LaunchService
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.actions import OpaqueFunction
 from launch.actions import ResetLaunchConfigurations
+from launch.actions import SetEnvironmentVariable
 from launch.actions import SetLaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import ThisLaunchFile
+from launch.substitutions import ThisLaunchFileDir
 from launch.utilities import perform_substitutions
 
 import pytest
@@ -85,6 +90,53 @@ def test_include_launch_description_launch_file_location():
     assert action2.visit(lc2) == [ld2]
     assert lc2.locals.current_launch_file_directory == str(this_file.parent)
     assert action2.get_asyncio_future() is None
+
+
+def test_include_launch_description_launch_file_dir_location_scoped():
+    """Test that the launch file name & dir locals are scoped to the included launch file."""
+    # Rely on the test launch files to set environment variables with
+    # ThisLaunchFile()/ThisLaunchFileDir() to make testing easier
+    parent_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'launch')
+    parent_launch_file = os.path.join(parent_dir, 'parent_launch_file_dir.launch.py')
+    included_dir = os.path.join(parent_dir, 'included')
+    included_launch_file = os.path.join(included_dir, 'launch_file_dir.launch.py')
+
+    # The current launch file/dir context locals should be scoped to the included launch file
+    ld = LaunchDescription([IncludeLaunchDescription(parent_launch_file)])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert 0 == ls.run()
+    lc = ls.context
+    assert lc.environment.get('Before_ThisLaunchFile') == parent_launch_file
+    assert lc.environment.get('Before_ThisLaunchFileDir') == parent_dir
+    assert lc.environment.get('Included_ThisLaunchFile') == included_launch_file
+    assert lc.environment.get('Included_ThisLaunchFileDir') == included_dir
+    assert lc.environment.get('After_ThisLaunchFile') == parent_launch_file
+    assert lc.environment.get('After_ThisLaunchFileDir') == parent_dir
+
+    # The launch file/dir context locals should be completely removed after the first included
+    # (parent) launch file, because at that point we're in a launch script and not a launch file,
+    # and therefore these substitutions should raise an error
+    ld2 = LaunchDescription([
+        IncludeLaunchDescription(parent_launch_file),
+        SetEnvironmentVariable('Outside_ThisLaunchFile', ThisLaunchFile()),
+        SetEnvironmentVariable('Outside_ThisLaunchFileDir', ThisLaunchFileDir()),
+    ])
+    ls2 = LaunchService()
+    ls2.include_launch_description(ld2)
+    assert 1 == ls2.run()
+
+    # The non-launch file/dir context locals should not be scoped to the included launch file
+    def assert_unscoped_context_local(context: LaunchContext):
+        assert context.locals.included_local == 'context_local_value'
+
+    ld3 = LaunchDescription([
+        IncludeLaunchDescription(parent_launch_file),
+        OpaqueFunction(function=assert_unscoped_context_local),
+    ])
+    ls3 = LaunchService()
+    ls3.include_launch_description(ld3)
+    assert 0 == ls3.run()
 
 
 def test_include_launch_description_launch_arguments():


### PR DESCRIPTION
Resolves #618

Some context locals are set by `IncludeLaunchDescription` with the path to the launch file (`current_launch_file_path`) and the path to the directory containing the launch file (`current_launch_file_directory`). They can then be used through substitutions: `ThisLaunchFile()` and `ThisLaunchFileDir()`, respectively. These only make sense in the included launch file itself, and these locals should not be set when not in a(n included) launch file, e.g., when in a launch script. That usually happens when calling the launch service manually, which is common in tests.

The issue reported in #618 is that `IncludeLaunchDescription` doesn't reset the context locals to the previous values. This means that the two launch file location locals point to the included launch file even _after_ the `IncludeLaunchDescription` action in the parent launch file. See the reproducer in the original issue.

The fix is to scope the two launch file location context locals to `IncludeLaunchDescription`. We also have to _remove_ the context locals after `IncludeLaunchDescription` if it was included by a launch script (see test). Since there is no easy way/API to _remove_ locals, I had to work around it a bit. I'm open to ideas to make that better.

Note that the solution _only_ scopes the two launch file location locals to `IncludeLaunchDescription`. Other locals are kept (see test), since included launch files are meant to act as if they were literally included in the parent launch file.