### PR TITLE
Using ``TimerAction`` with ``SetParameter`` from launch_ros causes crash

### DIFF
--- a/launch/launch/actions/reset_launch_configurations.py
+++ b/launch/launch/actions/reset_launch_configurations.py
@@ -14,6 +14,8 @@
 
 """Module for the ResetLaunchConfigurations action."""
 
+import collections.abc
+
 from typing import Any
 from typing import Dict
 from typing import List
@@ -21,14 +23,13 @@ from typing import Optional
 from typing import Tuple
 from typing import Type
 
-
 from ..action import Action
 from ..frontend import Entity
 from ..frontend import expose_action
 from ..frontend import Parser
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
-from ..substitution import Substitution
+from ..some_substitutions_type import SomeSubstitutionsType_types_tuple
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
 
@@ -85,31 +86,37 @@ class ResetLaunchConfigurations(Action):
         else:
             evaluated_configurations = {}
             for k, v in self.__launch_configurations.items():
-                # Move imports to the top of the file
-                import collections.abc
-                from pathlib import Path
-                from ..substitution import Substitution
-
                 def is_substitutable(value: Any) -> bool:
                     # Specifically look for iterables of non-substitutable values. Assume the rest
                     # is substitutable and let it error out if not
                     return (
                         not isinstance(value, collections.abc.Iterable)
                         or all(
-                            isinstance(iter_value, (str, Path, Substitution))
+                            (
+                                isinstance(iter_value, SomeSubstitutionsType_types_tuple)
+                                and not isinstance(iter_value, collections.abc.Iterable)
+                            )
                             for iter_value in value
                         )
                     )
 
-                k = (
+                evaluated_k = (
                     perform_substitutions(context, normalize_to_list_of_substitutions(k))
                     if is_substitutable(k) else k
                 )
-                v = (
+                evaluated_v = (
                     perform_substitutions(context, normalize_to_list_of_substitutions(v))
                     if is_substitutable(v) else v
                 )
-                evaluated_configurations[k] = v
+
+                # The key must be a string - check that it has resolved to a string
+                if not isinstance(evaluated_k, str):
+                    raise TypeError(
+                        f'Launch config name {k} must be a string or a Substitution, '
+                        f'but got {type(k)}'
+                    )
+
+                evaluated_configurations[evaluated_k] = evaluated_v
 
             context.launch_configurations.clear()
             context.launch_configurations.update(evaluated_configurations)

--- a/launch/launch/actions/reset_launch_configurations.py
+++ b/launch/launch/actions/reset_launch_configurations.py
@@ -100,21 +100,11 @@ class ResetLaunchConfigurations(Action):
                         )
                     )
 
-                evaluated_k = (
-                    perform_substitutions(context, normalize_to_list_of_substitutions(k))
-                    if is_substitutable(k) else k
-                )
+                evaluated_k = perform_substitutions(context, normalize_to_list_of_substitutions(k))
                 evaluated_v = (
                     perform_substitutions(context, normalize_to_list_of_substitutions(v))
                     if is_substitutable(v) else v
                 )
-
-                # The key must be a string - check that it has resolved to a string
-                if not isinstance(evaluated_k, str):
-                    raise TypeError(
-                        f'Launch config name {k} must be a string or a Substitution, '
-                        f'but got {type(k)}'
-                    )
 
                 evaluated_configurations[evaluated_k] = evaluated_v
 

--- a/launch/launch/actions/reset_launch_configurations.py
+++ b/launch/launch/actions/reset_launch_configurations.py
@@ -28,6 +28,7 @@ from ..frontend import expose_action
 from ..frontend import Parser
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
+from ..substitution import Substitution
 from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
 
@@ -84,9 +85,11 @@ class ResetLaunchConfigurations(Action):
         else:
             evaluated_configurations = {}
             for k, v in self.__launch_configurations.items():
-                evaluated_k = perform_substitutions(context, normalize_to_list_of_substitutions(k))
-                evaluated_v = perform_substitutions(context, normalize_to_list_of_substitutions(v))
-                evaluated_configurations[evaluated_k] = evaluated_v
+                if isinstance(k, Substitution) or isinstance(k, str):
+                    k = perform_substitutions(context, normalize_to_list_of_substitutions(k))
+                if isinstance(v, Substitution) or isinstance(v, str):
+                    v = perform_substitutions(context, normalize_to_list_of_substitutions(v))
+                evaluated_configurations[k] = v
 
             context.launch_configurations.clear()
             context.launch_configurations.update(evaluated_configurations)

--- a/launch/launch/actions/reset_launch_configurations.py
+++ b/launch/launch/actions/reset_launch_configurations.py
@@ -85,10 +85,30 @@ class ResetLaunchConfigurations(Action):
         else:
             evaluated_configurations = {}
             for k, v in self.__launch_configurations.items():
-                if isinstance(k, Substitution) or isinstance(k, str):
-                    k = perform_substitutions(context, normalize_to_list_of_substitutions(k))
-                if isinstance(v, Substitution) or isinstance(v, str):
-                    v = perform_substitutions(context, normalize_to_list_of_substitutions(v))
+                # Move imports to the top of the file
+                import collections.abc
+                from pathlib import Path
+                from ..substitution import Substitution
+
+                def is_substitutable(value: Any) -> bool:
+                    # Specifically look for iterables of non-substitutable values. Assume the rest
+                    # is substitutable and let it error out if not
+                    return (
+                        not isinstance(value, collections.abc.Iterable)
+                        or all(
+                            isinstance(iter_value, (str, Path, Substitution))
+                            for iter_value in value
+                        )
+                    )
+
+                k = (
+                    perform_substitutions(context, normalize_to_list_of_substitutions(k))
+                    if is_substitutable(k) else k
+                )
+                v = (
+                    perform_substitutions(context, normalize_to_list_of_substitutions(v))
+                    if is_substitutable(v) else v
+                )
                 evaluated_configurations[k] = v
 
             context.launch_configurations.clear()

--- a/launch/test/launch/actions/test_reset_launch_configurations.py
+++ b/launch/test/launch/actions/test_reset_launch_configurations.py
@@ -91,3 +91,10 @@ def test_reset_launch_configurations_execute():
     assert len(lc6.launch_configurations) == 1
     assert lc6.launch_configurations['foo'] == 'OOF'
     assert 'bar' not in lc6.launch_configurations.keys()
+
+    # With a non-substitutable launch configuration
+    lc7 = LaunchContext()
+    assert len(lc7.launch_configurations) == 0
+    ResetLaunchConfigurations(launch_configurations={'global_param': [('foo', 'true')]}).visit(lc7)
+    assert len(lc7.launch_configurations) == 1
+    assert lc7.launch_configurations['global_param'] == [('foo', 'true')]


### PR DESCRIPTION
Using ``TimerAction`` with ``SetParameter`` from launch_ros causes a launch error. Here is a minimal producible example:

```py
from launch import LaunchDescription
from launch_ros.actions import SetParameter
from launch.actions import TimerAction

def generate_launch_description():

    return LaunchDescription(
        [
            SetParameter(name="foo", value="true"),
            TimerAction(
                period=0.5,
                actions=[],
            ),
        ]
    )
```

Error log:

```bash
$ ros2 launch --debug test.launch.py 
[DEBUG] [launch.launch_context]: emitting event synchronously: 'launch.events.IncludeLaunchDescription'
[INFO] [launch]: All log files can be found below /home/ubuntu/.ros/log/2025-05-13-04-15-28-165140-sirius-XPS-15-9530-159994
[INFO] [launch]: Default logging verbosity is set to DEBUG
[DEBUG] [launch]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x71b6f03a7ad0>'
[DEBUG] [launch]: processing event: '<launch.events.include_launch_description.IncludeLaunchDescription object at 0x71b6f03a7ad0>' ✓ '<launch.event_handlers.on_include_launch_description.OnIncludeLaunchDescription object at 0x71b6f03c5fa0>'
[DEBUG] [launch.launch_context]: emitting event: 'launch.events.TimerEvent'
[DEBUG] [launch]: processing event: '<launch.events.timer_event.TimerEvent object at 0x71b6f057e8d0>'
[DEBUG] [launch]: processing event: '<launch.events.timer_event.TimerEvent object at 0x71b6f057e8d0>' ✓ '<launch.event_handler.EventHandler object at 0x71b6f260fb30>'
[DEBUG] [launch]: An exception was raised in an async action/event
[DEBUG] [launch]: Traceback (most recent call last):
  File "/craftsman_dev/build/launch/launch/launch_service.py", line 343, in run_async
    raise exception_to_raise
  File "/craftsman_dev/build/launch/launch/launch_service.py", line 230, in _process_one_event
    await self.__process_event(next_event)
  File "/craftsman_dev/build/launch/launch/launch_service.py", line 250, in __process_event
    visit_all_entities_and_collect_futures(entity, self.__context))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 38, in visit_all_entities_and_collect_futures
    sub_entities = entity.visit(context)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/action.py", line 109, in visit
    return self.execute(context)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/actions/reset_launch_configurations.py", line 83, in execute
    evaluated_v = perform_substitutions(context, normalize_to_list_of_substitutions(v))
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py", line 44, in normalize_to_list_of_substitutions
    return [normalize(y) for y in cast(Iterable, subs)]
            ^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py", line 36, in normalize
    raise TypeError(
TypeError: Failed to normalize given item of type '<class 'tuple'>', when only 'str' or 'launch.Substitution' were expected.

[ERROR] [launch]: Caught exception in launch (see debug for traceback): Failed to normalize given item of type '<class 'tuple'>', when only 'str' or 'launch.Substitution' were expected.
[DEBUG] [launch.launch_context]: emitting event: 'launch.events.Shutdown'
[DEBUG] [launch]: processing event: '<launch.events.shutdown.Shutdown object at 0x71b6f04dddc0>'
[DEBUG] [launch]: processing event: '<launch.events.shutdown.Shutdown object at 0x71b6f04dddc0>' ✓ '<launch.event_handler.EventHandler object at 0x71b6f03c4b30>'
[DEBUG] [launch]: processing event: '<launch.events.shutdown.Shutdown object at 0x71b6f04dddc0>' ✓ '<launch.event_handlers.on_shutdown.OnShutdown object at 0x71b6f261da90>'
```

---

The issue seems to be originating from ``TimerAction`` calling  ``ResetLaunchConfigurations`` with a launch configuration in the launch context that is not a string nor a substitution. The ``SetParameter`` action adds a launch configuration ``global_param`` of list type. To demonstrate this, the following is akin to what timer_action attempts to do, and it also raises the same error:

```
from launch import LaunchDescription
from launch.actions import ResetLaunchConfigurations

def generate_launch_description():

    return LaunchDescription(
        [
            ResetLaunchConfigurations(
                launch_configurations={
                    "global_param": [("foo", "true")],
                }
            ),
        ]
    )
```

---

In _launch_, the LaunchContext's launch_configurations' type hint specifies it as a dictionary of text -> text.
https://github.com/ros2/launch/blob/e716d1fcc719b4155b7c99f2ae25cc3466634231/launch/launch/launch_context.py#L65

But in _ros_launch_, in the `SetParameter` action, the ``global_params`` launch configuration has a [list type](https://github.com/ros2/launch_ros/blob/dea4eafc7ab17504385b0a95d2445c523ace1cf8/launch_ros/launch_ros/actions/set_parameter.py#L90-L93):

```py
    def execute(self, context: LaunchContext):
        """Execute the action."""
        eval_param_dict = evaluate_parameter_dict(context, self.__param_dict)
        global_param_list = context.launch_configurations.get('global_params', [])
        global_param_list.extend(eval_param_dict.items())
        context.launch_configurations['global_params'] = global_param_list
```

---

**I'm not sure if this is a problem with launch_ros adding an unexpected type to launch configurations, or launch should handle list types too. This PR does the latter, by doing an initial check of the type of the launch argument**.

