### PR TITLE
Sandbox environment variables in launch_xml/launch_yaml tests

### DIFF
--- a/launch_xml/test/conftest.py
+++ b/launch_xml/test/conftest.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fixtures shared by all tests in this package."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def sandbox_environment_variables():
+    """
+    Restore ``os.environ`` after each test.
+
+    ``LaunchContext.environment`` is ``os.environ`` itself, so actions like
+    ``ReplaceEnvironmentVariables`` and ``ResetEnvironment`` mutate the real process
+    environment when a test executes them.  Without this fixture those mutations leak
+    into every test that happens to run afterwards, which makes the suite sensitive to
+    collection order.
+    """
+    saved_environment = os.environ.copy()
+    try:
+        yield
+    finally:
+        # Assign through os.environ rather than replacing it so that putenv() is
+        # called for each key, keeping the C-level environment in sync.
+        for key, value in saved_environment.items():
+            os.environ[key] = value
+        for key in tuple(os.environ):
+            if key not in saved_environment:
+                del os.environ[key]

--- a/launch_yaml/test/conftest.py
+++ b/launch_yaml/test/conftest.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fixtures shared by all tests in this package."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def sandbox_environment_variables():
+    """
+    Restore ``os.environ`` after each test.
+
+    ``LaunchContext.environment`` is ``os.environ`` itself, so actions like
+    ``ReplaceEnvironmentVariables`` and ``ResetEnvironment`` mutate the real process
+    environment when a test executes them.  Without this fixture those mutations leak
+    into every test that happens to run afterwards, which makes the suite sensitive to
+    collection order.
+    """
+    saved_environment = os.environ.copy()
+    try:
+        yield
+    finally:
+        # Assign through os.environ rather than replacing it so that putenv() is
+        # called for each key, keeping the C-level environment in sync.
+        for key, value in saved_environment.items():
+            os.environ[key] = value
+        for key in tuple(os.environ):
+            if key not in saved_environment:
+                del os.environ[key]


### PR DESCRIPTION
`LaunchContext.environment` is `os.environ` itself, so `test_rep_env.py` — which executes `ReplaceEnvironmentVariables` against a real context and asserts the environment ends up empty — clears `PATH` for every test that runs after it in the same pytest process. That was harmless while pytest 7 collected `test/test_*.py` first, but pytest 9 collects `test/<pkg>/` first, so `test_rep_env.py` now runs ahead of `test_xmllint.py` and `shutil.which('xmllint')` returns `None`.

This adds an autouse fixture at the `test/` level in both packages that restores `os.environ` after each test, which fixes the failure without making it depend on collection order again.