### PR TITLE
fix: add get_launch_test_fixture_scope for pytest compatibility

### DIFF
--- a/launch_pytest/launch_pytest/plugin.py
+++ b/launch_pytest/launch_pytest/plugin.py
@@ -17,6 +17,7 @@ from collections.abc import Sequence
 import functools
 import inspect
 
+from _pytest.fixtures import getfixturemarker
 from _pytest.outcomes import fail
 from _pytest.outcomes import skip
 
@@ -171,12 +172,7 @@ def get_launch_test_fixturename(item):
 
 def get_launch_test_fixture_scope(fixture):
     """Return launch fixture scope for multiple pytest fixture representations."""
-    # Pytest < 8.4 decorates fixtures in-place and stores metadata in
-    # `_pytestfixturefunction`; pytest >= 8.4 returns a fixture object with
-    # `_fixture_function_marker`.
-    fixture_marker = getattr(fixture, '_pytestfixturefunction', None)
-    if fixture_marker is None:
-        fixture_marker = getattr(fixture, '_fixture_function_marker', None)
+    fixture_marker = getfixturemarker(fixture)
     if fixture_marker is None:
         raise AttributeError(
             f'Unable to retrieve fixture scope from fixture {fixture!r}.'

--- a/launch_pytest/launch_pytest/plugin.py
+++ b/launch_pytest/launch_pytest/plugin.py
@@ -169,6 +169,21 @@ def get_launch_test_fixturename(item):
     return None if fixture is None else fixture.__name__
 
 
+def get_launch_test_fixture_scope(fixture):
+    """Return launch fixture scope for multiple pytest fixture representations."""
+    # Pytest < 8.4 decorates fixtures in-place and stores metadata in
+    # `_pytestfixturefunction`; pytest >= 8.4 returns a fixture object with
+    # `_fixture_function_marker`.
+    fixture_marker = getattr(fixture, '_pytestfixturefunction', None)
+    if fixture_marker is None:
+        fixture_marker = getattr(fixture, '_fixture_function_marker', None)
+    if fixture_marker is None:
+        raise AttributeError(
+            f'Unable to retrieve fixture scope from fixture {fixture!r}.'
+        )
+    return fixture_marker.scope
+
+
 def is_valid_test_item(obj):
     """Return true if obj is a valid launch test item."""
     return (
@@ -236,7 +251,7 @@ def pytest_pycollect_makeitem(collector, name, obj):
                 return [item]
             fixture = get_launch_test_fixture(item)
             fixturename = fixture.__name__
-            scope = fixture._pytestfixturefunction.scope
+            scope = get_launch_test_fixture_scope(fixture)
             is_shutdown = has_shutdown_kwarg(item)
             items = generate_test_items(
                 collector, name, obj, fixturename, is_shutdown=is_shutdown, needs_renaming=False)
@@ -264,7 +279,7 @@ def is_same_launch_test_fixture(left_item, right_item):
         return False
     if lfn is not rfn:
         return False
-    if lfn._pytestfixturefunction.scope == 'function':
+    if get_launch_test_fixture_scope(lfn) == 'function':
         return False
     name = lfn.__name__
 
@@ -331,7 +346,7 @@ def pytest_pyfunc_call(pyfuncitem):
         return
     shutdown_test = is_shutdown_test(pyfuncitem)
     fixture = get_launch_test_fixture(pyfuncitem)
-    scope = fixture._pytestfixturefunction.scope
+    scope = get_launch_test_fixture_scope(fixture)
     event_loop = pyfuncitem.funcargs['event_loop']
     ls = pyfuncitem.funcargs['launch_service']
     auto_shutdown = fixture._launch_pytest_fixture_options['auto_shutdown']

--- a/launch_pytest/test/launch_pytest/test_plugin.py
+++ b/launch_pytest/test/launch_pytest/test_plugin.py
@@ -14,6 +14,9 @@
 
 from pathlib import Path
 import shutil
+from types import SimpleNamespace
+
+from launch_pytest.plugin import get_launch_test_fixture_scope
 
 
 def test_launch_fixture_is_not_a_launch_description(testdir):
@@ -330,3 +333,15 @@ def test_examples(testdir):
     shutil.copytree(examples_dir / 'executables', Path(testdir.tmpdir) / 'executables')
     result = testdir.runpytest()
     result.assert_outcomes(passed=22)
+
+
+def test_get_launch_test_fixture_scope_with_new_and_old_pytest_repr():
+    old_pytest_fixture = SimpleNamespace(
+        _pytestfixturefunction=SimpleNamespace(scope='module')
+    )
+    new_pytest_fixture = SimpleNamespace(
+        _fixture_function_marker=SimpleNamespace(scope='class')
+    )
+
+    assert get_launch_test_fixture_scope(old_pytest_fixture) == 'module'
+    assert get_launch_test_fixture_scope(new_pytest_fixture) == 'class'

--- a/launch_pytest/test/launch_pytest/test_plugin.py
+++ b/launch_pytest/test/launch_pytest/test_plugin.py
@@ -14,9 +14,6 @@
 
 from pathlib import Path
 import shutil
-from types import SimpleNamespace
-
-from launch_pytest.plugin import get_launch_test_fixture_scope
 
 
 def test_launch_fixture_is_not_a_launch_description(testdir):

--- a/launch_pytest/test/launch_pytest/test_plugin.py
+++ b/launch_pytest/test/launch_pytest/test_plugin.py
@@ -333,15 +333,3 @@ def test_examples(testdir):
     shutil.copytree(examples_dir / 'executables', Path(testdir.tmpdir) / 'executables')
     result = testdir.runpytest()
     result.assert_outcomes(passed=22)
-
-
-def test_get_launch_test_fixture_scope_with_new_and_old_pytest_repr():
-    old_pytest_fixture = SimpleNamespace(
-        _pytestfixturefunction=SimpleNamespace(scope='module')
-    )
-    new_pytest_fixture = SimpleNamespace(
-        _fixture_function_marker=SimpleNamespace(scope='class')
-    )
-
-    assert get_launch_test_fixture_scope(old_pytest_fixture) == 'module'
-    assert get_launch_test_fixture_scope(new_pytest_fixture) == 'class'


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #947 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

codex 5.3

### Additional Information

before
```
❯ PYTHONPATH=launch_pytest:launch_testing:launch:../ament_index/ament_index_python/ uvx --with pytest --with osrf_pycommon --with typing_extensions --with pyyaml --with lark pytest /Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py::test_sync_process_tools -q
E                                                                                                                                                  [100%]
========================================================================= ERRORS =========================================================================
_______________________________________________________ ERROR at setup of test_sync_process_tools ________________________________________________________
file /Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py, line 65
  @pytest.mark.launch(fixture=launch_description)
  def test_sync_process_tools(dut, launch_context):
E       fixture 'launch_context' not found
>       available fixtures: LineMatcher, _config_for_test, _pytest, _sys_snapshot, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capteesys, doctest_namespace, dut, launch_description, linecomp, monkeypatch, pytestconfig, pytester, record_property, record_testsuite_property, record_xml_attribute, recwarn, subtests, testdir, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py:65
==================================================================== warnings summary ====================================================================
launch_pytest/test/launch_pytest/tools/test_process.py:49
  /Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py:49: PytestUnknownMarkWarning: Unknown pytest.mark.launch - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.launch(fixture=launch_description)

launch_pytest/test/launch_pytest/tools/test_process.py:65
  /Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py:65: PytestUnknownMarkWarning: Unknown pytest.mark.launch - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.launch(fixture=launch_description)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ short test summary info =================================================================
ERROR launch_pytest/test/launch_pytest/tools/test_process.py::test_sync_process_tools
2 warnings, 1 error in 0.12s

~/workspace/launch rolling
❯ PYTHONPATH=launch_pytest:launch_testing:launch:../ament_index/ament_index_python \
      uvx --with pytest --with osrf_pycommon --with typing_extensions --with pyyaml --with lark \
      pytest -p launch_pytest.plugin \
      /Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py::test_sync_process_tools -q

================================================================== ERRORS ==================================================================
________________________________________ ERROR collecting test/launch_pytest/tools/test_process.py _________________________________________
../../.cache/uv/archive-v0/LH_vSsIIXaIhCxrT9it7P/lib/python3.14/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.cache/uv/archive-v0/LH_vSsIIXaIhCxrT9it7P/lib/python3.14/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
launch_pytest/launch_pytest/plugin.py:239: in pytest_pycollect_makeitem
    scope = fixture._pytestfixturefunction.scope
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'FixtureFunctionDefinition' object has no attribute '_pytestfixturefunction'. Did you mean: '_fixture_function'?
========================================================= short test summary info ==========================================================
ERROR launch_pytest/test/launch_pytest/tools/test_process.py - AttributeError: 'FixtureFunctionDefinition' object has no attribute '_pytestfixturefunction'. Did you mean: '_fixture_function'?
1 error in 0.06s
ERROR: found no collectors for /Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py::test_sync_process_tools
```

after
```
❯ PYTHONPATH=launch_pytest:launch_testing:launch:../ament_index/ament_index_python \
      uvx --with pytest --with osrf_pycommon --with typing_extensions --with pyyaml --with lark \
      pytest -p launch_pytest.plugin \
      /Users/daisuke/workspace/launch/launch_pytest/test/launch_pytest/tools/test_process.py::test_sync_process_tools -q
.                                                                                                                                    [100%]
============================================================= warnings summary =============================================================
test/launch_pytest/tools/test_process.py::test_sync_process_tools
  /Users/daisuke/workspace/launch/launch_pytest/launch_pytest/fixture.py:75: DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slated for removal in Python 3.16
    loop = asyncio.get_event_loop_policy().new_event_loop()

test/launch_pytest/tools/test_process.py::test_sync_process_tools
  /Users/daisuke/workspace/launch/launch_pytest/launch_pytest/fixture.py:76: DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slated for removal in Python 3.16
    policy = asyncio.get_event_loop_policy()

test/launch_pytest/tools/test_process.py::test_sync_process_tools
  /Users/daisuke/workspace/launch/launch_pytest/launch_pytest/fixture.py:87: DeprecationWarning: 'asyncio.set_event_loop_policy' is deprecated and slated for removal in Python 3.16
    asyncio.set_event_loop_policy(None)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
1 passed, 3 warnings in 5.04s
```