### PR TITLE
Improve readability when printing type of classes in error messages

### DIFF
--- a/launch/launch/actions/opaque_coroutine.py
+++ b/launch/launch/actions/opaque_coroutine.py
@@ -73,7 +73,7 @@ class OpaqueCoroutine(Action):
         if not asyncio.iscoroutinefunction(coroutine):
             raise TypeError(
                 "OpaqueCoroutine expected a coroutine function for 'coroutine', got '{}'".format(
-                    type(coroutine)
+                    type(coroutine).__name__
                 )
             )
         ensure_argument_type(

--- a/launch/launch/actions/opaque_function.py
+++ b/launch/launch/actions/opaque_function.py
@@ -57,7 +57,7 @@ class OpaqueFunction(Action):
         super().__init__(**left_over_kwargs)
         if not callable(function):
             raise TypeError("OpaqueFunction expected a callable for 'function', got '{}'".format(
-                type(function)
+                type(function).__name__
             ))
         ensure_argument_type(
             args, (collections.abc.Iterable, type(None)), 'args', 'OpaqueFunction')

--- a/launch/launch/event_handlers/on_action_event_base.py
+++ b/launch/launch/event_handlers/on_action_event_base.py
@@ -99,7 +99,7 @@ class OnActionEventBase(BaseEventHandler):
                     if not isinstance(entity, LaunchDescriptionEntity):
                         raise TypeError(
                             "expected all items in 'on_event' iterable to be of type "
-                            "'LaunchDescriptionEntity' but got '{}'".format(type(entity)))
+                            "'LaunchDescriptionEntity' but got '{}'".format(type(entity).__name__))
                 self.__actions_on_event = list(on_event)  # Outside list is to ensure type is List
             else:
                 self.__actions_on_event = [on_event]

--- a/launch/launch/substitutions/text_substitution.py
+++ b/launch/launch/substitutions/text_substitution.py
@@ -29,7 +29,9 @@ class TextSubstitution(Substitution):
 
         if not isinstance(text, Text):
             raise TypeError(
-                "TextSubstitution expected Text object got '{}' instead.".format(type(text))
+                "TextSubstitution expected Text object got '{}' instead.".format(
+                    type(text).__name__
+                )
             )
 
         self.__text = text

--- a/launch/launch/utilities/ensure_argument_type_impl.py
+++ b/launch/launch/utilities/ensure_argument_type_impl.py
@@ -43,7 +43,7 @@ def ensure_argument_type(
             'types',
             'type, collections.abc.Iterable of type',
             types,
-            type(types),
+            type(types).__name__,
         ))
     if not isinstance(argument_name, str):
         raise TypeError(error_msg_template.format(
@@ -51,7 +51,7 @@ def ensure_argument_type(
             'argument_name',
             'str',
             argument_name,
-            type(argument_name),
+            type(argument_name).__name__,
         ))
     if caller is not None and not isinstance(caller, str):
         raise TypeError(error_msg_template.format(
@@ -59,7 +59,7 @@ def ensure_argument_type(
             'caller',
             'str, None',
             caller,
-            type(caller),
+            type(caller).__name__,
         ))
 
     def check_argument(argument: Any, type_var: Type[Any]) -> bool:
@@ -76,5 +76,5 @@ def ensure_argument_type(
             argument_name,
             ', '.join([str(x) for x in list_of_types]),
             argument,
-            type(argument),
+            type(argument).__name__,
         ))

--- a/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
+++ b/launch/launch/utilities/normalize_to_list_of_substitutions_impl.py
@@ -38,7 +38,7 @@ def normalize_to_list_of_substitutions(subs: SomeSubstitutionsType) -> List[Subs
             return TextSubstitution(text=str(x))
         raise TypeError(
             "Failed to normalize given item of type '{}', when only "
-            "'str' or 'launch.Substitution' were expected.".format(type(x)))
+            "'str' or 'launch.Substitution' were expected.".format(type(x).__name__))
 
     if isinstance(subs, (str, Path)):
         return [TextSubstitution(text=str(subs))]

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -158,7 +158,7 @@ def extract_type(data_type: AllowedTypesType) -> Tuple[ScalarTypesType, bool]:
         is_list = True
         scalar_type = data_type.__args__[0]  # type: ignore
     if is_valid_scalar_type(scalar_type) is False:
-        raise ValueError(f'Unrecognized data type: {data_type}')
+        raise ValueError(f'Unrecognized data type: {data_type.__name__}')
     return (scalar_type, is_list)
 
 
@@ -245,7 +245,7 @@ def coerce_to_type(
 
         if not is_instance_of_valid_type(output, can_be_str=can_be_str):
             raise ValueError(
-                f'{error_msg}: output type is not allowed, got {type(output)}'
+                f'{error_msg}: output type is not allowed, got {type(output).__name__}'
             )
         return output
 
@@ -287,7 +287,7 @@ def coerce_to_type(
         raise ValueError(
             'data_type is invalid. Expected one of: '
             'int, float, str, bool, List[int], List[float], List[str], List[bool]'
-            f'. Got {data_type}')
+            f'. Got {data_type.__name__}')
     output = convert_as_yaml(value, f"Failed to convert '{value}' to '{type_obj}'")
     if isinstance(output, valid_types):
         return output
@@ -314,7 +314,7 @@ def coerce_list(
     ensure_argument_type(value, list, 'value', 'coerce_list')
     output = [coerce_to_type(i, data_type, can_be_str=can_be_str) for i in value]
     if not is_instance_of_valid_type(output, can_be_str=can_be_str):
-        raise ValueError(f'cannot convert value to {data_type}. Got value=`{value}`')
+        raise ValueError(f'cannot convert value to {data_type.__name__}. Got value=`{value}`')
     return cast(ListValueType, output)
 
 
@@ -342,8 +342,8 @@ def get_typed_value(
             data_type, is_list = extract_type(data_type)
             if not is_list:
                 raise TypeError(
-                    f"Cannot convert input '{value}' of type '{type(value)}' to"
-                    f" '{data_type}'"
+                    f"Cannot convert input '{value}' of type '{type(value).__name__}' to"
+                    f" '{data_type.__name__}'"
                 )
         return coerce_list(value, data_type, can_be_str=can_be_str)
     else:
@@ -423,7 +423,7 @@ def normalize_typed_substitution(
     # Resolve scalar types immediately
     if isinstance(value, ScalarTypesTuple):
         if not is_instance_of(value, data_type):
-            raise TypeError(f"value='{value}' is not an instance of {data_type}")
+            raise TypeError(f"value='{value}' is not an instance of {data_type.__name__}")
         return value
     # Resolve substitutions and list of substitutions immediately
     if is_substitution(value):
@@ -433,7 +433,7 @@ def normalize_typed_substitution(
         raise TypeError(
             'value should be either a scalar, a substitutions,'
             ' or a mixed list of scalars and substitutions. '
-            f'Got `value={value}` of type `{type(value)}`. '
+            f'Got `value={value}` of type `{type(value).__name__}`. '
         )
     # Collect the types of the items of the list
     types_in_list: Set[Optional[Type[Union[str, int, float, bool, Substitution]]]] = set()
@@ -455,13 +455,13 @@ def normalize_typed_substitution(
     if not is_list:
         raise TypeError(
             'The provided value resolves to a list, though the required type is a scalar. '
-            f"Got value='{value}', data_type='{data_type}'."
+            f"Got value='{value}', data_type='{data_type.__name__}'."
         )
 
     # Normalize each specific uniform list input
     err_msg = (
         "Got a list of '{}'"
-        f", expected a list of '{data_type}'. value='{value}'"
+        f", expected a list of '{data_type.__name__}'. value='{value}'"
     )
     if types_in_list == {Substitution}:
         # list of substitutions, can be coerced later to anything
@@ -551,7 +551,7 @@ def perform_typed_substitution(
     if isinstance(value, ScalarTypesTuple):
         if data_type is not None and not is_instance_of(value, data_type):
             raise TypeError(
-                f'value=`{value}` is a scalar and not an instance of `{data_type}`')
+                f'value=`{value}` is a scalar and not an instance of `{data_type.__name__}`')
         return value
     elif is_normalized_substitution(value):
         return coerce_to_type(
@@ -565,7 +565,7 @@ def perform_typed_substitution(
             if not is_list:
                 raise ValueError(
                     'The input value is a list, cannot convert it to a scalar. '
-                    f"Got value='{value}', expected type {scalar_type}."
+                    f"Got value='{value}', expected type {scalar_type.__name__}."
                 )
         output = [
             coerce_to_type(
@@ -575,7 +575,7 @@ def perform_typed_substitution(
         if not is_instance_of(output, data_type):
             raise ValueError(
                     'The output list does not match the expected type '
-                    f"Got value='{value}', expected type {scalar_type}."
+                    f"Got value='{value}', expected type {scalar_type.__name__}."
                     if scalar_type is not None else
                     'The output list is not uniform'
                 )

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -314,7 +314,8 @@ def coerce_list(
     ensure_argument_type(value, list, 'value', 'coerce_list')
     output = [coerce_to_type(i, data_type, can_be_str=can_be_str) for i in value]
     if not is_instance_of_valid_type(output, can_be_str=can_be_str):
-        raise ValueError(f'cannot convert value to {data_type.__name__}. Got value=`{value}`')
+        typename = data_type.__name__ if data_type is not None else "inferred type"
+        raise ValueError(f'cannot convert value to {typename}. Got value=`{value}`')
     return cast(ListValueType, output)
 
 
@@ -459,9 +460,10 @@ def normalize_typed_substitution(
         )
 
     # Normalize each specific uniform list input
+    type_name = data_type.__name__ if data_type is not None else "inferred type"
     err_msg = (
         "Got a list of '{}'"
-        f", expected a list of '{data_type.__name__}'. value='{value}'"
+        f", expected a list of '{type_name}'. value='{value}'"
     )
     if types_in_list == {Substitution}:
         # list of substitutions, can be coerced later to anything

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -460,7 +460,7 @@ def normalize_typed_substitution(
         )
 
     # Normalize each specific uniform list input
-    type_name = data_type.__name__ if data_type is not None else "inferred type"
+    type_name = data_type.__name__ if data_type is not None else 'inferred type'
     err_msg = (
         "Got a list of '{}'"
         f", expected a list of '{type_name}'. value='{value}'"

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -424,7 +424,8 @@ def normalize_typed_substitution(
     # Resolve scalar types immediately
     if isinstance(value, ScalarTypesTuple):
         if not is_instance_of(value, data_type):
-            raise TypeError(f"value='{value}' is not an instance of {data_type.__name__}")
+            typename = data_type.__name__ if data_type is not None else 'inferred type'
+            raise TypeError(f"value='{value}' is not an instance of {typename}")
         return value
     # Resolve substitutions and list of substitutions immediately
     if is_substitution(value):
@@ -454,9 +455,10 @@ def normalize_typed_substitution(
         data_type, is_list = extract_type(data_type)
     # Must be expecting a list
     if not is_list:
+        typename = data_type.__name__ if data_type is not None else 'inferred type'
         raise TypeError(
             'The provided value resolves to a list, though the required type is a scalar. '
-            f"Got value='{value}', data_type='{data_type.__name__}'."
+            f"Got value='{value}', data_type='{typename}'."
         )
 
     # Normalize each specific uniform list input

--- a/launch/launch/utilities/type_utils.py
+++ b/launch/launch/utilities/type_utils.py
@@ -314,7 +314,7 @@ def coerce_list(
     ensure_argument_type(value, list, 'value', 'coerce_list')
     output = [coerce_to_type(i, data_type, can_be_str=can_be_str) for i in value]
     if not is_instance_of_valid_type(output, can_be_str=can_be_str):
-        typename = data_type.__name__ if data_type is not None else "inferred type"
+        typename = data_type.__name__ if data_type is not None else 'inferred type'
         raise ValueError(f'cannot convert value to {typename}. Got value=`{value}`')
     return cast(ListValueType, output)
 

--- a/launch_testing/launch_testing/util/proc_lookup.py
+++ b/launch_testing/launch_testing/util/proc_lookup.py
@@ -154,5 +154,5 @@ def resolveProcesses(info_obj, *, process=None, cmd_args=None, strict_proc_match
     else:
         # Invalid argument passed for 'process'
         raise TypeError(
-            "proc argument must be 'ExecuteProcess' or 'str' not {}".format(type(process))
+            "proc argument must be 'ExecuteProcess' or 'str' not {}".format(type(process).__name__)
         )

--- a/launch_xml/launch_xml/entity.py
+++ b/launch_xml/launch_xml/entity.py
@@ -92,7 +92,7 @@ class Entity(BaseEntity):
         """
         attr_error = AttributeError(
             "Attribute '{}' of type '{}' not found in Entity '{}'".format(
-                name, data_type, self.type_name
+                name, data_type.__name__, self.type_name
             )
         )
         if check_is_list_entity(data_type):
@@ -125,7 +125,7 @@ class Entity(BaseEntity):
             raise TypeError(
                 "Attribute '{}' of Entity '{}' expected to be of type '{}'."
                 "'{}' can not be converted to one of those types".format(
-                    name, self.type_name, data_type, value
+                    name, self.type_name, data_type.__name__, value
                 )
             )
         return value

--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -59,7 +59,7 @@ class Entity(BaseEntity):
         self.__children_called = True
         if not isinstance(self.__element, (dict, list)):
             raise TypeError(
-                f'Expected a dict or list, got {type(self.element)}:'
+                f'Expected a dict or list, got {type(self.element).__name__}:'
                 f'\n---\n{self.__element}\n---'
             )
         if isinstance(self.__element, dict):
@@ -133,7 +133,7 @@ class Entity(BaseEntity):
         if not is_instance_of(data, data_type, can_be_str=can_be_str):
             raise TypeError(
                 "Attribute '{}' of Entity '{}' expected to be of type '{}', got '{}'".format(
-                    name, self.type_name, data_type, type(data)
+                    name, self.type_name, data_type.__name__, type(data).__name__
                 )
             )
         return data


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

In many places, error messages printed types in a verbose format like '<class 'str'>'. This PR simplifies that by displaying just the type name (e.g. 'str').

For example, given this invalid XML:

```xml
<?xml version="1.0"?>
<launch>
  <node />
</launch>
```

The previous error output was:
```
- AttributeError: Attribute 'exec' of type '<class 'str'>' not found in Entity 'node'
```

With this change, it becomes:
```
- AttributeError: Attribute 'exec' of type 'str' not found in Entity 'node'
```

### Did you use Generative AI?

No

