### PR TITLE
Materialize TimerAction action iterables

### DIFF
--- a/launch/launch/actions/timer_action.py
+++ b/launch/launch/actions/timer_action.py
@@ -95,7 +95,7 @@ class TimerAction(Action):
                 'passing a string literal was deprecated',
                 stacklevel=2)
         self.__period = type_utils.normalize_typed_substitution(period, float)
-        self.__actions = actions
+        self.__actions = list(actions)
         self.__context_locals: Dict[Text, Any] = {}
         self.__canceled = False
 

--- a/launch/test/launch/test_timer_action.py
+++ b/launch/test/launch/test_timer_action.py
@@ -34,6 +34,15 @@ from launch.substitutions import NotSubstitution
 from launch.substitutions import PythonExpression
 
 
+def test_timer_action_materializes_action_iterables():
+    action = LogInfo(msg='timer action')
+    timer = TimerAction(period=1.0, actions=iter([action]))
+
+    described_actions = timer.describe_conditional_sub_entities()[0][1]
+    assert list(described_actions) == [action]
+    assert list(timer.actions) == [action]
+
+
 def test_timer_action_can_capture_the_environment():
     """Test that timer actions capture the environment variables present when executed."""
     # Regression test for https://github.com/ros2/launch_ros/issues/376


### PR DESCRIPTION
## Summary

- materialize `TimerAction.actions` once at construction
- prevent introspection from consuming one-shot iterables before the timer fires
- cover repeated access after describing conditional sub-entities

## Testing

- focused source behavior probe: baseline retains no actions after introspection, while the fixed implementation retains them
- `launch/test/launch/test_timer_action.py`: 7 passed
- `ament_flake8`, `ament_pep257`, and `ament_copyright` on both modified files
- `python -m py_compile` on both modified files
- `git diff --check`