### PR TITLE
fix: parse respawn_max_retries YAML strings

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -365,6 +365,19 @@ class ExecuteProcess(ExecuteLocal):
             respawn_max_retries = entity.get_attr('respawn_max_retries', data_type=int,
                                                   optional=True)
             if respawn_max_retries is not None:
+                if isinstance(respawn_max_retries, bool):
+                    raise ValueError(
+                        'Attribute respawn_max_retries of Entity `{}` expected to be '
+                        'an integer but got `{}`'.format(entity.type_name, respawn_max_retries)
+                    )
+                if isinstance(respawn_max_retries, str):
+                    try:
+                        respawn_max_retries = int(respawn_max_retries)
+                    except ValueError:
+                        raise ValueError(
+                            'Attribute respawn_max_retries of Entity `{}` expected to be '
+                            'an integer but got `{}`'.format(entity.type_name, respawn_max_retries)
+                        ) from None
                 kwargs['respawn_max_retries'] = respawn_max_retries
 
         if 'respawn_delay' not in ignore:

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -19,6 +19,9 @@ import textwrap
 
 from launch import LaunchService
 from launch.actions import Shutdown
+from launch.actions.execute_process import ExecuteProcess
+
+import pytest
 
 from parser_no_extensions import load_no_extensions
 
@@ -80,6 +83,52 @@ def test_executable_on_exit():
     sub_entities = executable.get_sub_entities()
     assert len(sub_entities) == 1
     assert isinstance(sub_entities[0], Shutdown)
+
+
+def test_executable_respawn_max_retries_string_zero():
+    yaml_file = \
+        """\
+        launch:
+        -   executable:
+                cmd: echo test
+                respawn_max_retries: '0'
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+    _, kwargs = ExecuteProcess.parse(root_entity.children[0], parser)
+
+    assert kwargs['respawn_max_retries'] == 0
+    assert isinstance(kwargs['respawn_max_retries'], int)
+
+
+def test_executable_respawn_max_retries_empty_string_error():
+    yaml_file = \
+        """\
+        launch:
+        -   executable:
+                cmd: echo test
+                respawn_max_retries: ''
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+
+    with pytest.raises(ValueError, match='respawn_max_retries'):
+        ExecuteProcess.parse(root_entity.children[0], parser)
+
+
+def test_executable_respawn_max_retries_bool_error():
+    yaml_file = \
+        """\
+        launch:
+        -   executable:
+                cmd: echo test
+                respawn_max_retries: true
+        """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+
+    with pytest.raises(ValueError, match='respawn_max_retries'):
+        ExecuteProcess.parse(root_entity.children[0], parser)
 
 
 if __name__ == '__main__':

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -21,9 +21,9 @@ from launch import LaunchService
 from launch.actions import Shutdown
 from launch.actions.execute_process import ExecuteProcess
 
-import pytest
-
 from parser_no_extensions import load_no_extensions
+
+import pytest
 
 
 def test_executable():


### PR DESCRIPTION
## Summary

Parse YAML string values for `respawn_max_retries` into integers during frontend parsing, and reject empty strings and booleans with a clear `ValueError`.

Closes #968

<details>
<summary>Before</summary>

```console
$ python direct_parse_respawn_max_retries.py  # upstream/rolling
"'0'" -> '0' (str)
"''" -> '' (str)
'true' -> True (bool)
```

</details>

<details>
<summary>After</summary>

```console
$ git diff --check

$ python3 -m py_compile launch/launch/actions/execute_process.py launch_yaml/test/launch_yaml/test_executable.py
$WORKSPACE/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources

$ ruff check launch/launch/actions/execute_process.py launch_yaml/test/launch_yaml/test_executable.py
All checks passed!

$ python direct_parse_respawn_max_retries.py  # patched worktree
"'0'" -> 0 (int)
"''" -> ValueError: Attribute respawn_max_retries of Entity `executable` expected to be an integer but got ``
'true' -> ValueError: Attribute respawn_max_retries of Entity `executable` expected to be an integer but got `True`

$ python -m pytest -q launch_yaml/test/launch_yaml/test_executable.py::test_executable_respawn_max_retries_string_zero launch_yaml/test/launch_yaml/test_executable.py::test_executable_respawn_max_retries_empty_string_error launch_yaml/test/launch_yaml/test_executable.py::test_executable_respawn_max_retries_bool_error
...                                                                      [100%]
=============================== warnings summary ===============================
test/launch_yaml/test_executable.py::test_executable_respawn_max_retries_string_zero
  $WORKSPACE/ros2-contrib/worktrees/launch-968/launch/launch/frontend/parser.py:96: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    groups = entry_points.get('launch.frontend.parser', [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
3 passed, 1 warning in 0.11s
```

</details>

## Test plan

- [x] `git diff --check`
- [x] `python3 -m py_compile launch/launch/actions/execute_process.py launch_yaml/test/launch_yaml/test_executable.py`
- [x] `ruff check launch/launch/actions/execute_process.py launch_yaml/test/launch_yaml/test_executable.py`
- [x] Direct parser check for `'0'`, `''`, and `true`
- [x] `python -m pytest -q launch_yaml/test/launch_yaml/test_executable.py::test_executable_respawn_max_retries_string_zero launch_yaml/test/launch_yaml/test_executable.py::test_executable_respawn_max_retries_empty_string_error launch_yaml/test/launch_yaml/test_executable.py::test_executable_respawn_max_retries_bool_error`
