### PR TITLE
Parse YAML respawn delay strings

### DIFF
--- a/launch/launch/actions/execute_process.py
+++ b/launch/launch/actions/execute_process.py
@@ -370,6 +370,15 @@ class ExecuteProcess(ExecuteLocal):
         if 'respawn_delay' not in ignore:
             respawn_delay = entity.get_attr('respawn_delay', data_type=float, optional=True)
             if respawn_delay is not None:
+                if isinstance(respawn_delay, str):
+                    try:
+                        respawn_delay = float(respawn_delay)
+                    except ValueError:
+                        raise ValueError(
+                            'Attribute respawn_delay of Entity node expected to be '
+                            'a non-negative floating-point value but got `{}`'.format(
+                                respawn_delay)
+                        ) from None
                 if respawn_delay < 0.0:
                     raise ValueError(
                         'Attribute respawn_delay of Entity node expected to be '

--- a/launch_yaml/test/launch_yaml/test_executable.py
+++ b/launch_yaml/test/launch_yaml/test_executable.py
@@ -19,8 +19,10 @@ import textwrap
 
 from launch import LaunchService
 from launch.actions import Shutdown
+from launch.actions.execute_process import ExecuteProcess
 
 from parser_no_extensions import load_no_extensions
+import pytest
 
 
 def test_executable():
@@ -80,6 +82,38 @@ def test_executable_on_exit():
     sub_entities = executable.get_sub_entities()
     assert len(sub_entities) == 1
     assert isinstance(sub_entities[0], Shutdown)
+
+
+def test_executable_respawn_delay_string():
+    yaml_file = textwrap.dedent(
+        """
+        launch:
+        -   executable:
+                cmd: echo test
+                respawn_delay: '2.0'
+        """
+    )
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+
+    _, kwargs = ExecuteProcess.parse(root_entity.children[0], parser)
+
+    assert kwargs['respawn_delay'] == 2.0
+    assert isinstance(kwargs['respawn_delay'], float)
+
+
+def test_executable_respawn_delay_invalid_string():
+    yaml_file = textwrap.dedent(
+        """
+        launch:
+        -   executable:
+                cmd: echo test
+                respawn_delay: ''
+        """
+    )
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+
+    with pytest.raises(ValueError, match='respawn_delay'):
+        ExecuteProcess.parse(root_entity.children[0], parser)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The YAML frontend accepts strings for attributes declared as `float`, but `ExecuteProcess.parse()` compared a string-valued `respawn_delay` with `0.0` before converting it. A launch file using `respawn_delay: '2.0'` therefore failed during parsing with `TypeError: '<' not supported between instances of 'str' and 'float'`.

Convert string-valued respawn delays at the existing frontend parsing boundary. Valid values reach `ExecuteLocal` as floats, while invalid strings fail immediately with a descriptive `ValueError`. Native float behavior and the runtime respawn state machine are unchanged.

### Is this user-facing behavior change?

Yes. Quoted numeric `respawn_delay` values in YAML launch files now work consistently instead of failing with a comparison `TypeError`. Invalid strings produce a parse-time error.

### Did you use Generative AI?

Yes. OpenAI Codex assisted with tracing the frontend data flow, preparing the focused fix and tests, and reviewing the result. I reviewed the diff and verification output.

### Additional Information

Local verification:
- reproduced the Rolling failure with `respawn_delay: '2.0'`
- all 279 `launch` functional tests passed
- all 18 `launch_yaml` functional tests passed
- both package flake8 tests passed
- targeted `ament_mypy` passed with zero errors
- `ament_flake8`, `ament_pep257`, and `ament_copyright` passed for both changed files
- `compileall` and `git diff --check` passed