### PR TITLE
Add a `/` path join operator for `PathJoinSubstitution`

### DIFF
--- a/launch/launch/substitutions/__init__.py
+++ b/launch/launch/substitutions/__init__.py
@@ -33,6 +33,7 @@ from .launch_log_dir import LaunchLogDir
 from .local_substitution import LocalSubstitution
 from .not_equals_substitution import NotEqualsSubstitution
 from .path_join_substitution import PathJoinSubstitution
+from .path_join_substitution import PathSubstitution
 from .python_expression import PythonExpression
 from .string_join_substitution import StringJoinSubstitution
 from .substitution_failure import SubstitutionFailure
@@ -60,6 +61,7 @@ __all__ = [
     'NotEqualsSubstitution',
     'OrSubstitution',
     'PathJoinSubstitution',
+    'PathSubstitution',
     'PythonExpression',
     'StringJoinSubstitution',
     'SubstitutionFailure',

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -22,6 +22,7 @@ from typing import Text
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
+from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
 
 
@@ -83,3 +84,8 @@ class PathJoinSubstitution(Substitution):
             for component_substitutions in self.substitutions
         ]
         return os.path.join(*path_components)
+
+    def __truediv__(self, additional_path: SomeSubstitutionsType) -> 'PathJoinSubstitution':
+        """Join path substitutions using the / operator, mimicking pathlib.Path operation."""
+        return PathJoinSubstitution(
+            self.substitutions + [normalize_to_list_of_substitutions(additional_path)])

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -43,6 +43,13 @@ class PathJoinSubstitution(Substitution):
             ['config_', LaunchConfiguration('map'), '.yml']
         ])
 
+    Or:
+
+    .. code-block:: python
+
+        cfg_dir = PathJoinSubstitution([EnvironmentVariable('SOME_DIR'), 'cfg'])
+        cfg_file = cfg_dir / ['config_', LaunchConfiguration('map'), '.yml']
+
     If the ``SOME_DIR`` environment variable was set to ``/home/user/dir`` and the ``map`` launch
     configuration was set to ``my_map``, this would result in a path equal equivalent to (depending
     on the platform):
@@ -92,7 +99,20 @@ class PathJoinSubstitution(Substitution):
 
 
 class PathSubstitution(PathJoinSubstitution):
-    """Thin wrapper on PathJoinSubstitution for more pathlib.Path-like construction."""
+    """
+    Thin wrapper on PathJoinSubstitution for more pathlib.Path-like construction.
+
+    .. code-block:: python
+
+        PathSubstitution(LaunchConfiguration('base_dir')) / 'sub_dir' / 'file_name'
+
+    Which, for `base_dir:=/my_dir`, results in (depending on the platform)
+
+    .. code-block:: python
+
+        /my_dir/sub_dir/file_name
+
+    """
 
     def __init__(self, path: SomeSubstitutionsType):
         """

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -106,7 +106,7 @@ class PathSubstitution(PathJoinSubstitution):
 
         PathSubstitution(LaunchConfiguration('base_dir')) / 'sub_dir' / 'file_name'
 
-    Which, for `base_dir:=/my_dir`, results in (depending on the platform)
+    Which, for ``base_dir:=/my_dir``, results in (depending on the platform):
 
     .. code-block:: python
 

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -89,3 +89,16 @@ class PathJoinSubstitution(Substitution):
         """Join path substitutions using the / operator, mimicking pathlib.Path operation."""
         return PathJoinSubstitution(
             self.substitutions + [normalize_to_list_of_substitutions(additional_path)])
+
+
+class PathSubstitution(PathJoinSubstitution):
+    """Thin wrapper on PathJoinSubstitution for more pathlib.Path-like construction."""
+
+    def __init__(self, path: SomeSubstitutionsType):
+        """
+        Create a PathSubstitution.
+
+        :param path: May be a single text or Substitution element,
+        or an Iterable of them which are then joined
+        """
+        super().__init__(normalize_to_list_of_substitutions(path))

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -35,4 +35,5 @@ def test_path_join():
     sub = PathSubstitution('some') / 'path'
     sub = sub / PathJoinSubstitution(['to', 'some', 'dir'])
     sub = sub / (TextSubstitution(text='my_model'), '.xacro')
-    assert sub.perform(context) == os.path.join('some', 'path', 'to', 'some', 'dir', 'my_model.xacro')
+    assert sub.perform(context) == os.path.join(
+        'some', 'path', 'to', 'some', 'dir', 'my_model.xacro')

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -33,5 +33,6 @@ def test_path_join():
     assert sub.perform(context) == os.path.join('path', 'to', 'my_file.yaml')
 
     sub = PathSubstitution('some') / 'path'
-    sub = sub / PathJoinSubstitution(['to', 'some', 'file'])
-    assert sub.perform(context) == os.path.join('some', 'path', 'to', 'some', 'file')
+    sub = sub / PathJoinSubstitution(['to', 'some', 'dir'])
+    sub = sub / (TextSubstitution(text='my_model'), '.xacro')
+    assert sub.perform(context) == os.path.join('some', 'path', 'to', 'some', 'dir', 'my_model.xacro')

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -17,7 +17,7 @@
 import os
 
 from launch import LaunchContext
-from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import PathJoinSubstitution, PathSubstitution
 from launch.substitutions import TextSubstitution
 
 
@@ -31,3 +31,7 @@ def test_path_join():
     path = ['path', ['to'], ['my_', TextSubstitution(text='file'), '.yaml']]
     sub = PathJoinSubstitution(path)
     assert sub.perform(context) == os.path.join('path', 'to', 'my_file.yaml')
+
+    sub = PathSubstitution('some') / 'path'
+    sub = sub / PathJoinSubstitution(['to', 'some', 'file'])
+    assert sub.perform(context) == os.path.join('some', 'path', 'to', 'some', 'file')


### PR DESCRIPTION
Closes https://github.com/robograph-project/docs/issues/18

Adds a `PathJoinSubstition(['stuff']) / 'other` pattern.

Also adds a `PathSubstitution` simple wrapper that allows for passing a single value like: `PathSubstitution('path') / 'subdir' / PathJoinSubstitution(['some', 'things'])`

Make launch feel a little more natural, match the modern `pathlib.Path` API which we should be encouraging more, I see a lot of `os.path` in user-facing examples.

Part of ergonomics pass.
