### PR TITLE
Use a relative target for the latest log symlink

### DIFF
--- a/launch/launch/logging/__init__.py
+++ b/launch/launch/logging/__init__.py
@@ -104,7 +104,7 @@ def _renew_latest_log_dir(*, log_dir: str) -> bool:
         if not os.path.islink(latest_dir):
             return False
         os.unlink(latest_dir)
-    os.symlink(log_dir, latest_dir, target_is_directory=True)
+    os.symlink(os.path.basename(log_dir), latest_dir, target_is_directory=True)
     return True
 
 

--- a/launch/test/launch/test_logging.py
+++ b/launch/test/launch/test_logging.py
@@ -37,6 +37,20 @@ def mock_clean_env(monkeypatch):
     monkeypatch.delenv('OVERRIDE_LAUNCH_LOG_FORMAT', raising=False)
 
 
+def test_renew_latest_log_dir_uses_relative_target(tmp_path):
+    log_dir = tmp_path / 'run'
+    latest_dir = tmp_path / 'latest'
+
+    with mock.patch('launch.logging.os.symlink') as symlink_mock:
+        assert launch.logging._renew_latest_log_dir(log_dir=str(log_dir))
+
+    target = symlink_mock.call_args.args[0]
+    assert not os.path.isabs(target)
+    assert os.path.normpath(os.path.join(tmp_path, target)) == str(log_dir)
+    symlink_mock.assert_called_once_with(
+        log_dir.name, str(latest_dir), target_is_directory=True)
+
+
 def test_bad_logging_launch_config(mock_clean_env):
     """Tests that setup throws at bad configuration."""
     launch.logging.reset()


### PR DESCRIPTION
## Description

Create the `latest` log symlink with the run directory basename as its target. Because the link and run directory are siblings, the relative target resolves identically in place and remains valid when the parent log directory is mounted at a different absolute path.

Add a platform-independent regression test that verifies the target is relative and resolves back to the run directory.

Fixes #978

### Is this user-facing behavior change?

Yes. `latest` continues to resolve to the newest run directory, but `os.readlink()` now returns a relative basename instead of an absolute path. This keeps the link usable across host and container mount paths.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) was used to trace the logging path, implement the one-line behavior change, add the regression test, and review the diff. The contributor reviewed and locally validated the final change.

### Additional Information

Local validation:

- `pytest launch/test/launch/test_logging.py`: 21 passed
- `pytest launch/test/launch`: 280 passed
- `pytest launch/test/test_flake8.py`: 1 passed