### PR TITLE
add functionality to enable color logging for ros2launch messages

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -25,6 +25,8 @@ import sys
 from typing import (Any, Dict, List, Literal, Optional, Protocol, Set, Tuple,
                     Union)
 
+import colorlog
+
 from typing_extensions import TypeAlias
 
 from . import handlers
@@ -125,6 +127,27 @@ class LaunchConfig:
         logging.root.setLevel(logging.INFO)
         self.set_screen_format('default')
         self.set_log_format('default')
+
+    def _logging_colors_enabled(self) -> bool:
+        """
+        Determine if colored output should be used for console logging.
+
+        Colors are enabled when:
+        - RCUTILS_COLORIZED_OUTPUT=1 is explicitly set, OR
+        - RCUTILS_COLORIZED_OUTPUT is unset AND stdout is a TTY
+
+        Colors are disabled when:
+        - RCUTILS_COLORIZED_OUTPUT=0 is explicitly set
+
+        :return: True if colors should be used, False otherwise
+        """
+        colorized_output = os.environ.get('RCUTILS_COLORIZED_OUTPUT')
+        if colorized_output == '0':
+            return False
+        elif colorized_output == '1':
+            return True
+        else:
+            return sys.stdout.isatty()
 
     @property
     def level(self) -> int:
@@ -262,9 +285,13 @@ class LaunchConfig:
                     )
             if screen_style is None:
                 screen_style = '{'
-            self.screen_formatter = logging.Formatter(
-                screen_format, style=screen_style
-            )
+            if self._logging_colors_enabled():
+                self.screen_formatter = colorlog.ColoredFormatter(
+                    '{log_color}' + screen_format,
+                    style=screen_style
+                )
+            else:
+                self.screen_formatter = logging.Formatter(screen_format, style=screen_style)
             if self.screen_handler is not None:
                 self.screen_handler.setFormatter(self.screen_formatter)
         else:

--- a/launch/package.xml
+++ b/launch/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>python3-osrf-pycommon</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>python3-typing-extensions</exec_depend>
+  <exec_depend>python3-colorlog</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -25,6 +25,24 @@ import launch.logging
 import pytest
 
 
+def contains_ansicode(str_to_check: str) -> bool:
+    """
+    Check if given string contains an ANSI code sequence.
+
+    :param str_to_check: Given string to check for ANSI codes.
+    :return: True if the given string contains any ANSI code sequence,
+    False otherwise.
+    """
+    ansi_regex = re.compile(r"""
+        \x1b     # literal ESC
+        \[       # literal [
+        [;\d]*   # zero or more digits or semicolons
+        [A-Za-z] # a letter
+        """, re.VERBOSE)
+
+    return bool(ansi_regex.search(str_to_check))
+
+
 @pytest.fixture
 def log_dir(tmpdir_factory):
     """Test fixture that generates a temporary directory for log files."""
@@ -95,6 +113,111 @@ params = [
     for (config, checks) in configs
     for log_file_name in log_file_names
 ]
+
+
+def test_colorized_output_with_tty(capsys, monkeypatch, mock_clean_env):
+    """
+    Test color output with TTY.
+
+    Colors should be enabled when stdout is set to a TTY and
+    RCUTILS_COLORIZED_OUTPUT is unset.
+    """
+    monkeypatch.setattr('sys.stdout.isatty', lambda: True)
+    monkeypatch.delenv('RCUTILS_COLORIZED_OUTPUT', raising=False)
+
+    launch.logging.reset()
+    logger = launch.logging.get_logger()
+    logger.setLevel(logging.INFO)
+    logger.info('Test message with TTY')
+
+    capture = capsys.readouterr()
+    assert contains_ansicode(capture.out), \
+        'Expected ANSI color codes in output with TTY'
+
+
+def test_colorized_output_disabled_by_env(capsys, monkeypatch, mock_clean_env):
+    """
+    Test color output disabled by env var.
+
+    Colors should be disabled when stdout is a TTY but
+    RCUTILS_COLORIZED_OUTPUT=0.
+    """
+    monkeypatch.setattr('sys.stdout.isatty', lambda: True)
+    monkeypatch.setenv('RCUTILS_COLORIZED_OUTPUT', '0')
+
+    launch.logging.reset()
+    logger = launch.logging.get_logger()
+    logger.setLevel(logging.INFO)
+    logger.info('Test message with colors disabled')
+
+    capture = capsys.readouterr()
+    assert not contains_ansicode(capture.out), \
+        'Expected no ANSI color codes when disabled by env var'
+
+
+def test_colorized_output_forced_by_env(capsys, monkeypatch, mock_clean_env):
+    """
+    Test color output forced by env var in non TTY.
+
+    Colors should be forced on when RCUTILS_COLORIZED_OUTPUT=1
+    even without TTY.
+    """
+    monkeypatch.setattr('sys.stdout.isatty', lambda: False)
+    monkeypatch.setenv('RCUTILS_COLORIZED_OUTPUT', '1')
+
+    launch.logging.reset()
+    logger = launch.logging.get_logger()
+    logger.setLevel(logging.INFO)
+    logger.info('Test message with forced colors')
+
+    capture = capsys.readouterr()
+    assert contains_ansicode(capture.out), \
+        'Expected ANSI color codes when forced by env var'
+
+
+def test_file_logs_not_colorized(log_dir, monkeypatch, mock_clean_env):
+    """
+    Test that file logs are not colorized.
+
+    File logs should never contain ANSI color codes even if
+    RCUTILS_COLORIZED_OUTPUT=1.
+    """
+    monkeypatch.setenv('RCUTILS_COLORIZED_OUTPUT', '1')
+
+    launch.logging.reset()
+    launch.logging.launch_config.log_dir = log_dir
+    logger = launch.logging.get_logger()
+    logger.setLevel(logging.INFO)
+    logger.info('Test message for file logging')
+
+    log_file = pathlib.Path(log_dir) / 'launch.log'
+    assert log_file.exists(), 'Log file should exist'
+    file_contents = log_file.read_text()
+
+    assert not contains_ansicode(file_contents), \
+        'File logs should never contain ANSI color codes'
+    assert 'Test message for file logging' in file_contents, \
+        'Message should be in log file'
+
+
+def test_colorized_output_no_tty(capsys, monkeypatch, mock_clean_env):
+    """
+    Test color output without a TTY and no env var.
+
+    Colors should be disabled when stdout is not a TTY and
+    RCUTILS_COLORIZED_OUTPUT is unset.
+    """
+    monkeypatch.setattr('sys.stdout.isatty', lambda: False)
+    monkeypatch.delenv('RCUTILS_COLORIZED_OUTPUT', raising=False)
+
+    launch.logging.reset()
+    logger = launch.logging.get_logger()
+    logger.setLevel(logging.INFO)
+    logger.info('Test message without TTY')
+
+    capture = capsys.readouterr()
+    assert not contains_ansicode(capture.out), \
+        'Expected no ANSI color codes without TTY'
 
 
 @pytest.mark.parametrize('config,checks,main_log_file_name', params)


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
This PR adds color logging support to the launch system. Currently the logs of individual nodes run from the launch file can be colorized using e.g. *emulate_tty*, however the messages generated by ros2launch itself (e.g., "process started", "process has died", and log tags [INFO] or [ERROR]) remained unaffected/non-colored.

Corresponding tests to the colorlog functionality have been added too. 


(a) ros2 launch using the newly added colorlogging 
<img width="1140" height="399" alt="image" src="https://github.com/user-attachments/assets/9722e5f6-b276-4652-856f-91caba957672" />

(b) old behavior in which *RCUTILS_COLORIZED_OUTPUT* or *emulaty_tty* did not affect the color logging ability of ros2launch messages
<img width="1140" height="399" alt="image" src="https://github.com/user-attachments/assets/c693f373-3479-4783-936d-3f567e15349f" />


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #942 

### Is this user-facing behavior change?

Yes. Users will now see colorized log output for ros2launch events when running in a tty or when *RCUTILS_COLORIZED_OUTPUT=1*

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
- The *contains_ansicode* helper function used for the added tests is derived from the ansi regex check posted here: https://stackoverflow.com/questions/68556358/how-to-check-for-ansi-character-in-python

- Since the PR adds a new python3 dependency (python3-colorlog) the corresponding rosdep key was already added. See https://github.com/ros/rosdistro/pull/49860


<!--
If applicable, provide any additional context or details about the changes.
-->
