### PR TITLE
Support frontends for PathJoinSubstitution

### DIFF
--- a/launch/launch/substitutions/path_join_substitution.py
+++ b/launch/launch/substitutions/path_join_substitution.py
@@ -15,10 +15,16 @@
 """Module for the PathJoinSubstitution substitution."""
 
 from pathlib import Path
+from typing import Any
+from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Sequence
 from typing import Text
+from typing import Tuple
+from typing import Type
 
+from ..frontend import expose_substitution
 from ..launch_context import LaunchContext
 from ..some_substitutions_type import SomeSubstitutionsType
 from ..substitution import Substitution
@@ -26,6 +32,7 @@ from ..utilities import normalize_to_list_of_substitutions
 from ..utilities import perform_substitutions
 
 
+@expose_substitution('path-join')
 class PathJoinSubstitution(Substitution):
     """
     Substitution that join paths, in a platform independent way.
@@ -35,11 +42,19 @@ class PathJoinSubstitution(Substitution):
 
     For example:
 
+    .. code-block:: xml
+
+        $(path-join $(env SOME_DIR) 'cfg 2' config_$(var map).yml)
+
+    .. code-block:: yaml
+
+        $(path-join $(env SOME_DIR) "cfg 2" config_$(var map).yml)
+
     .. code-block:: python
 
         PathJoinSubstitution([
             EnvironmentVariable('SOME_DIR'),
-            'cfg',
+            'cfg 2',
             ['config_', LaunchConfiguration('map'), '.yml']
         ])
 
@@ -47,7 +62,7 @@ class PathJoinSubstitution(Substitution):
 
     .. code-block:: python
 
-        cfg_dir = PathJoinSubstitution([EnvironmentVariable('SOME_DIR'), 'cfg'])
+        cfg_dir = PathJoinSubstitution([EnvironmentVariable('SOME_DIR'), 'cfg 2'])
         cfg_file = cfg_dir / ['config_', LaunchConfiguration('map'), '.yml']
 
     If the ``SOME_DIR`` environment variable was set to ``/home/user/dir`` and the ``map`` launch
@@ -56,7 +71,7 @@ class PathJoinSubstitution(Substitution):
 
     .. code-block:: python
 
-        '/home/user/dir/cfg/config_my_map.yml'
+        '/home/user/dir/cfg 2/config_my_map.yml'
     """
 
     def __init__(self, substitutions: Iterable[SomeSubstitutionsType]) -> None:
@@ -65,7 +80,6 @@ class PathJoinSubstitution(Substitution):
 
         :param substitutions: the list of path component substitutions to join
         """
-        from ..utilities import normalize_to_list_of_substitutions
         self.__substitutions = [
             normalize_to_list_of_substitutions(path_component_substitutions)
             for path_component_substitutions in substitutions
@@ -75,6 +89,17 @@ class PathJoinSubstitution(Substitution):
     def substitutions(self) -> List[List[Substitution]]:
         """Getter for substitutions."""
         return self.__substitutions
+
+    @classmethod
+    def parse(
+        cls,
+        data: Sequence[SomeSubstitutionsType],
+    ) -> Tuple[Type['PathJoinSubstitution'], Dict[str, Any]]:
+        if len(data) == 0:
+            raise ValueError(f'{cls.__name__} expects at least 1 argument')
+        kwargs = {}
+        kwargs['substitutions'] = data
+        return cls, kwargs
 
     def __repr__(self) -> Text:
         """Return a description of this substitution as a string."""

--- a/launch_xml/test/launch_xml/test_path_join_substitution.py
+++ b/launch_xml/test/launch_xml/test_path_join_substitution.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test parsing a `PathJoinSubstitution` substitution."""
+
+import io
+import textwrap
+
+import lark
+
+from launch import LaunchService
+from launch.actions import Log
+from launch.substitutions import PathJoinSubstitution
+from launch.utilities import perform_substitutions
+
+from parser_no_extensions import load_no_extensions
+
+import pytest
+
+
+def test_path_join_substitution():
+    xml_file = \
+        """\
+        <launch>
+          <let name="model" value="a" />
+          <let name="id" value="2" />
+          <let name="ver" value="1.0" />
+          <log
+            message="file=$(path-join 'robot$(var id)' $(var model) 'ur df' v_$(var ver).xacro)"
+          />
+        </launch>
+        """
+    xml_file = textwrap.dedent(xml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+    launch_description = parser.parse_description(root_entity)
+
+    ls = LaunchService(debug=True)
+    ls.include_launch_description(launch_description)
+    assert 0 == ls.run()
+
+    log_info = launch_description.entities[3]
+    assert isinstance(log_info, Log)
+    assert isinstance(log_info.msg[1], PathJoinSubstitution)
+    assert perform_substitutions(ls.context, log_info.msg) == 'file=robot2/a/ur df/v_1.0.xacro'
+
+
+def test_path_join_substitution_empty():
+    xml_file = \
+        """\
+        <launch>
+          <log message="file=$(path-join)" />
+        </launch>
+        """
+    xml_file = textwrap.dedent(xml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+    # lark hides the parsing error from the underlying Python class
+    with pytest.raises(lark.exceptions.VisitError) as excinfo:
+        parser.parse_description(root_entity)
+    assert isinstance(excinfo.value.orig_exc, ValueError)

--- a/launch_xml/test/launch_xml/test_path_join_substitution.py
+++ b/launch_xml/test/launch_xml/test_path_join_substitution.py
@@ -15,6 +15,7 @@
 """Test parsing a `PathJoinSubstitution` substitution."""
 
 import io
+from pathlib import Path
 import textwrap
 
 import lark
@@ -52,7 +53,8 @@ def test_path_join_substitution():
     log_info = launch_description.entities[3]
     assert isinstance(log_info, Log)
     assert isinstance(log_info.msg[1], PathJoinSubstitution)
-    assert perform_substitutions(ls.context, log_info.msg) == 'file=robot2/a/ur df/v_1.0.xacro'
+    assert perform_substitutions(ls.context, log_info.msg) == \
+        'file=' + str(Path('robot2', 'a', 'ur df', 'v_1.0.xacro'))
 
 
 def test_path_join_substitution_empty():

--- a/launch_yaml/test/launch_yaml/test_path_join_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_path_join_substitution.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test parsing a `PathJoinSubstitution` substitution."""
+
+import io
+import textwrap
+
+import lark
+
+from launch import LaunchService
+from launch.actions import Log
+from launch.substitutions import PathJoinSubstitution
+from launch.utilities import perform_substitutions
+
+from parser_no_extensions import load_no_extensions
+
+import pytest
+
+
+def test_path_join_substitution():
+    yaml_file = \
+        """\
+        launch:
+        - let:
+            name: 'model'
+            value: 'a'
+        - let:
+            name: 'id'
+            value: '2'
+        - let:
+            name: 'ver'
+            value: '1.0'
+        - log:
+            message: file=$(path-join "robot$(var id)" $(var model) "ur df" v_$(var ver).xacro)
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+    launch_description = parser.parse_description(root_entity)
+
+    ls = LaunchService(debug=True)
+    ls.include_launch_description(launch_description)
+    assert 0 == ls.run()
+
+    log_info = launch_description.entities[3]
+    assert isinstance(log_info, Log)
+    assert isinstance(log_info.msg[1], PathJoinSubstitution)
+    assert perform_substitutions(ls.context, log_info.msg) == 'file=robot2/a/ur df/v_1.0.xacro'
+
+
+def test_path_join_substitution_empty():
+    yaml_file = \
+        """\
+        launch:
+        - log:
+            message: file=$(path-join)
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+    # lark hides the parsing error from the underlying Python class
+    with pytest.raises(lark.exceptions.VisitError) as excinfo:
+        parser.parse_description(root_entity)
+    assert isinstance(excinfo.value.orig_exc, ValueError)

--- a/launch_yaml/test/launch_yaml/test_path_join_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_path_join_substitution.py
@@ -15,6 +15,7 @@
 """Test parsing a `PathJoinSubstitution` substitution."""
 
 import io
+from pathlib import Path
 import textwrap
 
 import lark
@@ -56,7 +57,8 @@ def test_path_join_substitution():
     log_info = launch_description.entities[3]
     assert isinstance(log_info, Log)
     assert isinstance(log_info.msg[1], PathJoinSubstitution)
-    assert perform_substitutions(ls.context, log_info.msg) == 'file=robot2/a/ur df/v_1.0.xacro'
+    assert perform_substitutions(ls.context, log_info.msg) == \
+        'file=' + str(Path('robot2', 'a', 'ur df', 'v_1.0.xacro'))
 
 
 def test_path_join_substitution_empty():


### PR DESCRIPTION
## Description

Implement frontend parsing for `PathJoinSubstitution`.

Note the handling of individual components after `$(path-join`: path components including a space character have to be quoted, otherwise they don't need to be quoted. See examples in the Python class docstring.

### Is this user-facing behavior change?

Yes, users can now use `PathJoinSubstitution` in frontends.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

I made the parser raise an exception if the substitution is used without any path components. This will raise:

```yaml
launch:
- log:
    message: file=$(path-join)
```

but this will not raise:

```yaml
launch:
- let:
    name: 'model'
    value: ''
- log:
    message: file=$(path-join $(var model))
```

The first one is definitely _invalid_ while the second one's behaviour is defined (by `pathlib.Path`):

```py
>>> from pathlib import Path
>>> Path('')
PosixPath('.')
```