### PR TITLE
docs: add basic Sphinx doc skeleton for launch_xml and launch_yaml

### DIFF
--- a/launch_xml/doc/conf.py
+++ b/launch_xml/doc/conf.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration file for the Sphinx documentation builder."""
+
+import os
+import sys
+
+# rosdoc2 copies this package's modules alongside conf.py, so add parent to path
+sys.path.insert(0, os.path.abspath('.'))
+

--- a/launch_xml/doc/conf.py
+++ b/launch_xml/doc/conf.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,3 @@ import sys
 
 # rosdoc2 copies this package's modules alongside conf.py, so add parent to path
 sys.path.insert(0, os.path.abspath('.'))
-

--- a/launch_xml/doc/index.rst
+++ b/launch_xml/doc/index.rst
@@ -1,0 +1,22 @@
+Welcome to launch_xml's documentation!
+======================================
+
+``launch_xml`` provides an XML frontend for the ROS 2 launch system.
+
+For usage details, see `Using XML, YAML, and Python for ROS 2 Launch Files
+<https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html>`_.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   standard_docs/README
+   modules
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/launch_xml/doc/index.rst
+++ b/launch_xml/doc/index.rst
@@ -2,9 +2,7 @@ Welcome to launch_xml's documentation!
 ======================================
 
 ``launch_xml`` provides an XML frontend for the ROS 2 launch system.
-
-For usage details, see `Using XML, YAML, and Python for ROS 2 Launch Files
-<https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html>`_.
+See the ROS 2 documentation for usage examples with XML, YAML, and Python launch files.
 
 .. toctree::
    :maxdepth: 2

--- a/launch_yaml/doc/conf.py
+++ b/launch_yaml/doc/conf.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration file for the Sphinx documentation builder."""
+
+import os
+import sys
+
+# rosdoc2 copies this package's modules alongside conf.py, so add parent to path
+sys.path.insert(0, os.path.abspath('.'))
+

--- a/launch_yaml/doc/conf.py
+++ b/launch_yaml/doc/conf.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,3 @@ import sys
 
 # rosdoc2 copies this package's modules alongside conf.py, so add parent to path
 sys.path.insert(0, os.path.abspath('.'))
-

--- a/launch_yaml/doc/index.rst
+++ b/launch_yaml/doc/index.rst
@@ -2,9 +2,7 @@ Welcome to launch_yaml's documentation!
 =======================================
 
 ``launch_yaml`` provides a YAML frontend for the ROS 2 launch system.
-
-For usage details, see `Using XML, YAML, and Python for ROS 2 Launch Files
-<https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html>`_.
+See the ROS 2 documentation for usage examples with XML, YAML, and Python launch files.
 
 .. toctree::
    :maxdepth: 2

--- a/launch_yaml/doc/index.rst
+++ b/launch_yaml/doc/index.rst
@@ -1,0 +1,22 @@
+Welcome to launch_yaml's documentation!
+=======================================
+
+``launch_yaml`` provides a YAML frontend for the ROS 2 launch system.
+
+For usage details, see `Using XML, YAML, and Python for ROS 2 Launch Files
+<https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html>`_.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   standard_docs/README
+   modules
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
## Description

Add basic Sphinx documentation skeleton for `launch_xml` and `launch_yaml` packages.

- Add `doc/conf.py` and `doc/index.rst` for both packages
- Include README and API modules via rosdoc2
- Link to ROS 2 launch file formats how-to guide

Fixes #929

### Did you use Generative AI?

Cursor AI Assistant for scaffolding and iteration. Each generated line reviewed.

### Additional Information

* Tested locally with `rosdoc2 build --package-path src/ros2/launch/launch_xml` and `rosdoc2 build --package-path src/ros2/launch/launch_yaml`.
* launch_xml and launch_yaml docs structure is slightly different from launch. Removed extra source folder and other Makefiles.