### PR TITLE
Allow `include:` to take a single text element instead of requiring `file:`

### DIFF
--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -86,7 +86,9 @@ class IncludeLaunchDescription(Action):
     def parse(cls, entity: Entity, parser: Parser):
         """Return `IncludeLaunchDescription` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
-        file_path = parser.parse_substitution(entity.get_attr('file'))
+        file_attr = entity.get_attr('file') if not entity.is_element() else entity.element
+        file_path = parser.parse_substitution(file_attr)
+
         kwargs['launch_description_source'] = file_path
         args = entity.get_attr('arg', data_type=List[Entity], optional=True)
         if args is not None:

--- a/launch/launch/actions/include_launch_description.py
+++ b/launch/launch/actions/include_launch_description.py
@@ -86,7 +86,7 @@ class IncludeLaunchDescription(Action):
     def parse(cls, entity: Entity, parser: Parser):
         """Return `IncludeLaunchDescription` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
-        file_attr = entity.get_attr('file') if not entity.is_element() else entity.element
+        file_attr = entity.bare_text or entity.get_attr('file')
         file_path = parser.parse_substitution(file_attr)
 
         kwargs['launch_description_source'] = file_path

--- a/launch/launch/frontend/entity.py
+++ b/launch/launch/frontend/entity.py
@@ -116,3 +116,8 @@ class Entity:
         function completed.
         """
         raise NotImplementedError()
+
+    @property
+    def bare_text(self) -> Optional[Text]:
+        """Return the bare text of this element if it is a bare text element, or None."""
+        raise NotImplementedError()

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -37,14 +37,12 @@ class Entity(BaseEntity):
         parent: 'Entity' = None
     ) -> Text:
         """Construct the Entity."""
-        text = xml_element.text.strip() if xml_element.text else None
-        num_children = len([i for i in xml_element])
-        self.__is_element = False
-        if text and num_children:
-            raise ValueError(f'Cannot provide XML text alongside children. Found text "{text}" and {num_children} child(ren) in element {xml_element}')
-        elif text:
-            self.__is_element = True
-            self.__element = text
+        self.__bare_text = xml_element.text.strip() if xml_element.text else None
+        num_children = len(list(xml_element))
+        if self.__bare_text and num_children:
+            raise ValueError(
+                f'Cannot provide XML text alongside children. Found text "{self.__bare_text}" '
+                f'and {num_children} child(ren) in element {xml_element}')
 
         self.__xml_element = xml_element
         self.__parent = parent
@@ -81,12 +79,9 @@ class Entity(BaseEntity):
                 f'{unparsed_attributes}'
             )
 
-    def is_element(self) -> bool:
-        return self.__is_element
-
     @property
-    def element(self) -> Text:
-        return self.__element
+    def bare_text(self) -> Optional[Text]:
+        return self.__bare_text
 
     def get_attr(
         self,

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -37,6 +37,15 @@ class Entity(BaseEntity):
         parent: 'Entity' = None
     ) -> Text:
         """Construct the Entity."""
+        text = xml_element.text.strip() if xml_element.text else None
+        num_children = len([i for i in xml_element])
+        self.__is_element = False
+        if text and num_children:
+            raise ValueError(f'Cannot provide XML text alongside children. Found text "{text}" and {num_children} child(ren) in element {xml_element}')
+        elif text:
+            self.__is_element = True
+            self.__element = text
+
         self.__xml_element = xml_element
         self.__parent = parent
         self.__read_attributes = set()
@@ -71,6 +80,13 @@ class Entity(BaseEntity):
                 f'Unexpected attribute(s) found in `{self.__xml_element.tag}`: '
                 f'{unparsed_attributes}'
             )
+
+    def is_element(self) -> bool:
+        return self.__is_element
+
+    @property
+    def element(self) -> Text:
+        return self.__element
 
     def get_attr(
         self,

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -31,7 +31,7 @@ class Entity(BaseEntity):
 
     def __init__(
         self,
-        element: dict,
+        element: Union[dict, List, Text],
         type_name: Text = None,
         *,
         parent: 'Entity' = None
@@ -70,6 +70,8 @@ class Entity(BaseEntity):
                     'list element')
             self.__read_keys.add('children')
             children = self.__element['children']
+        elif isinstance(self.__element, str):
+            return [self]
         else:
             children = self.__element
         entities = []
@@ -83,6 +85,8 @@ class Entity(BaseEntity):
         return entities
 
     def assert_entity_completely_parsed(self):
+        if isinstance(self.__element, str):
+            return
         if isinstance(self.__element, list):
             if not self.__children_called:
                 raise ValueError(
@@ -94,6 +98,15 @@ class Entity(BaseEntity):
             raise ValueError(
                 f'Unexpected key(s) found in `{self.__type_name}`: {unparsed_keys}'
             )
+
+    def is_element(self) -> bool:
+        return isinstance(self.__element, str)
+
+    @property
+    def element(self) -> Text:
+        if not self.is_element():
+            raise RuntimeError('Directly retrieving the element of a non-str Entity is ill-formed.')
+        return self.__element
 
     def get_attr(
         self,

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -37,6 +37,7 @@ class Entity(BaseEntity):
         parent: 'Entity' = None
     ) -> Text:
         """Create an Entity."""
+        self.__bare_text = element if isinstance(element, str) else None
         self.__type_name = type_name
         self.__element = element
         self.__parent = parent
@@ -99,13 +100,8 @@ class Entity(BaseEntity):
                 f'Unexpected key(s) found in `{self.__type_name}`: {unparsed_keys}'
             )
 
-    def is_element(self) -> bool:
-        return isinstance(self.__element, str)
-
     @property
-    def element(self) -> Text:
-        if not self.is_element():
-            raise RuntimeError('Directly retrieving the element of a non-str Entity is ill-formed.')
+    def bare_text(self) -> Optional[Text]:
         return self.__element
 
     def get_attr(

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -102,7 +102,7 @@ class Entity(BaseEntity):
 
     @property
     def bare_text(self) -> Optional[Text]:
-        return self.__element
+        return self.__bare_text
 
     def get_attr(
         self,

--- a/launch_yaml/test/launch_yaml/executable.yaml
+++ b/launch_yaml/test/launch_yaml/executable.yaml
@@ -1,0 +1,15 @@
+---
+launch:
+  - executable:
+      cmd: ls -l -a -s
+      cwd: /
+      name: my_ls
+      shell: true
+      output: log
+      emulate_tty: true
+      sigkill_timeout: 4.0
+      sigterm_timeout: 7.0
+      launch-prefix: $(env LAUNCH_PREFIX '')
+      env:
+        - name: var
+          value: "1"

--- a/launch_yaml/test/launch_yaml/test_include.py
+++ b/launch_yaml/test/launch_yaml/test_include.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Polymath Robotics, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test parsing an include action."""
+"""Test parsing a launch file inclusion."""
 
 import io
 from pathlib import Path
@@ -26,17 +26,15 @@ from parser_no_extensions import load_no_extensions
 
 
 def test_include():
-    """Parse node xml example."""
-    # Always use posix style paths in launch XML files.
-    path = (Path(__file__).parent / 'executable.xml').as_posix()
-    xml_file = \
-        """\
-        <launch>
-            <include file="{}"/>
-        </launch>
-        """.format(path)  # noqa: E501
-    xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+    """Parse include yaml example."""
+    path = (Path(__file__).parent / 'executable.yaml').as_posix()
+    yaml_file = f"""\
+        launch:
+          - include:
+              file: {path}
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
     include = ld.entities[0]
     assert isinstance(include, IncludeLaunchDescription)
@@ -47,14 +45,14 @@ def test_include():
 
 
 def test_include_bare_text():
-    path = (Path(__file__).parent / 'executable.xml').as_posix()
-    xml_file = f"""
-        <launch>
-            <include>{path}</include>
-        </launch>
-    """
-    xml_file = textwrap.dedent(xml_file)
-    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+    """Parse include yaml example."""
+    path = (Path(__file__).parent / 'executable.yaml').as_posix()
+    yaml_file = f"""
+        launch:
+          - include: {path}
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
     ld = parser.parse_description(root_entity)
     include = ld.entities[0]
     assert isinstance(include, IncludeLaunchDescription)


### PR DESCRIPTION
Closes robograph-project/docs#15

Not sure this  _has_ to be in launch, but it's part of an ergonomics sweep I'm doing while writing more YAML/XML launchfiles.

I felt that for simple actions, it made sense to be able to just pass the single argument as a bare text element to the action, rather than requiring a `list` or `dict` contents.

Specifically, the following felt obvious, but was not supported, and probably makes sense for some other Actions.

```
---
# Before
launch:
  - include:
      file: $(find-pkg-share pkg)/launch/my_launch.yaml
      
# After
launch:
  - include: $(find-pkg-share pkg)/launch/my_launch.yaml
```

```
# Before
<launch>
  <include file="$(find-pkg-share pkg)/launch/my_launch.xml"/>
<launch>

# After
<launch>
  <include>$(find-pkg-share pkg)/launch/my_launch.xml</include>
</launch>
```

Admittedly, the XML one is actually more verbose, it's a bigger improvement for simple YAML.

This is a complete enhancement PR with unit tests for the new feature, if others agree that this makes sense.

Argument for: This matches the Python API more directly since `IncludeLaunchDescription` takes a non-keyword first argument for the `launch_description_source`. It also allows for shorter, clearer launchfiles for simple usage

Argument against: most real usage has other attributes, `arg` etc, allowing this simple syntax could make things more confusing by having multiple ways of doing things.