### PR TITLE
Make the directory-finding substitutions into a PathSubstitution for / operator

### DIFF
--- a/launch/launch/substitutions/launch_log_dir.py
+++ b/launch/launch/substitutions/launch_log_dir.py
@@ -35,7 +35,7 @@ class LaunchLogDir(PathSubstitution):
 
     def __init__(self) -> None:
         """Create a LaunchLogDir substitution."""
-        super().__init__(self)
+        super().__init__(path=self)
 
     @classmethod
     def parse(cls, data: Sequence[SomeSubstitutionsType]

--- a/launch/launch/substitutions/launch_log_dir.py
+++ b/launch/launch/substitutions/launch_log_dir.py
@@ -21,22 +21,21 @@ from typing import Text
 from typing import Tuple
 from typing import Type
 
-
+from .path_join_substitution import PathSubstitution
 from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
 from ..logging import launch_config as launch_logging_config
 from ..some_substitutions_type import SomeSubstitutionsType
-from ..substitution import Substitution
 
 
 @expose_substitution('launch_log_dir')
 @expose_substitution('log_dir')
-class LaunchLogDir(Substitution):
+class LaunchLogDir(PathSubstitution):
     """Substitution that returns the absolute path to the current launch log directory."""
 
     def __init__(self) -> None:
         """Create a LaunchLogDir substitution."""
-        super().__init__()
+        super().__init__(self)
 
     @classmethod
     def parse(cls, data: Sequence[SomeSubstitutionsType]

--- a/launch/launch/substitutions/this_launch_file_dir.py
+++ b/launch/launch/substitutions/this_launch_file_dir.py
@@ -35,7 +35,7 @@ class ThisLaunchFileDir(PathSubstitution):
 
     def __init__(self) -> None:
         """Create a ThisLaunchFileDir substitution."""
-        super().__init__(self)
+        super().__init__(path=self)
 
     @classmethod
     def parse(cls, data: Sequence[SomeSubstitutionsType]

--- a/launch/launch/substitutions/this_launch_file_dir.py
+++ b/launch/launch/substitutions/this_launch_file_dir.py
@@ -22,20 +22,20 @@ from typing import Tuple
 from typing import Type
 
 
+from .path_join_substitution import PathSubstitution
 from .substitution_failure import SubstitutionFailure
 from ..frontend.expose import expose_substitution
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
-from ..substitution import Substitution
 
 
 @expose_substitution('dirname')
-class ThisLaunchFileDir(Substitution):
+class ThisLaunchFileDir(PathSubstitution):
     """Substitution that returns the absolute path to the current launch file."""
 
     def __init__(self) -> None:
         """Create a ThisLaunchFileDir substitution."""
-        super().__init__()
+        super().__init__(self)
 
     @classmethod
     def parse(cls, data: Sequence[SomeSubstitutionsType]

--- a/launch/test/launch/substitutions/test_launch_log_dir.py
+++ b/launch/test/launch/substitutions/test_launch_log_dir.py
@@ -32,6 +32,14 @@ def test_launch_log_dir_methods():
     assert lld.perform(lc)
 
 
+def test_launch_log_dir_path():
+    test_dir = LaunchLogDir() / 'subdir'
+    lc = LaunchContext()
+    result = test_dir.perform(lc)
+    assert result
+    assert result.endswith('subdir')
+
+
 def test_launch_log_dir_frontend():
     """Test launch_log_dir/log_dir frontend substitutions."""
     for sub in ('launch_log_dir', 'log_dir'):

--- a/launch/test/launch/substitutions/test_this_launch_file_dir.py
+++ b/launch/test/launch/substitutions/test_this_launch_file_dir.py
@@ -14,6 +14,8 @@
 
 """Tests for the ThisLaunchFileDir substitution class."""
 
+import os
+
 from launch import LaunchContext
 from launch.substitutions import SubstitutionFailure
 from launch.substitutions import ThisLaunchFileDir
@@ -35,3 +37,10 @@ def test_this_launch_file_path_methods():
         tlfp.perform(lc)
     lc.extend_locals({'current_launch_file_directory': 'foo'})
     assert tlfp.perform(lc) == 'foo'
+
+
+def test_this_launch_file_dir_pathing():
+    test_file = ThisLaunchFileDir() / 'some_launch.xml'
+    lc = LaunchContext()
+    lc.extend_locals({'current_launch_file_directory': 'foo'})
+    assert test_file.perform(lc) == os.path.join('foo', 'some_launch.xml')


### PR DESCRIPTION
## Description

Part of https://github.com/robograph-project/planning/issues/38

Makes the two Substitutions that return a directory into a subclass of `PathSubstitution`
- `LaunchLogDir`
- `ThisLaunchFileDir`

So that one can immediately use the path join operator `/` with them.

Allows changing:

```
PathSubstitution(ThisLaunchFileDir()) / 'my_launch.py'
# or
PathJoinSubstitution([ThisLaunchFileDir(), 'my_launch.py'])
```

into

```
ThisLaunchFileDir() / 'my_launch.py'
```

### Is this user-facing behavior change?

New user-facing capability, no existing usage changed.

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
