### PR TITLE
Reject invalid GroupAction boolean attributes

### DIFF
--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -93,8 +93,10 @@ class GroupAction(Action):
               ) -> Tuple[Type['GroupAction'], Dict[str, Any]]:
         """Return `GroupAction` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
-        scoped = entity.get_attr('scoped', data_type=bool, optional=True)
-        forwarding = entity.get_attr('forwarding', data_type=bool, optional=True)
+        scoped = entity.get_attr(
+            'scoped', data_type=bool, optional=True, can_be_str=False)
+        forwarding = entity.get_attr(
+            'forwarding', data_type=bool, optional=True, can_be_str=False)
         keeps = entity.get_attr('keep', data_type=List[Entity], optional=True)
         if scoped is not None:
             kwargs['scoped'] = scoped

--- a/launch_xml/test/launch_xml/test_group.py
+++ b/launch_xml/test/launch_xml/test_group.py
@@ -26,8 +26,8 @@ from launch.actions import ResetEnvironment
 from launch.actions import ResetLaunchConfigurations
 from launch.actions import SetLaunchConfiguration
 from launch.launch_context import LaunchContext
-
 from parser_no_extensions import load_no_extensions
+import pytest
 
 
 def test_group():
@@ -84,6 +84,15 @@ def test_group():
     actions[5].visit(lc)
     actions[6].visit(lc)
     actions[7].visit(lc)
+
+
+@pytest.mark.parametrize('attribute', ('scoped', 'forwarding'))
+def test_group_rejects_invalid_boolean_attributes(attribute):
+    xml_file = f'<launch><group {attribute}="invalid"/></launch>'
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+
+    with pytest.raises(TypeError, match=f"Attribute '{attribute}'"):
+        parser.parse_description(root_entity)
 
 
 if __name__ == '__main__':

--- a/launch_yaml/test/launch_yaml/test_group.py
+++ b/launch_yaml/test/launch_yaml/test_group.py
@@ -28,6 +28,7 @@ from launch.actions import SetLaunchConfiguration
 from launch.launch_context import LaunchContext
 
 from parser_no_extensions import load_no_extensions
+import pytest
 
 
 def test_group():
@@ -96,6 +97,20 @@ def test_group():
     actions[5].visit(lc)
     actions[6].visit(lc)
     actions[7].visit(lc)
+
+
+@pytest.mark.parametrize('attribute', ('scoped', 'forwarding'))
+def test_group_rejects_invalid_boolean_attributes(attribute):
+    yaml_file = f"""\
+    launch:
+    -   group:
+            {attribute}: invalid
+    """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+
+    with pytest.raises(TypeError, match=f"Attribute '{attribute}'"):
+        parser.parse_description(root_entity)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Reject non-boolean values for `GroupAction` XML and YAML `scoped` and `forwarding` attributes instead of retaining them as strings and treating them as truthy. Add regression coverage for both frontends and both attributes.

Fixes #970

### Is this user-facing behavior change?

Yes. Invalid `scoped` and `forwarding` values now fail launch-file parsing with a `TypeError` instead of silently enabling the option.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) was used to trace the parser data flow, implement the validation change, add tests, and review the diff. The contributor reviewed and locally validated the final change.

### Additional Information

Local validation:

- `pytest launch_xml/test/launch_xml/test_group.py`: 3 passed
- `pytest launch_yaml/test/launch_yaml/test_group.py`: 3 passed
- `pytest launch/test/launch/actions/test_group_action.py`: 2 passed
- `ament_flake8`, `ament_pep257`, and `ament_copyright` on all three changed files
- Python bytecode compilation
- `git diff --check`