### PR TITLE
Allow empty YAML entity lists

### DIFF
--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -123,7 +123,7 @@ class Entity(BaseEntity):
         self.__read_keys.add(name)
         data = self.__element[name]
         if check_is_list_entity(data_type):
-            if isinstance(data, list) and isinstance(data[0], dict):
+            if isinstance(data, list) and (not data or isinstance(data[0], dict)):
                 return [Entity(child, name) for child in data]
             raise TypeError(
                 "Attribute '{}' of Entity '{}' expected to be a list of dictionaries.".format(

--- a/launch_yaml/test/launch_yaml/test_include.py
+++ b/launch_yaml/test/launch_yaml/test_include.py
@@ -61,5 +61,24 @@ def test_include():
     assert ls.context.launch_configurations['baz'] == 'BAZ'
 
 
+def test_include_with_empty_argument_lists():
+    """Parse an include action with explicitly empty argument lists."""
+    path = (Path(__file__).parent / 'executable.yaml').as_posix()
+    yaml_file = textwrap.dedent(
+        """\
+        launch:
+        - include:
+            file: '{}'
+            arg: []
+            let: []
+        """.format(path)
+    )
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+    ld = parser.parse_description(root_entity)
+
+    include = ld.entities[0]
+    assert include.launch_arguments == ()
+
+
 if __name__ == '__main__':
     test_include()


### PR DESCRIPTION
## Description

`launch_yaml.Entity.get_attr()` indexed the first item of every nested entity list while validating its shape. Explicitly empty lists such as `arg: []` or `let: []` therefore raised `IndexError` instead of being parsed as empty child collections.

Accept empty nested entity lists at the YAML adapter boundary and retain the existing dictionary check for non-empty lists. Add an include-action regression covering both empty argument forms.

### Is this user-facing behavior change?

Yes. YAML launch files can now contain explicitly empty nested entity lists without failing during parsing.

### Did you use Generative AI?

Yes. OpenAI Codex assisted with tracing the YAML parser data flow, preparing the focused fix and regression test, and reviewing the result. I reviewed the diff and verification output.

### Additional Information

Local verification:
- reproduced the Rolling `IndexError` with an empty `List[Entity]` attribute
- all 17 `launch_yaml` functional tests passed
- `ament_flake8`, `ament_pep257`, and `ament_copyright` passed for both changed files
- Python bytecode compilation and `git diff --check` passed