### PR TITLE
Apply launch prefix without overwriting the logger name

### DIFF
--- a/launch/launch/descriptions/executable.py
+++ b/launch/launch/descriptions/executable.py
@@ -178,11 +178,13 @@ class Executable:
             prefix_filter = perform_substitutions(context, self.__prefix_filter)
             # Apply if filter regex matches (empty regex matches all strings)
             should_apply_prefix = re.match(prefix_filter, os.path.basename(cmd[0])) is not None
+        # Derive the logger name from the user's command before the prefix is
+        # prepended, otherwise ``prefix='gdb ...'`` ends up as the logger name.
+        name = os.path.basename(cmd[0]) if self.__name is None \
+            else perform_substitutions(context, self.__name)
         if should_apply_prefix:
             cmd = shlex.split(perform_substitutions(context, self.__prefix)) + cmd
         self.__final_cmd = cmd
-        name = os.path.basename(cmd[0]) if self.__name is None \
-            else perform_substitutions(context, self.__name)
         with _executable_process_counter_lock:
             global _executable_process_counter
             _executable_process_counter += 1

--- a/launch/test/launch/test_executable.py
+++ b/launch/test/launch/test_executable.py
@@ -56,6 +56,16 @@ def test_passthrough_properties():
     assert exe.final_env == env
 
 
+def test_prefix_does_not_overwrite_logger_name():
+    # Regression test for https://github.com/ros2/launch/issues/938
+    # ``final_name`` (used as the log output prefix) must be derived from the
+    # user's command, not from the launch ``prefix=`` token that gets prepended.
+    exe = Executable(cmd=['my_program'], prefix='gdb -ex run --args')
+    exe.prepare(LaunchContext(), None)
+    assert exe.final_cmd[0] == 'gdb'
+    assert exe.final_name.startswith('my_program')
+
+
 def test_substituted_properties():
     os.environ['EXECUTABLE_NAME'] = 'name'
     os.environ['EXECUTABLE_CWD'] = 'cwd'


### PR DESCRIPTION
Fixes #938.

When `prefix=` is set, the prefix tokens were prepended to `cmd` before `final_name` was computed, so `cmd[0]` (e.g. `gdb`) ended up as the logger name instead of the user's executable. The fix moves the `final_name` derivation above the prefix prepend; behavior is unchanged when no prefix is given.

Regression test added: `test_prefix_does_not_overwrite_logger_name`.