### PR TITLE
launch_yaml: cache and restore test environment

### DIFF
--- a/launch_yaml/conftest.py
+++ b/launch_yaml/conftest.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def restore_env():
+    """
+    Restore environment after running tests.
+
+    Protects the environment when tests mutate or clear it.
+    """
+    original_env = os.environ.copy()
+    yield  # The test runs here
+    os.environ.clear()
+    os.environ.update(original_env)


### PR DESCRIPTION
Several of the launch_yaml tests mutate the os.environ variable, which can yield some unexpected results depending on the sequence the tests are run. Use a fixture to cache and restore the original environment.


Assisted-by: Gemini CLI:2.0-Flash [glob, read_file, run_shell_command, web_fetch, google_web_search, grep_search, replace, write_file, git, gh, uv, invoke_agent]
