### PR TITLE
Reject invalid ExecuteProcess boolean attributes

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -398,12 +398,14 @@ class ExecuteProcess(ExecuteLocal):
                 kwargs['sigterm_timeout'] = str(sigterm_timeout)
 
         if 'shell' not in ignore:
-            shell = entity.get_attr('shell', data_type=bool, optional=True)
+            shell = entity.get_attr(
+                'shell', data_type=bool, optional=True, can_be_str=False)
             if shell is not None:
                 kwargs['shell'] = shell
 
         if 'emulate_tty' not in ignore:
-            emulate_tty = entity.get_attr('emulate_tty', data_type=bool, optional=True)
+            emulate_tty = entity.get_attr(
+                'emulate_tty', data_type=bool, optional=True, can_be_str=False)
             if emulate_tty is not None:
                 kwargs['emulate_tty'] = emulate_tty
 

--- a/launch_xml/test/launch_xml/test_executable.py
+++ b/launch_xml/test/launch_xml/test_executable.py
@@ -85,5 +85,14 @@ def test_executable_on_exit():
     assert isinstance(sub_entities[0], Shutdown)
 
 
+@pytest.mark.parametrize('attribute', ('shell', 'emulate_tty'))
+def test_executable_rejects_invalid_boolean_attributes(attribute):
+    xml_file = f'<launch><executable cmd="echo" {attribute}="invalid"/></launch>'
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+
+    with pytest.raises(TypeError, match=f"Attribute '{attribute}'"):
+        parser.parse_description(root_entity)
+
+
 if __name__ == '__main__':
     test_executable()

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -22,6 +22,8 @@ from launch.actions import Shutdown
 
 from parser_no_extensions import load_no_extensions
 
+import pytest
+
 
 def test_executable():
     """Parse executable yaml example."""
@@ -80,6 +82,21 @@ def test_executable_on_exit():
     sub_entities = executable.get_sub_entities()
     assert len(sub_entities) == 1
     assert isinstance(sub_entities[0], Shutdown)
+
+
+@pytest.mark.parametrize('attribute', ('shell', 'emulate_tty'))
+def test_executable_rejects_invalid_boolean_attributes(attribute):
+    yaml_file = f"""\
+    launch:
+    -   executable:
+            cmd: echo
+            {attribute}: invalid
+    """
+    yaml_file = textwrap.dedent(yaml_file)
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+
+    with pytest.raises(TypeError, match=f"Attribute '{attribute}'"):
+        parser.parse_description(root_entity)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Reject invalid string values for the static `ExecuteProcess` frontend attributes `shell` and `emulate_tty`.

Both attributes are consumed directly as booleans. The frontend previously allowed failed XML conversions and YAML string values to pass through unchanged, causing any non-empty string to be treated as true. This change requires an actual boolean conversion and adds regression coverage for both attributes in the XML and YAML frontends.

### Is this user-facing behavior change?

Yes. Valid XML boolean values and YAML booleans continue to work. Invalid strings now fail launch-file parsing with a `TypeError` instead of silently enabling `shell` or TTY emulation.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) was used to audit the frontend data flow, implement the validation change, add tests, and review the diff. The contributor reviewed and locally validated the final change.

### Additional Information

Local validation:

- `pytest launch/test/launch`: 279 passed
- `pytest launch_xml/test/launch_xml`: 30 passed
- `pytest launch_yaml/test/launch_yaml`: 18 passed
- `pytest launch/test/test_flake8.py`: 1 passed
- `pytest launch_xml/test/test_flake8.py`: 1 passed
- `pytest launch_yaml/test/test_flake8.py`: 1 passed