### PR TITLE
Fix LaunchService._is_idle() to consider active asyncio background tasks

### DIFF
--- a/launch/launch/launch_service.py
+++ b/launch/launch/launch_service.py
@@ -94,7 +94,8 @@ class LaunchService:
         # it being set to None by run() as it exits.
         self.__loop_from_run_thread_lock = threading.RLock()
         self.__loop_from_run_thread = None
-        self.__this_task: Optional[asyncio.Future[None]] = None
+        self.__this_task: Optional[asyncio.Task[None]] = None
+        self.__process_one_event_task: Optional[asyncio.Task[None]] = None
 
         # Used to indicate when shutdown() has been called.
         self.__shutting_down = False
@@ -156,7 +157,17 @@ class LaunchService:
     def _is_idle(self) -> bool:
         number_of_entity_future_pairs = self._prune_and_count_entity_future_pairs()
         number_of_entity_future_pairs += self._prune_and_count_context_completion_futures()
-        return number_of_entity_future_pairs == 0 and self.__context._event_queue.empty()
+        if self.event_loop is not None:
+            tasks_to_ignore = {self.__this_task, self.__process_one_event_task}
+            active_tasks = [
+                task for task in asyncio.all_tasks(self.event_loop)
+                if task not in tasks_to_ignore and not task.done()
+            ]
+        else:
+            active_tasks = []
+        return (number_of_entity_future_pairs == 0 and
+                self.__context._event_queue.empty() and
+                len(active_tasks) == 0)
 
     @contextlib.contextmanager
     def _prepare_run_loop(
@@ -234,6 +245,8 @@ class LaunchService:
             with self.__loop_from_run_thread_lock:
                 self.__context._set_asyncio_loop(None)
                 self.__loop_from_run_thread = None
+                self.__this_task = None
+                self.__process_one_event_task = None
                 self.__shutting_down = False
 
     async def _process_one_event(self) -> None:
@@ -328,6 +341,7 @@ class LaunchService:
                     # in the queue
                     if process_one_event_task is None or process_one_event_task.done():
                         process_one_event_task = this_loop.create_task(self._process_one_event())
+                        self.__process_one_event_task = process_one_event_task
 
                     # Add the process event task to the list of awaitables
                     entity_futures.append(process_one_event_task)

--- a/launch/test/launch/test_execute_local.py
+++ b/launch/test/launch/test_execute_local.py
@@ -178,3 +178,47 @@ def test_execute_process_with_output_dictionary():
     ls = LaunchService()
     ls.include_launch_description(ld)
     assert 0 == ls.run()
+
+
+def test_execute_process_with_shutdown_on_error():
+    """Test proper shutdown of children after exception during launch."""
+    exited_processes = 0
+
+    def on_exit(event, context):
+        nonlocal exited_processes
+        exited_processes += 1
+
+    executable_1 = ExecuteLocal(
+        process_description=Executable(
+            cmd=[sys.executable, '-c', 'while True: pass']
+        ),
+        output={'stdout': 'screen', 'stderr': 'screen'},
+        on_exit=on_exit,
+    )
+    executable_2 = ExecuteLocal(
+        process_description=Executable(
+            cmd=[sys.executable, '-c', 'while True: pass']
+        ),
+        output={'stdout': 'screen', 'stderr': 'screen'},
+        on_exit=on_exit,
+    )
+
+    # It's slightly tricky to coerce the standard implementation to fail in
+    # this way. However, launch_ros's Node class can fail similar to this and
+    # this case therefore needs to be handled correctly.
+    class ExecutableThatFails(ExecuteLocal):
+
+        def execute(self, context):
+            raise Exception('Execute Local failed')
+
+    executable_invalid = ExecutableThatFails(
+        process_description=Executable(
+            cmd=['fake_process_that_doesnt_exist']
+        ),
+        output={'stdout': 'screen', 'stderr': 'screen'},
+    )
+    ld = LaunchDescription([executable_1, executable_2, executable_invalid])
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    assert ls.run() == 1
+    assert exited_processes == 2


### PR DESCRIPTION
## Description

This PR updates `LaunchService._is_idle()` to account for active `asyncio.Task` instances running in the event loop that are not tracked as entity/completion futures.

When an error occurs during launch description evaluation (e.g. invalid action/node argument or failure during `execute()`), previously launched processes might still be in the middle of asynchronous setup. When `LaunchService._is_idle()` exited immediately, these subprocesses were orphaned because the main event loop exited before their `ProcessStarted` / `OnShutdown` handlers could be processed.

This addresses the deadlock issue found in #901 by excluding `LaunchService`'s internal event-processing task (`__process_one_event_task`) and main task (`__this_task`) when inspecting active tasks.

Fixes #747
Supersedes #901

### Is this user-facing behavior change?

No. Child processes started before an exception during launch are now reliably terminated during shutdown rather than orphaned.

### Did you use Generative AI?

Yes, Gemini 3.7 Flash.