### PR TITLE
Allow Path in substitutions, instead of requiring cast to str

### DIFF
--- a/launch/launch/launch_description_sources/python_launch_file_utilities.py
+++ b/launch/launch/launch_description_sources/python_launch_file_utilities.py
@@ -17,8 +17,10 @@
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec
 from importlib.util import spec_from_loader
+from pathlib import Path
 from types import ModuleType
 from typing import Text
+from typing import Union
 
 from ..launch_description import LaunchDescription
 
@@ -29,9 +31,9 @@ class InvalidPythonLaunchFileError(Exception):
     ...
 
 
-def load_python_launch_file_as_module(python_launch_file_path: Text) -> ModuleType:
+def load_python_launch_file_as_module(python_launch_file_path: Union[Text, Path]) -> ModuleType:
     """Load a given Python launch file (by path) as a Python module."""
-    loader = SourceFileLoader('python_launch_file', python_launch_file_path)
+    loader = SourceFileLoader('python_launch_file', str(python_launch_file_path))
     spec = spec_from_loader(loader.name, loader)
     if spec is None:
         raise RuntimeError('Failed to load module spec!')
@@ -41,7 +43,7 @@ def load_python_launch_file_as_module(python_launch_file_path: Text) -> ModuleTy
 
 
 def get_launch_description_from_python_launch_file(
-    python_launch_file_path: Text
+    python_launch_file_path: Union[Text, Path]
 ) -> LaunchDescription:
     """
     Load a given Python launch file (by path), and return the launch description from it.

--- a/launch/launch/some_substitutions_type.py
+++ b/launch/launch/some_substitutions_type.py
@@ -15,6 +15,7 @@
 """Module for SomeSubstitutionsType type."""
 
 import collections.abc
+from pathlib import Path
 from typing import Iterable
 from typing import Text
 from typing import Union
@@ -23,12 +24,14 @@ from .substitution import Substitution
 
 SomeSubstitutionsType = Union[
     Text,
+    Path,
     Substitution,
-    Iterable[Union[Text, Substitution]],
+    Iterable[Union[Text, Path, Substitution]],
 ]
 
 SomeSubstitutionsType_types_tuple = (
     str,
+    Path,
     Substitution,
     collections.abc.Iterable,
 )

--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -14,7 +14,7 @@
 
 """Module for the PathJoinSubstitution substitution."""
 
-import os
+from pathlib import Path
 from typing import Iterable
 from typing import List
 from typing import Text
@@ -90,7 +90,7 @@ class PathJoinSubstitution(Substitution):
             perform_substitutions(context, component_substitutions)
             for component_substitutions in self.substitutions
         ]
-        return os.path.join(*path_components)
+        return str(Path(*path_components))
 
     def __truediv__(self, additional_path: SomeSubstitutionsType) -> 'PathJoinSubstitution':
         """Join path substitutions using the / operator, mimicking pathlib.Path operation."""

--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -16,6 +16,7 @@
 
 import collections.abc
 import importlib
+from pathlib import Path
 from typing import List
 from typing import Sequence
 from typing import Text
@@ -72,6 +73,7 @@ class PythonExpression(Substitution):
             # Check if we got empty list from XML
             # Ensure that we got a list!
             assert not isinstance(data[1], str)
+            assert not isinstance(data[1], Path)
             assert not isinstance(data[1], Substitution)
             # Modules
             modules = list(data[1])

--- a/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
+++ b/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
@@ -32,8 +32,8 @@ def normalize_to_list_of_substitutions(subs: SomeSubstitutionsType) -> List[Subs
     def normalize(x):
         if isinstance(x, Substitution):
             return x
-        if isinstance(x, str):
-            return TextSubstitution(text=x)
+        if isinstance(x, (str, Path)):
+            return TextSubstitution(text=str(x))
         raise TypeError(
             "Failed to normalize given item of type '{}', when only "
             "'str' or 'launch.Substitution' were expected.".format(type(x)))

--- a/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
+++ b/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
@@ -14,6 +14,7 @@
 
 """Module for the normalize_to_list_of_substitutions() utility function."""
 
+from pathlib import Path
 from typing import cast
 from typing import Iterable
 from typing import List
@@ -37,8 +38,8 @@ def normalize_to_list_of_substitutions(subs: SomeSubstitutionsType) -> List[Subs
             "Failed to normalize given item of type '{}', when only "
             "'str' or 'launch.Substitution' were expected.".format(type(x)))
 
-    if isinstance(subs, str):
-        return [TextSubstitution(text=subs)]
+    if isinstance(subs, (str, Path)):
+        return [TextSubstitution(text=str(subs))]
     if is_a_subclass(subs, Substitution):
         return [cast(Substitution, subs)]
     return [normalize(y) for y in cast(Iterable, subs)]

--- a/launch/launch/utilities/typing_file_path.py
+++ b/launch/launch/utilities/typing_file_path.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
 import typing
 
 # Type of a filesystem path
-FilePath = typing.TypeVar('FilePath', str, bytes, os.PathLike)
+FilePath = typing.TypeVar('FilePath', str, bytes, os.PathLike, Path)

--- a/launch/test/launch/actions/test_include_launch_description.py
+++ b/launch/test/launch/actions/test_include_launch_description.py
@@ -14,7 +14,7 @@
 
 """Tests for the IncludeLaunchDescription action class."""
 
-import os
+from pathlib import Path
 
 from launch import LaunchContext
 from launch import LaunchDescription
@@ -74,7 +74,7 @@ def test_include_launch_description_launch_file_location():
     assert lc1.locals.current_launch_file_directory == '<script>'
     assert action.get_asyncio_future() is None
 
-    this_file = os.path.abspath(__file__)
+    this_file = Path(__file__).absolute()
     ld2 = LaunchDescription()
     action2 = IncludeLaunchDescription(LaunchDescriptionSource(ld2, this_file))
     assert 'IncludeLaunchDescription' in action2.describe()
@@ -83,7 +83,7 @@ def test_include_launch_description_launch_file_location():
     lc2 = LaunchContext()
     # Result should only contain the launch description as there are no launch arguments.
     assert action2.visit(lc2) == [ld2]
-    assert lc2.locals.current_launch_file_directory == os.path.dirname(this_file)
+    assert lc2.locals.current_launch_file_directory == str(this_file.parent)
     assert action2.get_asyncio_future() is None
 
 
@@ -209,11 +209,8 @@ def test_include_launch_description_launch_arguments():
 
 def test_include_python():
     """Test including Python, with and without explicit PythonLaunchDescriptionSource."""
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    simple_launch_file_path = os.path.join(this_dir,
-                                           '..',
-                                           'launch_description_source',
-                                           'simple.launch.py')
+    this_dir = Path(__file__).parent
+    simple_launch_file_path = this_dir.parent / 'launch_description_source' / 'simple.launch.py'
 
     # Explicitly construct with PythonLaunchDescriptionSource
     plds = PythonLaunchDescriptionSource(simple_launch_file_path)
@@ -232,4 +229,4 @@ def test_include_python():
         assert action.get_asyncio_future() is None
         assert len(action.launch_arguments) == 0
 
-        assert action.launch_description_source.location == simple_launch_file_path
+        assert action.launch_description_source.location == str(simple_launch_file_path)

--- a/launch/test/launch/launch_description_source/test_python_launch_description_source.py
+++ b/launch/test/launch/launch_description_source/test_python_launch_description_source.py
@@ -14,7 +14,7 @@
 
 """Tests for the PythonLaunchDescriptionSource class."""
 
-import os
+from pathlib import Path
 
 from launch import LaunchContext
 from launch.launch_description_sources import InvalidPythonLaunchFileError
@@ -25,17 +25,17 @@ import pytest
 
 def test_python_launch_description_source():
     """Test the PythonLaunchDescriptionSource class."""
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    simple_launch_file_path = os.path.join(this_dir, 'simple.launch.py')
+    this_dir = Path(__file__).parent
+    simple_launch_file_path = this_dir / 'simple.launch.py'
     plds = PythonLaunchDescriptionSource(simple_launch_file_path)
     assert 'python launch file' in plds.method
     assert 'launch.substitutions.text_substitution.TextSubstitution' in plds.location
     ld = plds.get_launch_description(LaunchContext())
-    assert plds.location == simple_launch_file_path
+    assert plds.location == str(simple_launch_file_path)
     assert 0 == len(ld.entities)
 
     with pytest.raises(InvalidPythonLaunchFileError):
-        plds = PythonLaunchDescriptionSource(os.path.join(this_dir, 'loadable_python_module.py'))
+        plds = PythonLaunchDescriptionSource(this_dir / 'loadable_python_module.py')
         ld = plds.get_launch_description(LaunchContext())
 
     with pytest.raises(FileNotFoundError):

--- a/launch/test/launch/launch_description_source/test_python_launch_file_utilities.py
+++ b/launch/test/launch/launch_description_source/test_python_launch_file_utilities.py
@@ -14,7 +14,7 @@
 
 """Tests for the Python launch file utility functions."""
 
-import os
+from pathlib import Path
 import sys
 
 from launch.launch_description_sources import get_launch_description_from_python_launch_file
@@ -26,8 +26,8 @@ import pytest
 
 def test_load_python_launch_file_as_module():
     """Test load_python_launch_file_as_module()."""
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    module = load_python_launch_file_as_module(os.path.join(this_dir, 'loadable_python_module.py'))
+    this_dir = Path(__file__).parent
+    module = load_python_launch_file_as_module(this_dir / 'loadable_python_module.py')
     assert sys.executable == module.some_function()
 
     with pytest.raises(FileNotFoundError):
@@ -36,13 +36,12 @@ def test_load_python_launch_file_as_module():
 
 def test_get_launch_description_from_python_launch_file():
     """Test get_launch_description_from_python_launch_file()."""
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    ld = get_launch_description_from_python_launch_file(os.path.join(this_dir, 'simple.launch.py'))
+    this_dir = Path(__file__).parent
+    ld = get_launch_description_from_python_launch_file(this_dir / 'simple.launch.py')
     assert 0 == len(ld.entities)
 
     with pytest.raises(InvalidPythonLaunchFileError):
-        ld = get_launch_description_from_python_launch_file(
-            os.path.join(this_dir, 'loadable_python_module.py'))
+        ld = get_launch_description_from_python_launch_file(this_dir / 'loadable_python_module.py')
 
     with pytest.raises(FileNotFoundError):
         ld = get_launch_description_from_python_launch_file('does_not_exist')

--- a/launch/test/launch/substitutions/test_command.py
+++ b/launch/test/launch/substitutions/test_command.py
@@ -29,9 +29,9 @@ def commands():
     this_dir = pathlib.Path(__file__).parent
 
     commands = {
-        'normal': str(this_dir / 'test_command' / 'normal_command.bash'),
-        'failing': str(this_dir / 'test_command' / 'failing_command.bash'),
-        'with_stderr': str(this_dir / 'test_command' / 'command_with_stderr.bash')
+        'normal': this_dir / 'test_command' / 'normal_command.bash',
+        'failing': this_dir / 'test_command' / 'failing_command.bash',
+        'with_stderr': this_dir / 'test_command' / 'command_with_stderr.bash'
     }
 
     if os.name == 'nt':

--- a/launch/test/launch/substitutions/test_command.py
+++ b/launch/test/launch/substitutions/test_command.py
@@ -36,7 +36,7 @@ def commands():
 
     if os.name == 'nt':
         for key, value in commands.items():
-            commands[key] = value.with_suffix('bat')
+            commands[key] = value.with_suffix('.bat')
     return commands
 
 

--- a/launch/test/launch/substitutions/test_command.py
+++ b/launch/test/launch/substitutions/test_command.py
@@ -36,7 +36,7 @@ def commands():
 
     if os.name == 'nt':
         for key, value in commands.items():
-            commands[key] = value.replace('bash', 'bat')
+            commands[key] = value.with_suffix('bat')
     return commands
 
 

--- a/launch/test/launch/substitutions/test_file_content.py
+++ b/launch/test/launch/substitutions/test_file_content.py
@@ -28,8 +28,8 @@ def files():
     this_dir = pathlib.Path(__file__).parent
 
     files = {
-        'foo': str(this_dir / 'test_file_content' / 'foo.txt'),
-        'bar': str(this_dir / 'test_file_content' / 'bar.txt'),
+        'foo': this_dir / 'test_file_content' / 'foo.txt',
+        'bar': this_dir / 'test_file_content' / 'bar.txt',
     }
 
     return files

--- a/launch/test/launch/substitutions/test_path_join_substitution.py
+++ b/launch/test/launch/substitutions/test_path_join_substitution.py
@@ -14,7 +14,7 @@
 
 """Tests for the PathJoinSubstitution substitution class."""
 
-import os
+from pathlib import Path
 
 from launch import LaunchContext
 from launch.substitutions import PathJoinSubstitution, PathSubstitution
@@ -26,14 +26,17 @@ def test_path_join():
 
     path = ['asd', 'bsd', 'cds']
     sub = PathJoinSubstitution(path)
-    assert sub.perform(context) == os.path.join(*path)
+    assert sub.perform(context) == str(Path(*path))
 
     path = ['path', ['to'], ['my_', TextSubstitution(text='file'), '.yaml']]
     sub = PathJoinSubstitution(path)
-    assert sub.perform(context) == os.path.join('path', 'to', 'my_file.yaml')
+    assert sub.perform(context) == str(Path('path', 'to', 'my_file.yaml'))
 
     sub = PathSubstitution('some') / 'path'
     sub = sub / PathJoinSubstitution(['to', 'some', 'dir'])
     sub = sub / (TextSubstitution(text='my_model'), '.xacro')
-    assert sub.perform(context) == os.path.join(
-        'some', 'path', 'to', 'some', 'dir', 'my_model.xacro')
+    assert sub.perform(context) == str(Path('some', 'path', 'to', 'some', 'dir', 'my_model.xacro'))
+
+    path = ['path', [Path('to', 'my'), '_dir'], Path('file.yml')]
+    sub = PathJoinSubstitution(path)
+    assert sub.perform(context) == str(Path('path', 'to', 'my_dir', 'file.yml'))

--- a/launch_pytest/test/launch_pytest/examples/check_node_msgs.py
+++ b/launch_pytest/test/launch_pytest/examples/check_node_msgs.py
@@ -36,7 +36,7 @@ def generate_test_description():
     return launch.LaunchDescription([
         launch_ros.actions.Node(
             executable=sys.executable,
-            arguments=[str(path_to_test / 'executables' / 'talker.py')],
+            arguments=[path_to_test / 'executables' / 'talker.py'],
             additional_env={'PYTHONUNBUFFERED': '1'},
             name='demo_node_1',
             output='screen',

--- a/launch_pytest/test/launch_pytest/test_plugin.py
+++ b/launch_pytest/test/launch_pytest/test_plugin.py
@@ -327,6 +327,6 @@ def test_examples(testdir):
         if example.is_file() and example.name != 'check_node_msgs.py':
             copied_example = Path(testdir.copy_example(example))
             copied_example.rename(copied_example.parent / f'test_{copied_example.name}')
-    shutil.copytree(examples_dir / 'executables', Path(str(testdir.tmpdir)) / 'executables')
+    shutil.copytree(examples_dir / 'executables', Path(testdir.tmpdir) / 'executables')
     result = testdir.runpytest()
     result.assert_outcomes(passed=22)

--- a/launch_xml/test/launch_xml/test_executable.py
+++ b/launch_xml/test/launch_xml/test_executable.py
@@ -28,7 +28,7 @@ import pytest
 
 def test_executable():
     """Parse node xml example."""
-    xml_file = str(Path(__file__).parent / 'executable.xml')
+    xml_file = Path(__file__).parent / 'executable.xml'
     root_entity, parser = load_no_extensions(xml_file)
     ld = parser.parse_description(root_entity)
     executable = ld.entities[0]

--- a/test_launch_testing/test/test_launch_testing/actions/test_gtest.py
+++ b/test_launch_testing/test/test_launch_testing/actions/test_gtest.py
@@ -25,7 +25,7 @@ from launch_testing.actions import GTest
 def launch_gtest(test_path):
     """Launch a gtest."""
     ld = LaunchDescription([
-        GTest(path=str(test_path), timeout=5.0, on_exit=[EmitEvent(event=Shutdown())])
+        GTest(path=test_path, timeout=5.0, on_exit=[EmitEvent(event=Shutdown())])
     ])
     ls = LaunchService()
     ls.include_launch_description(ld)

--- a/test_launch_testing/test/test_launch_testing/actions/test_pytest.py
+++ b/test_launch_testing/test/test_launch_testing/actions/test_pytest.py
@@ -25,7 +25,7 @@ from launch_testing.actions import PyTest
 def launch_pytest(test_path):
     """Launch a pytest."""
     ld = LaunchDescription([
-        PyTest(path=str(test_path), timeout=5.0, on_exit=[EmitEvent(event=Shutdown())])
+        PyTest(path=test_path, timeout=5.0, on_exit=[EmitEvent(event=Shutdown())])
     ])
     ls = LaunchService()
     ls.include_launch_description(ld)


### PR DESCRIPTION
Closes #805
Closes robograph-project/docs#12
Replaces #790 
Related to #868 

Allow passing `pathlib.Path` objects directly into contexts expecting a `Substitution`, for more natural modern pythonic usage. For example `IncludeLaunchDescription(Path(__file__).parent / 'file_in_this_dir_launch.yaml'))`

As part of this change, stop doing `str(Path)` casts everywhere it's done for this reason.