### PR TITLE
Fix #931:add 'actions' key support for YAML,keeping the existing 'children' key as a fallback

### DIFF
--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -63,13 +63,17 @@ class Entity(BaseEntity):
                 f'\n---\n{self.__element}\n---'
             )
         if isinstance(self.__element, dict):
-            if 'children' not in self.__element:
+            if 'actions' in self.__element:
+                self.__read_keys.add('actions')
+                children = self.__element['actions']
+            elif 'children' in self.__element:
+                self.__read_keys.add('children')
+                children = self.__element['children']
+            else :
                 raise ValueError(
                     f'Expected entity `{self.__type_name}` to have children entities.'
-                    f'That can be a list of subentities or a dictionary with a `children` '
-                    'list element')
-            self.__read_keys.add('children')
-            children = self.__element['children']
+                    f'That can be a list of subentities or a dictionary with an `actions` '
+                    f'or `children` list element')
         else:
             children = self.__element
         entities = []


### PR DESCRIPTION
## Description
This PR adds support for YAML to accept 'actions' key to match the Python API, while continuing to have 'children' as a fallback to not break the existing usage.The ValueError message in the parser has also been updated to reflect both 'actions' and 'children' as valid keys

Fixes #931

### Is this user-facing behavior change?

yes. User can now use 'actions' to define nested entities.Existing files using 'children' will continue to work as that children is added as fallback.Error message also has been updated to reflect support for both actions and children keys.

### Did you use Generative AI?

No

### Additional Information