### PR TITLE
Validate iterable elements in ensure_argument_type

### DIFF
--- a/launch/launch/utilities/ensure_argument_type_impl.py
+++ b/launch/launch/utilities/ensure_argument_type_impl.py
@@ -69,7 +69,16 @@ def ensure_argument_type(
             result |= issubclass(argument.__class__, type_var)
         return result
 
-    list_of_types = types if isinstance(types, collections.abc.Iterable) else [types]
+    list_of_types = list(types) if isinstance(types, collections.abc.Iterable) else [types]
+    for type_var in list_of_types:
+        if not isinstance(type_var, type):
+            raise TypeError(error_msg_template.format(
+                "'ensure_argument_type()' e",
+                'types',
+                'type, collections.abc.Iterable of type',
+                type_var,
+                type(type_var),
+            ))
     if not any(check_argument(argument, type_var) for type_var in list_of_types):
         raise TypeError(error_msg_template.format(
             'E' if caller is None else "'{}' e".format(caller),

--- a/launch/test/launch/utilities/test_ensure_argument_type.py
+++ b/launch/test/launch/utilities/test_ensure_argument_type.py
@@ -40,6 +40,37 @@ def test_valid_argument_types():
     ensure_argument_type(mock_child_obj, MockClass, 'MockChildClass')
 
 
+def test_valid_iterables_of_types():
+    """Test the ensure_argument_type function with valid iterables of types."""
+    ensure_argument_type('foo', (str, int), 'arg_foo')
+    ensure_argument_type(1, [str, int], 'arg_bar')
+    ensure_argument_type('foo', (t for t in (str, int)), 'arg_baz')
+
+
+def test_invalid_element_in_types():
+    """Test the ensure_argument_type function with non-type elements in the types iterable."""
+    # Invalid element before a valid type.
+    with pytest.raises(TypeError) as ex:
+        ensure_argument_type('foo', [123, str], 'arg_foo')
+    assert "'types'" in str(ex.value)
+    assert 'type, collections.abc.Iterable of type' in str(ex.value)
+    # Invalid element after a type that matches the argument.
+    with pytest.raises(TypeError) as ex:
+        ensure_argument_type('foo', [str, 123], 'arg_foo')
+    assert "'types'" in str(ex.value)
+    assert 'type, collections.abc.Iterable of type' in str(ex.value)
+    # A string is an iterable, but not of types.
+    with pytest.raises(TypeError) as ex:
+        ensure_argument_type('foo', 'str', 'arg_foo')
+    assert "'types'" in str(ex.value)
+    assert 'type, collections.abc.Iterable of type' in str(ex.value)
+    # The error message should identify the 'types' parameter and the expectation.
+    with pytest.raises(TypeError) as ex:
+        ensure_argument_type('foo', (t for t in (str, None)), 'arg_foo')
+    assert "'ensure_argument_type()' expected 'types'" in str(ex.value)
+    assert 'type, collections.abc.Iterable of type' in str(ex.value)
+
+
 def test_invalid_argument_types():
     """Test the ensure_argument_type function with invalid input."""
     with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #109.

## Summary

`ensure_argument_type()` accepted an iterable for its `types` argument without validating that every element was actually a type.

This caused two inconsistent behaviors:

- an invalid element before a valid type exposed Python's generic `isinstance()` error
- an invalid element after an already matching type could be silently ignored because `any()` short-circuited

This change materializes the iterable once and validates every element before performing argument matching.

Existing behavior remains unchanged for:

- a single type
- lists and tuples of types
- generators and other iterables
- inheritance checks
- empty iterables

## Testing

- `python3 -m pytest launch/test/launch/utilities/test_ensure_argument_type.py -q`
- `python3 -m pytest launch/test/launch/utilities -q`
- `python3 -m flake8 --config=/opt/ros/jazzy/lib/python3.12/site-packages/ament_flake8/configuration/ament_flake8.ini launch/launch/utilities/ensure_argument_type_impl.py launch/test/launch/utilities/test_ensure_argument_type.py`
- `git diff --check`

Results:

- focused tests: 5 passed
- utility tests: 38 passed
- flake8: clean
