### PR TITLE
Reject invalid GroupAction boolean attributes

### DIFF
--- a/launch/launch/actions/group_action.py
+++ b/launch/launch/actions/group_action.py
@@ -93,8 +93,8 @@ class GroupAction(Action):
               ) -> Tuple[Type['GroupAction'], Dict[str, Any]]:
         """Return `GroupAction` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
-        scoped = entity.get_attr('scoped', data_type=bool, optional=True)
-        forwarding = entity.get_attr('forwarding', data_type=bool, optional=True)
+        scoped = entity.get_attr('scoped', data_type=bool, optional=True, can_be_str=False)
+        forwarding = entity.get_attr('forwarding', data_type=bool, optional=True, can_be_str=False)
         keeps = entity.get_attr('keep', data_type=List[Entity], optional=True)
         if scoped is not None:
             kwargs['scoped'] = scoped

--- a/launch_xml/test/launch_xml/test_group.py
+++ b/launch_xml/test/launch_xml/test_group.py
@@ -29,6 +29,21 @@ from launch.launch_context import LaunchContext
 
 from parser_no_extensions import load_no_extensions
 
+import pytest
+
+
+@pytest.mark.parametrize('attribute', ['scoped', 'forwarding'])
+def test_group_rejects_arbitrary_boolean_strings(attribute):
+    """Reject arbitrary strings for boolean GroupAction attributes."""
+    xml_file = textwrap.dedent(f"""\
+        <launch>
+            <group {attribute}="not-a-boolean" />
+        </launch>
+    """)
+    root_entity, parser = load_no_extensions(io.StringIO(xml_file))
+    with pytest.raises(TypeError, match=attribute):
+        parser.parse_description(root_entity)
+
 
 def test_group():
     xml_file = \


### PR DESCRIPTION
## Description

The XML frontend previously treated any non-empty string as true for the GroupAction `scoped` and `forwarding` attributes. This made invalid values silently change launch behavior.

This change disables string coercion for these boolean attributes so invalid XML values raise a TypeError during parsing. Existing boolean values continue to work.

Fixes #970

### Is this user-facing behavior change?

No. This makes invalid XML fail clearly instead of being accepted with surprising semantics.

### Did you use Generative AI?

Codex (GPT-5) was used to assist with implementation and tests.

### Additional Information

Added parameterized regression coverage for both attributes. Tested with the full launch_xml test suite (35 tests passed).