### PR TITLE
Backport the equals and not equals substitutions

### DIFF
--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -20,9 +20,11 @@ from .boolean_substitution import NotSubstitution
 from .boolean_substitution import OrSubstitution
 from .command import Command
 from .environment_variable import EnvironmentVariable
+from .equals_substitution import EqualsSubstitution
 from .find_executable import FindExecutable
 from .launch_configuration import LaunchConfiguration
 from .local_substitution import LocalSubstitution
+from .not_equals_substitution import NotEqualsSubstitution
 from .path_join_substitution import PathJoinSubstitution
 from .python_expression import PythonExpression
 from .substitution_failure import SubstitutionFailure
@@ -35,9 +37,11 @@ __all__ = [
     'AnonName',
     'Command',
     'EnvironmentVariable',
+    'EqualsSubstitution',
     'FindExecutable',
     'LaunchConfiguration',
     'LocalSubstitution',
+    'NotEqualsSubstitution',
     'NotSubstitution',
     'OrSubstitution',
     'PathJoinSubstitution',

--- a/launch/launch/substitutions/equals_substitution.py
+++ b/launch/launch/substitutions/equals_substitution.py
@@ -1,0 +1,130 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the EqualsSubstitution substitution."""
+
+import math
+
+from typing import Any
+from typing import cast
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Text
+from typing import Union
+
+from ..frontend import expose_substitution
+from ..launch_context import LaunchContext
+from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
+from ..utilities import normalize_to_list_of_substitutions
+from ..utilities.type_utils import is_substitution, perform_substitutions
+
+
+def _str_is_bool(input_str: Text) -> bool:
+    """Check if string input is convertible to a boolean."""
+    if not isinstance(input_str, Text):
+        return False
+    else:
+        return input_str.lower() in ('true', 'false', '1', '0')
+
+
+def _str_is_float(input_str: Text) -> bool:
+    """Check if string input is convertible to a float."""
+    try:
+        float(input_str)
+        return True
+    except ValueError:
+        return False
+
+
+@expose_substitution('equals')
+class EqualsSubstitution(Substitution):
+    """
+    Substitution that checks if two inputs are equal.
+
+    Returns 'true' or 'false' strings depending on the result.
+    """
+
+    def __init__(
+        self,
+        left: Optional[Union[Any, Iterable[Any]]],
+        right: Optional[Union[Any, Iterable[Any]]]
+    ) -> None:
+        """Create an EqualsSubstitution substitution."""
+        super().__init__()
+
+        if not is_substitution(left):
+            if left is None:
+                left = ''
+            elif isinstance(left, bool):
+                left = str(left).lower()
+            else:
+                left = str(left)
+
+        if not is_substitution(right):
+            if right is None:
+                right = ''
+            elif isinstance(right, bool):
+                right = str(right).lower()
+            else:
+                right = str(right)
+
+        # mypy is unable to understand that if we passed in the `else` branch
+        # above, left & right must be substitutions. Unfortunately due to the
+        # way is_substitution is written, it's hard to get mypy to typecheck
+        # it correctly, so cast here.
+        self.__left = normalize_to_list_of_substitutions(
+                cast(Union[str, Substitution, Sequence[Union[str, Substitution]]], left)
+                )
+        self.__right = normalize_to_list_of_substitutions(
+                cast(Union[str, Substitution, Sequence[Union[str, Substitution]]], right)
+                )
+
+    @classmethod
+    def parse(cls, data: Sequence[SomeSubstitutionsType]):
+        """Parse `EqualsSubstitution` substitution."""
+        if len(data) != 2:
+            raise TypeError('and substitution expects 2 arguments')
+        return cls, {'left': data[0], 'right': data[1]}
+
+    @property
+    def left(self) -> List[Substitution]:
+        """Getter for left."""
+        return self.__left
+
+    @property
+    def right(self) -> List[Substitution]:
+        """Getter for right."""
+        return self.__right
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'EqualsSubstitution({self.left} {self.right})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        left = perform_substitutions(context, self.left)
+        right = perform_substitutions(context, self.right)
+
+        # Special case for booleans
+        if _str_is_bool(left) and _str_is_bool(right):
+            return str((left.lower() in ('true', '1')) == (right.lower() in ('true', '1'))).lower()
+
+        # Special case for floats (epsilon closeness)
+        if _str_is_float(left) and _str_is_float(right):
+            return str(math.isclose(float(left), float(right))).lower()
+
+        return str(left == right).lower()

--- a/launch/launch/substitutions/not_equals_substitution.py
+++ b/launch/launch/substitutions/not_equals_substitution.py
@@ -1,0 +1,50 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the NotEqualsSubstitution substitution."""
+
+from typing import Any
+from typing import Iterable
+from typing import Optional
+from typing import Text
+from typing import Union
+
+from .equals_substitution import EqualsSubstitution
+from ..frontend import expose_substitution
+from ..launch_context import LaunchContext
+
+
+@expose_substitution('not-equals')
+class NotEqualsSubstitution(EqualsSubstitution):
+    """
+    Substitution that checks if two inputs are not equal.
+
+    Returns 'true' or 'false' strings depending on the result.
+    """
+
+    def __init__(
+        self,
+        left: Optional[Union[Any, Iterable[Any]]],
+        right: Optional[Union[Any, Iterable[Any]]]
+    ) -> None:
+        """Create a NotEqualsSubstitution substitution."""
+        super().__init__(left, right)
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return f'NotEqualsSubstitution({self.left} {self.right})'
+
+    def perform(self, context: LaunchContext) -> Text:
+        """Perform the substitution."""
+        return str(not (super().perform(context) == 'true')).lower()

--- a/launch/test/launch/substitutions/test_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_equals_substitution.py
@@ -1,0 +1,115 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the EqualsSubstitution class."""
+
+import os
+
+from launch import LaunchContext
+
+from launch.substitutions import EqualsSubstitution
+from launch.substitutions import PathJoinSubstitution
+
+
+def test_equals_substitution():
+    def _permute_assertion(left, right, context, output):
+        assert EqualsSubstitution(left, right).perform(context) == output
+        assert EqualsSubstitution(right, left).perform(context) == output
+
+    lc = LaunchContext()
+
+    # NoneType
+    _permute_assertion(None, None, lc, 'true')
+    _permute_assertion(None, '', lc, 'true')
+    _permute_assertion(None, 'something', lc, 'false')
+
+    # Booleans
+    _permute_assertion(True, True, lc, 'true')
+    _permute_assertion(False, False, lc, 'true')
+    _permute_assertion(True, False, lc, 'false')
+
+    _permute_assertion(True, 'true', lc, 'true')
+    _permute_assertion(True, 'True', lc, 'true')
+    _permute_assertion(False, 'false', lc, 'true')
+    _permute_assertion(False, 'False', lc, 'true')
+    _permute_assertion(True, 'False', lc, 'false')
+
+    _permute_assertion(True, 1, lc, 'true')
+    _permute_assertion(True, '1', lc, 'true')
+    _permute_assertion(True, 0, lc, 'false')
+    _permute_assertion(True, '0', lc, 'false')
+    _permute_assertion(True, '10', lc, 'false')
+    _permute_assertion(True, '-1', lc, 'false')
+
+    _permute_assertion(False, 1, lc, 'false')
+    _permute_assertion(False, '1', lc, 'false')
+    _permute_assertion(False, 0, lc, 'true')
+    _permute_assertion(False, '0', lc, 'true')
+    _permute_assertion(False, '10', lc, 'false')
+    _permute_assertion(False, '-1', lc, 'false')
+
+    _permute_assertion('true', 1, lc, 'true')
+    _permute_assertion('true', '1', lc, 'true')
+    _permute_assertion('true', '0', lc, 'false')
+    _permute_assertion('true', 'true', lc, 'true')
+    _permute_assertion('false', 1, lc, 'false')
+    _permute_assertion('false', '1', lc, 'false')
+    _permute_assertion('false', '0', lc, 'true')
+    _permute_assertion('false', 'false', lc, 'true')
+    _permute_assertion('true', 'false', lc, 'false')
+
+    # Numerics
+    _permute_assertion(1, 1, lc, 'true')
+    _permute_assertion(1, 0, lc, 'false')
+    _permute_assertion(1, -1, lc, 'false')
+    _permute_assertion(10, 10, lc, 'true')
+    _permute_assertion(10, -10, lc, 'false')
+
+    _permute_assertion(10, 10.0, lc, 'true')
+    _permute_assertion(10, 10 + 1e-10, lc, 'true')
+    _permute_assertion(10, 10.1, lc, 'false')
+    _permute_assertion(10.0, -10.0, lc, 'false')
+
+    _permute_assertion(float('nan'), float('nan'), lc, 'false')
+    _permute_assertion(float('nan'), 'nan', lc, 'false')
+    _permute_assertion('nan', 'nan', lc, 'false')  # Special case
+
+    _permute_assertion(float('inf'), float('inf'), lc, 'true')
+    _permute_assertion(float('inf'), 'inf', lc, 'true')
+    _permute_assertion('inf', 'inf', lc, 'true')
+
+    _permute_assertion(float('inf'), float('-inf'), lc, 'false')
+    _permute_assertion(float('inf'), '-inf', lc, 'false')
+    _permute_assertion('inf', '-inf', lc, 'false')
+    _permute_assertion('-inf', '-inf', lc, 'true')
+
+    # Numerics (scientific E notation)
+    _permute_assertion('1234e1', '12340', lc, 'true')
+    _permute_assertion('1234E2', '123400', lc, 'true')
+    _permute_assertion('1234E2', '1234E2', lc, 'true')
+    _permute_assertion("'1234E2'", '123400', lc, 'false')
+    _permute_assertion("'1234E2'", '1234E2', lc, 'false')
+    _permute_assertion("'1234E2'", "'1234E2'", lc, 'true')
+
+    # Strings
+    _permute_assertion('wow', 'wow', lc, 'true')
+    _permute_assertion('wow', True, lc, 'false')
+    _permute_assertion('wow', 1, lc, 'false')
+    _permute_assertion('wow', 0, lc, 'false')
+    _permute_assertion('wow', 10, lc, 'false')
+
+    # Substitutions
+    path = ['asd', 'bsd', 'cds']
+    sub = PathJoinSubstitution(path)
+    assert EqualsSubstitution(sub, os.path.join(*path)).perform(lc) == 'true'

--- a/launch/test/launch/substitutions/test_not_equals_substitution.py
+++ b/launch/test/launch/substitutions/test_not_equals_substitution.py
@@ -1,0 +1,107 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the NotEqualsSubstitution class."""
+
+import os
+
+from launch import LaunchContext
+
+from launch.substitutions import NotEqualsSubstitution
+from launch.substitutions import PathJoinSubstitution
+
+
+def test_not_equals_substitution():
+    def _permute_assertion(left, right, context, output):
+        assert NotEqualsSubstitution(left, right).perform(context) == output
+        assert NotEqualsSubstitution(right, left).perform(context) == output
+
+    lc = LaunchContext()
+
+    # NoneType
+    _permute_assertion(None, None, lc, 'false')
+    _permute_assertion(None, '', lc, 'false')
+    _permute_assertion(None, 'something', lc, 'true')
+
+    # Booleans
+    _permute_assertion(True, True, lc, 'false')
+    _permute_assertion(False, False, lc, 'false')
+    _permute_assertion(True, False, lc, 'true')
+
+    _permute_assertion(True, 'true', lc, 'false')
+    _permute_assertion(True, 'True', lc, 'false')
+    _permute_assertion(False, 'false', lc, 'false')
+    _permute_assertion(False, 'False', lc, 'false')
+    _permute_assertion(True, 'False', lc, 'true')
+
+    _permute_assertion(True, 1, lc, 'false')
+    _permute_assertion(True, '1', lc, 'false')
+    _permute_assertion(True, 0, lc, 'true')
+    _permute_assertion(True, '0', lc, 'true')
+    _permute_assertion(True, '10', lc, 'true')
+    _permute_assertion(True, '-1', lc, 'true')
+
+    _permute_assertion(False, 1, lc, 'true')
+    _permute_assertion(False, '1', lc, 'true')
+    _permute_assertion(False, 0, lc, 'false')
+    _permute_assertion(False, '0', lc, 'false')
+    _permute_assertion(False, '10', lc, 'true')
+    _permute_assertion(False, '-1', lc, 'true')
+
+    _permute_assertion('true', 1, lc, 'false')
+    _permute_assertion('true', '1', lc, 'false')
+    _permute_assertion('true', '0', lc, 'true')
+    _permute_assertion('true', 'true', lc, 'false')
+    _permute_assertion('false', 1, lc, 'true')
+    _permute_assertion('false', '1', lc, 'true')
+    _permute_assertion('false', '0', lc, 'false')
+    _permute_assertion('false', 'false', lc, 'false')
+    _permute_assertion('true', 'false', lc, 'true')
+
+    # Numerics
+    _permute_assertion(1, 1, lc, 'false')
+    _permute_assertion(1, 0, lc, 'true')
+    _permute_assertion(1, -1, lc, 'true')
+    _permute_assertion(10, 10, lc, 'false')
+    _permute_assertion(10, -10, lc, 'true')
+
+    _permute_assertion(10, 10.0, lc, 'false')
+    _permute_assertion(10, 10 + 1e-10, lc, 'false')
+    _permute_assertion(10, 10.1, lc, 'true')
+    _permute_assertion(10.0, -10.0, lc, 'true')
+
+    _permute_assertion(float('nan'), float('nan'), lc, 'true')
+    _permute_assertion(float('nan'), 'nan', lc, 'true')
+    _permute_assertion('nan', 'nan', lc, 'true')  # Special case
+
+    _permute_assertion(float('inf'), float('inf'), lc, 'false')
+    _permute_assertion(float('inf'), 'inf', lc, 'false')
+    _permute_assertion('inf', 'inf', lc, 'false')
+
+    _permute_assertion(float('inf'), float('-inf'), lc, 'true')
+    _permute_assertion(float('inf'), '-inf', lc, 'true')
+    _permute_assertion('inf', '-inf', lc, 'true')
+    _permute_assertion('-inf', '-inf', lc, 'false')
+
+    # Strings
+    _permute_assertion('wow', 'wow', lc, 'false')
+    _permute_assertion('wow', True, lc, 'true')
+    _permute_assertion('wow', 1, lc, 'true')
+    _permute_assertion('wow', 0, lc, 'true')
+    _permute_assertion('wow', 10, lc, 'true')
+
+    # Substitutions
+    path = ['asd', 'bsd', 'cds']
+    sub = PathJoinSubstitution(path)
+    assert NotEqualsSubstitution(sub, os.path.join(*path)).perform(lc) == 'false'


### PR DESCRIPTION
Hello,

This PR backports the equals and not equals substitutions to humble along with their tests.

Update:
More information:

This is a backport of the PR https://github.com/ros2/launch/pull/649