### PR TITLE
Fix intersphinx_mapping format

### DIFF
--- a/launch/doc/source/conf.py
+++ b/launch/doc/source/conf.py
@@ -199,7 +199,7 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for todo extension ----------------------------------------------
 


### PR DESCRIPTION
## Description
Fixes https://github.com/ros2/launch/issues/920

This fixes the docs build of the `launch` package with sphinx 8, which the buildfarm uses. To test locally, install rosdoc2 from source and ensure its sphinx-8 dependency is used (and not the system-wide sphinx 7 install).

This should be backported to all active distros.

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No

### Additional Information
See https://github.com/ros2/launch/issues/920#issuecomment-3506508909
