### PR TITLE
Allow eval substitutions with spaced expressions

### DIFF
--- a/launch/launch/substitutions/python_expression.py
+++ b/launch/launch/substitutions/python_expression.py
@@ -68,9 +68,22 @@ class PythonExpression(Substitution):
     def parse(cls, data: Sequence[SomeSubstitutionsType]
               ) -> Tuple[Type['PythonExpression'], Dict[str, Any]]:
         """Parse `PythonExpression` substitution."""
-        if len(data) < 1 or len(data) > 2:
-            raise TypeError('eval substitution expects 1 or 2 arguments')
-        kwargs = {'expression': data[0]}
+        if len(data) < 1:
+            raise TypeError('eval substitution expects at least 1 argument')
+        kwargs: Dict[str, Any] = {}
+        if len(data) <= 2:
+            kwargs['expression'] = data[0]
+        else:
+            # The expression is split into multiple arguments when it contains
+            # spaces, e.g. `$(eval 1 == 1)`.
+            # Join the arguments back with spaces to recover the expression.
+            from ..utilities import normalize_to_list_of_substitutions
+            expression: List[Substitution] = []
+            for i, sub_expression in enumerate(data):
+                if i > 0:
+                    expression += normalize_to_list_of_substitutions(' ')
+                expression += normalize_to_list_of_substitutions(sub_expression)
+            kwargs['expression'] = expression
         if len(data) == 2:
             # We get a text substitution from XML,
             # whose contents are comma-separated module names

--- a/launch/test/launch/substitutions/test_python_expression.py
+++ b/launch/test/launch/substitutions/test_python_expression.py
@@ -137,3 +137,20 @@ def test_python_substitution_submodule():
 
     # The expression should evaluate to True
     assert result
+
+
+def test_python_substitution_parse_multiple_arguments():
+    """Check that parse() joins an expression split across multiple arguments."""
+    lc = LaunchContext()
+
+    # The frontend splits an expression containing spaces, e.g. `$(eval 1 == 1)`
+    cls, kwargs = PythonExpression.parse(['1', '==', '1'])
+    subst = cls(**kwargs)
+    result = subst.perform(lc)
+
+    assert result == 'True'
+
+    # Test the describe() method
+    assert subst.describe() == (
+        "PythonExpr('1' + ' ' + '==' + ' ' + '1', ['math'])"
+    )


### PR DESCRIPTION
## Summary

Allows `eval` substitutions to parse expressions that the frontend splits across multiple arguments because of spaces.

For example, `$(eval 1 == 1)` can now be parsed by joining the split expression arguments back together with spaces.

## Changes

- Updates `PythonExpression.parse()` to accept three or more expression arguments.
- Joins split expression arguments with spaces before constructing the substitution.
- Adds a focused unit test for parsing a split expression.

## Testing

- `python -m pytest launch/test/launch/substitutions/test_python_expression.py -q`
- `python -m pytest launch/test/launch/frontend/test_substitutions.py -q`
- `python -m flake8 --ignore=E501 launch/launch/substitutions/python_expression.py launch/test/launch/substitutions/test_python_expression.py`
- `git diff --check`

## Issue reference

Relates #469

## Notes

This keeps the existing one-argument and two-argument parsing behavior unchanged.
In particular, this PR does not change the existing handling of unescaped quote characters in frontend expressions.

## AI assistance disclosure

Claude Code helped prepare this code change and test.
I manually reviewed the diff and test results.
