### PR TITLE
Make sure to install py.typed files

### DIFF
--- a/launch/setup.py
+++ b/launch/setup.py
@@ -13,6 +13,7 @@ setup(
             ['resource/' + package_name]),
         ('share/launch/frontend', ['share/launch/frontend/grammar.lark']),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/launch_pytest/setup.py
+++ b/launch_pytest/setup.py
@@ -24,6 +24,7 @@ setup(
             glob.glob(f'test/{package_name}/examples/executables/[!_]*')
         ),
     ],
+    package_data={'': ['py.typed']},
     entry_points={
         'pytest11': ['launch_pytest = launch_pytest.plugin'],
     },

--- a/launch_testing/setup.py
+++ b/launch_testing/setup.py
@@ -14,6 +14,7 @@ setup(
         ('share/launch_testing', ['package.xml']),
         ('share/launch_testing/examples', glob.glob('test/launch_testing/examples/[!_]**')),
     ],
+    package_data={'': ['py.typed']},
     entry_points={
         'console_scripts': ['launch_test=launch_testing.launch_test:main'],
         'pytest11': ['launch_testing = launch_testing.pytest.hooks'],

--- a/launch_xml/setup.py
+++ b/launch_xml/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     zip_safe=True,
     author='Ivan Paunovic',

--- a/launch_yaml/setup.py
+++ b/launch_yaml/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['setuptools'],
     zip_safe=True,
     author='Ivan Paunovic',


### PR DESCRIPTION
## Description

When `--symlink-install` isn't used, these changes make sure that the `py.typed` file is installed, e.g., under `$ws/install/launch/lib/python3.12/site-packages/launch/py.typed`. And I assume it should end up under `/opt/ros/rolling/lib/python3.12/site-packages/launch/py.typed` in the Debian package.

Requires https://github.com/ros2/ros2_tracing/pull/184 (otherwise `mypy` tests in `tracetools_launch` will fail)  
Fixes #885  
Follow-up to #828  
Relates to https://github.com/ros2/ros2_tracing/issues/160

### Is this user-facing behavior change?

This will make `mypy` (e.g., through `ament_mypy`) be stricter about type annotation for downstream users of the packages with a `py.typed` file such as `launch`. For example, see https://github.com/ros2/ros2_tracing/issues/160#issuecomment-2971204451. This could be considered a breaking change.

### Did you use Generative AI?

No.

### Additional Information

As mentioned in #885, the `tracetools_launch` `mypy` test will most likely fail in ci.ros2.org. The errors reported by `mypy` need to be addressed before this is merged.