### PR TITLE
Preserve iterable executable arguments

### DIFF
--- a/launch/launch/descriptions/executable.py
+++ b/launch/launch/descriptions/executable.py
@@ -18,6 +18,7 @@
 """Module for a description of an Executable."""
 
 import os
+import pathlib
 import re
 import shlex
 import threading
@@ -74,7 +75,10 @@ class Executable:
             additional_env.
         :param arguments: list of extra arguments for the executable
         """
-        self.__arguments = None if arguments is None else list(arguments)
+        self.__arguments = None if arguments is None else [
+            argument if isinstance(argument, (str, pathlib.Path, Substitution)) else list(argument)
+            for argument in arguments
+        ]
         self.__cmd = [normalize_to_list_of_substitutions(x) for x in cmd]
         self.__cmd += ([] if self.__arguments is None
                        else [normalize_to_list_of_substitutions(x) for x in self.__arguments])

--- a/launch/launch/descriptions/executable.py
+++ b/launch/launch/descriptions/executable.py
@@ -74,9 +74,10 @@ class Executable:
             additional_env.
         :param arguments: list of extra arguments for the executable
         """
+        self.__arguments = None if arguments is None else list(arguments)
         self.__cmd = [normalize_to_list_of_substitutions(x) for x in cmd]
-        self.__cmd += ([] if arguments is None
-                       else [normalize_to_list_of_substitutions(x) for x in arguments])
+        self.__cmd += ([] if self.__arguments is None
+                       else [normalize_to_list_of_substitutions(x) for x in self.__arguments])
         self.__prefix = normalize_to_list_of_substitutions(
             LaunchConfiguration('launch-prefix', default='') if prefix is None else prefix
         )
@@ -99,7 +100,6 @@ class Executable:
                 self.__additional_env.append((
                     normalize_to_list_of_substitutions(key),
                     normalize_to_list_of_substitutions(value)))
-        self.__arguments = arguments
         self.__final_cmd: Optional[List[str]] = None
         self.__final_cwd: Optional[str] = None
         self.__final_env: Optional[Dict[str, str]] = None

--- a/launch/test/launch/test_executable.py
+++ b/launch/test/launch/test_executable.py
@@ -45,6 +45,14 @@ def test_cmd_multiple_arguments_in_string():
     assert all(a == b for a, b in zip(exe.final_cmd, ['ls', '-opt1', '-opt2', '-opt3']))
 
 
+def test_arguments_generator_is_preserved():
+    arguments = (value for value in ['--flag', 'value'])
+    exe = Executable(cmd=['test'], arguments=arguments)
+    exe.prepare(LaunchContext(), None)
+    assert exe.final_cmd == ['test', '--flag', 'value']
+    assert list(exe.arguments) == ['--flag', 'value']
+
+
 def test_passthrough_properties():
     name = 'name'
     cwd = 'cwd'

--- a/launch/test/launch/test_executable.py
+++ b/launch/test/launch/test_executable.py
@@ -53,6 +53,14 @@ def test_arguments_generator_is_preserved():
     assert list(exe.arguments) == ['--flag', 'value']
 
 
+def test_nested_argument_generator_is_preserved():
+    argument = (value for value in ['--', 'flag'])
+    exe = Executable(cmd=['test'], arguments=[argument])
+    exe.prepare(LaunchContext(), None)
+    assert exe.final_cmd == ['test', '--flag']
+    assert exe.arguments == [['--', 'flag']]
+
+
 def test_passthrough_properties():
     name = 'name'
     cwd = 'cwd'


### PR DESCRIPTION
## Summary

- materialize `Executable.arguments` and each nested argument iterable once at construction
- build the command and expose the public property from the same stored values
- prevent one-shot outer or nested argument iterables from appearing empty after normalization

## Testing

- focused runtime probe reproduced a nested generator producing the correct command token while leaving `arguments` empty before the fix
- `launch/test/launch/test_executable.py`: 8 passed
- `ament_flake8`, `ament_pep257`, and `ament_copyright` on both modified files
- targeted `mypy` on `launch/launch/descriptions/executable.py`
- `python -m py_compile` on both modified files
- `git diff --check`