### PR TITLE
Allow native YAML scalar values in launch_yaml

### DIFF
--- a/launch_yaml/launch_yaml/entity.py
+++ b/launch_yaml/launch_yaml/entity.py
@@ -26,6 +26,12 @@ from launch.utilities.type_utils import AllowedValueType
 from launch.utilities.type_utils import is_instance_of
 
 
+def _stringify_scalar(value: AllowedValueType) -> str:
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    return str(value)
+
+
 class Entity(BaseEntity):
     """Single item in the intermediate YAML front_end representation."""
 
@@ -130,6 +136,8 @@ class Entity(BaseEntity):
                     name, self.type_name
                 )
             )
+        if data_type is str and isinstance(data, (bool, int, float)):
+            return _stringify_scalar(data)
         if not is_instance_of(data, data_type, can_be_str=can_be_str):
             raise TypeError(
                 "Attribute '{}' of Entity '{}' expected to be of type '{}', got '{}'".format(

--- a/launch_yaml/test/launch_yaml/test_boolean_substitution.py
+++ b/launch_yaml/test/launch_yaml/test_boolean_substitution.py
@@ -15,7 +15,10 @@
 import io
 import textwrap
 
+from launch.actions import GroupAction
+from launch.actions import SetLaunchConfiguration
 from launch import LaunchService
+from launch import LaunchContext
 from launch.utilities import perform_substitutions
 
 from parser_no_extensions import load_no_extensions
@@ -113,3 +116,30 @@ def check_boolean_substitution(file):
     assert perform(any_true_false.value) == 'true'
     assert perform(any_false_true.value) == 'true'
     assert perform(any_false_false.value) == 'false'
+
+
+def test_native_yaml_scalar_values():
+    yaml_file = textwrap.dedent(
+        r"""
+        launch:
+            - let: { name: int_value, value: 42 }
+            - let: { name: float_value, value: 3.5 }
+            - let: { name: bool_value, value: false }
+            - group:
+                if: false
+                children:
+                    - let: { name: skipped_value, value: unreachable }
+        """
+    )
+    root_entity, parser = load_no_extensions(io.StringIO(yaml_file))
+    ld = parser.parse_description(root_entity)
+    launch_context = LaunchContext()
+
+    assert isinstance(ld.entities[0], SetLaunchConfiguration)
+    assert perform_substitutions(launch_context, ld.entities[0].value) == '42'
+    assert isinstance(ld.entities[1], SetLaunchConfiguration)
+    assert perform_substitutions(launch_context, ld.entities[1].value) == '3.5'
+    assert isinstance(ld.entities[2], SetLaunchConfiguration)
+    assert perform_substitutions(launch_context, ld.entities[2].value) == 'false'
+    assert isinstance(ld.entities[3], GroupAction)
+    assert ld.entities[3].visit(launch_context) is None


### PR DESCRIPTION
Fixes #955

## Summary
- accept native YAML bool/int/float scalars when an entity attribute expects a string-backed value
- preserve existing validation for other typed attribute lookups
- add a regression for native let values and boolean conditionals in YAML launch files

## Testing
- python -m py_compile launch_yaml/launch_yaml/entity.py launch_yaml/test/launch_yaml/test_boolean_substitution.py
- pytest launch_yaml/test/launch_yaml/test_boolean_substitution.py is blocked locally by a missing ament_index_python dependency in this Windows environment