### PR TITLE
Fix all/any in xml and yaml launch files

### DIFF
--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -14,6 +14,7 @@
 
 """Module for boolean substitutions."""
 
+from itertools import chain
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -172,7 +173,11 @@ class AnySubstitution(Substitution):
     If none of the arguments evaluate to true, then this substitution returns the string 'false'.
     """
 
-    def __init__(self, *args: SomeSubstitutionsType) -> None:
+    def __init__(
+        self,
+        *args: SomeSubstitutionsType,
+        container: Iterable[SomeSubstitutionsType] | None = None,
+    ) -> None:
         """
         Create an AnySubstitution substitution.
 
@@ -180,13 +185,16 @@ class AnySubstitution(Substitution):
         """
         super().__init__()
 
-        self.__args = [normalize_to_list_of_substitutions(arg) for arg in args]
+        if container is None:
+            container = []
+
+        self.__args = [normalize_to_list_of_substitutions(arg) for arg in chain(args, container)]
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]
               ) -> Tuple[Type['AnySubstitution'], Dict[str, Any]]:
         """Parse `AnySubstitution` substitution."""
-        return cls, {'args': data}
+        return cls, {'container': data}
 
     @property
     def args(self) -> List[List[Substitution]]:
@@ -218,7 +226,11 @@ class AllSubstitution(Substitution):
     If any of the arguments evaluates to false, then this substitution returns the string 'false'.
     """
 
-    def __init__(self, *args: SomeSubstitutionsType) -> None:
+    def __init__(
+        self,
+        *args: SomeSubstitutionsType,
+        container: Iterable[SomeSubstitutionsType] | None = None,
+    ) -> None:
         """
         Create an AllSubstitution substitution.
 
@@ -227,13 +239,16 @@ class AllSubstitution(Substitution):
         """
         super().__init__()
 
-        self.__args = [normalize_to_list_of_substitutions(arg) for arg in args]
+        if container is None:
+            container = []
+
+        self.__args = [normalize_to_list_of_substitutions(arg) for arg in chain(args, container)]
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]
               ) -> Tuple[Type['AllSubstitution'], Dict[str, Any]]:
         """Parse `AllSubstitution` substitution."""
-        return cls, {'args': data}
+        return cls, {'container': data}
 
     @property
     def args(self) -> List[List[Substitution]]:

--- a/launch/launch/substitutions/boolean_substitution.py
+++ b/launch/launch/substitutions/boolean_substitution.py
@@ -19,6 +19,7 @@ from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Optional
 from typing import Sequence
 from typing import Text
 from typing import Tuple
@@ -176,7 +177,7 @@ class AnySubstitution(Substitution):
     def __init__(
         self,
         *args: SomeSubstitutionsType,
-        container: Iterable[SomeSubstitutionsType] | None = None,
+        container: Optional[Iterable[SomeSubstitutionsType]] = None,
     ) -> None:
         """
         Create an AnySubstitution substitution.
@@ -229,7 +230,7 @@ class AllSubstitution(Substitution):
     def __init__(
         self,
         *args: SomeSubstitutionsType,
-        container: Iterable[SomeSubstitutionsType] | None = None,
+        container: Optional[Iterable[SomeSubstitutionsType]] = None,
     ) -> None:
         """
         Create an AllSubstitution substitution.

--- a/launch_xml/test/launch_xml/test_boolean_substitution.py
+++ b/launch_xml/test/launch_xml/test_boolean_substitution.py
@@ -40,6 +40,16 @@ def test_boolean_substitution_xml():
             <let name="or_true_false" value="$(or $(var true_value) $(var false_value))" />
             <let name="or_false_true" value="$(or $(var false_value) $(var true_value))" />
             <let name="or_false_false" value="$(or $(var false_value) $(var false_value))" />
+
+            <let name="all_true_true" value="$(all $(var true_value) $(var true_value))" />
+            <let name="all_true_false" value="$(all $(var true_value) $(var false_value))" />
+            <let name="all_false_true" value="$(all $(var false_value) $(var true_value))" />
+            <let name="all_false_false" value="$(all $(var false_value) $(var false_value))" />
+
+            <let name="any_true_true" value="$(any $(var true_value) $(var true_value))" />
+            <let name="any_true_false" value="$(any $(var true_value) $(var false_value))" />
+            <let name="any_false_true" value="$(any $(var false_value) $(var true_value))" />
+            <let name="any_false_false" value="$(any $(var false_value) $(var false_value))" />
         </launch>
         """
     )
@@ -72,6 +82,16 @@ def check_boolean_substitution(file):
     or_false_true = sub_entries[10]
     or_false_false = sub_entries[11]
 
+    all_true_true = sub_entries[12]
+    all_true_false = sub_entries[13]
+    all_false_true = sub_entries[14]
+    all_false_false = sub_entries[15]
+
+    any_true_true = sub_entries[16]
+    any_true_false = sub_entries[17]
+    any_false_true = sub_entries[18]
+    any_false_false = sub_entries[19]
+
     assert perform(not_true.value) == 'false'
     assert perform(not_false.value) == 'true'
 
@@ -84,3 +104,13 @@ def check_boolean_substitution(file):
     assert perform(or_true_false.value) == 'true'
     assert perform(or_false_true.value) == 'true'
     assert perform(or_false_false.value) == 'false'
+
+    assert perform(all_true_true.value) == 'true'
+    assert perform(all_true_false.value) == 'false'
+    assert perform(all_false_true.value) == 'false'
+    assert perform(all_false_false.value) == 'false'
+
+    assert perform(any_true_true.value) == 'true'
+    assert perform(any_true_false.value) == 'true'
+    assert perform(any_false_true.value) == 'true'
+    assert perform(any_false_false.value) == 'false'

--- a/launch_yaml/test/launch_yaml/test_boolean_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_boolean_substitution.py
@@ -40,6 +40,16 @@ def test_boolean_substitution_yaml():
             - let: { name: or_true_false, value: "$(or $(var true_value) $(var false_value))" }
             - let: { name: or_false_true, value: "$(or $(var false_value) $(var true_value))" }
             - let: { name: or_false_false, value: "$(or $(var false_value) $(var false_value))" }
+
+            - let: { name: all_true_true, value: "$(all $(var true_value) $(var true_value))" }
+            - let: { name: all_true_false, value: "$(all $(var true_value) $(var false_value))" }
+            - let: { name: all_false_true, value: "$(all $(var false_value) $(var true_value))" }
+            - let: { name: all_false_false, value: "$(all $(var false_value) $(var false_value))" }
+
+            - let: { name: any_true_true, value: "$(any $(var true_value) $(var true_value))" }
+            - let: { name: any_true_false, value: "$(any $(var true_value) $(var false_value))" }
+            - let: { name: any_false_true, value: "$(any $(var false_value) $(var true_value))" }
+            - let: { name: any_false_false, value: "$(any $(var false_value) $(var false_value))" }
         """
     )
     with io.StringIO(yaml_file) as f:
@@ -71,6 +81,16 @@ def check_boolean_substitution(file):
     or_false_true = sub_entries[10]
     or_false_false = sub_entries[11]
 
+    all_true_true = sub_entries[12]
+    all_true_false = sub_entries[13]
+    all_false_true = sub_entries[14]
+    all_false_false = sub_entries[15]
+
+    any_true_true = sub_entries[16]
+    any_true_false = sub_entries[17]
+    any_false_true = sub_entries[18]
+    any_false_false = sub_entries[19]
+
     assert perform(not_true.value) == 'false'
     assert perform(not_false.value) == 'true'
 
@@ -83,3 +103,13 @@ def check_boolean_substitution(file):
     assert perform(or_true_false.value) == 'true'
     assert perform(or_false_true.value) == 'true'
     assert perform(or_false_false.value) == 'false'
+
+    assert perform(all_true_true.value) == 'true'
+    assert perform(all_true_false.value) == 'false'
+    assert perform(all_false_true.value) == 'false'
+    assert perform(all_false_false.value) == 'false'
+
+    assert perform(any_true_true.value) == 'true'
+    assert perform(any_true_false.value) == 'true'
+    assert perform(any_false_true.value) == 'true'
+    assert perform(any_false_false.value) == 'false'


### PR DESCRIPTION
## Description

Seperate PR for fixing the All/Any in XML/YAML as discussed in https://github.com/ros2/launch/pull/769.

### Is this user-facing behavior change?

All/Any substitutions are not working right now in XML/YAML. This PR will fix it. The behaviour of the python interface doesn't change.

### Did you use Generative AI?

Code completion of the repetitive parts in the tests using GH copilot.

### Additional Information
