### PR TITLE
Update timeout handling

### DIFF
--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -55,10 +55,10 @@ macro(parse_launch_test_arguments namespace filename)
     "ARGS;LABELS"
     ${ARGN})
 
-  if(NOT ${namespace}_TIMEOUT)
-    set(${namespace}_TIMEOUT 60)
+  if(NOT DEFINED ${namespace}_TIMEOUT OR "${${namespace}_TIMEOUT}" STREQUAL "")
+    set(${namespace}_TIMEOUT 60) #seconds
   endif()
-
+  
   if(NOT ${namespace}_PYTHON_EXECUTABLE)
     set(${namespace}_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
   endif()


### PR DESCRIPTION
## Description

Fixes a bug where 0 is not a legal input and defaults to 60 seconds. However 0 should symbolize an infinite long timeout according to the documentation: https://cmake.org/cmake/help/latest/prop_test/TIMEOUT.html

This is especially important for robotics since some tests let you run into the halting problem. So you do not know how long it takes. Example: optimization 

### Is this user-facing behavior change?

Kind of. This should not break existing test cases but this corrects the expectation that a TIMEOUT 0 means that the tests run indefinitely. So it gets rid of the hard to spot bugs that happen only when you have tests that should run over 60 sec.

### Did you use Generative AI?

No AI was used (hence the typos)

### Additional Information

Tested on Ubuntu 22.04.5 LTS (Linux 6.8.0-107-generic) using ROS 2 humble

This bug is dragged trough https://github.com/ament/ament_cmake, I made a second pull request for that too. The changes will not go into affect till they merge this in.

See: https://github.com/ament/ament_cmake/pull/623#issue-4258442384